### PR TITLE
Make sure `depth` is int in `generate_rb_sequence`

### DIFF
--- a/pyquil/api/compiler.py
+++ b/pyquil/api/compiler.py
@@ -253,7 +253,7 @@ class CompilerConnection(object):
          programs are called cliffords then `sum(cliffords, Program())` will give the randomized
          benchmarking experiment, which will compose to the identity program.
         """
-
+        depth = int(depth)  # needs to be jsonable, no np.int64 please!
         payload = self._rb_sequence_payload(depth, gateset)
         response = post_json(self.session, self.sync_endpoint + "/rb", payload).json()
         programs = []


### PR DESCRIPTION
It would give a mysterious json error if you passed a `np.int64`, perhaps as the result of iterating over an `np.arange`