### PR TITLE
Fix is zero and identity

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -710,19 +710,19 @@ def commuting_sets(pauli_terms):
     return groups
 
 
-def is_identity(pauli_object):
+def is_identity(term):
     """
     Tests to see if a PauliTerm or PauliSum is a scalar multiple of identity
 
-    :param pauli_object: Either a PauliTerm or PauliSum
+    :param term: Either a PauliTerm or PauliSum
     :returns: True if the PauliTerm or PauliSum is a scalar multiple of identity, False otherwise
     :rtype: bool
     """
-    if isinstance(pauli_object, PauliTerm):
-        return (len(pauli_object) == 0) and (not np.isclose(pauli_object.coefficient, 0))
-    elif isinstance(pauli_object, PauliSum):
-        return (len(pauli_object.terms) == 1) and (len(pauli_object.terms[0]) == 0) and \
-               (not np.isclose(pauli_object.terms[0].coefficient, 0))
+    if isinstance(term, PauliTerm):
+        return (len(term) == 0) and (not np.isclose(term.coefficient, 0))
+    elif isinstance(term, PauliSum):
+        return (len(term.terms) == 1) and (len(term.terms[0]) == 0) and \
+               (not np.isclose(term.terms[0].coefficient, 0))
     else:
         raise TypeError("is_identity only checks PauliTerms and PauliSum objects!")
 

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -710,15 +710,30 @@ def commuting_sets(pauli_terms):
     return groups
 
 
-def is_identity(term):
+def is_identity(pauli_object):
     """
-    Check if Pauli Term is a scalar multiple of identity
+    Tests to see if a PauliTerm or PauliSum is a scalar multiple of identity
 
-    :param PauliTerm term: A PauliTerm object
-    :returns: True if the PauliTerm is a scalar multiple of identity, false otherwise
+    :param pauli_object: Either a PauliTerm or PauliSum
+    :returns: True if the PauliTerm or PauliSum is a scalar multiple of identity, False otherwise
     :rtype: bool
     """
-    return len(term) == 0
+    # return len(pauli_object) == 0
+    if isinstance(pauli_object, PauliTerm):
+        print ("This is a PauliTerm")
+        if (len(pauli_object) == 0) and (not np.isclose(pauli_object.coefficient, 0)):
+            return True
+        else:
+            return False
+    elif isinstance(pauli_object, PauliSum):
+        print ("This is a PauliSum")
+        if (len(pauli_object.terms) == 1) and (len(pauli_object.terms[0]) == 0) and \
+                (not np.isclose(pauli_object.terms[0].coefficient, 0)):
+            return True
+        else:
+            return False
+    else:
+        raise TypeError("is_identity only checks PauliTerms and PauliSum objects!")
 
 
 def exponentiate(term: PauliTerm):
@@ -876,12 +891,12 @@ def is_zero(pauli_object):
     :rtype: bool
     """
     if isinstance(pauli_object, PauliTerm):
-        if pauli_object.id() == '':
+        if np.isclose(pauli_object.coefficient, 0):
             return True
         else:
             return False
     elif isinstance(pauli_object, PauliSum):
-        if len(pauli_object.terms) == 1 and pauli_object.terms[0].id() == '':
+        if len(pauli_object.terms) == 1 and np.isclose(pauli_object.terms[0].coefficient, 0):
             return True
         else:
             return False

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -25,7 +25,7 @@ import copy
 from pyquil.quilatom import QubitPlaceholder
 
 from .quil import Program
-from .gates import H, RZ, RX, CNOT, X, PHASE, QUANTUM_GATES
+from .gates import I, H, RZ, RX, CNOT, X, PHASE, QUANTUM_GATES
 from numbers import Number
 from collections import Sequence, OrderedDict
 import warnings
@@ -768,6 +768,8 @@ def exponential_map(term):
             prog.inst(PHASE(-param * coeff, 0))
             prog.inst(X(0))
             prog.inst(PHASE(-param * coeff, 0))
+        elif is_zero(term):
+            prog.inst(I(0))
         else:
             prog += _exponentiate_general_case(term, param)
         return prog

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -760,7 +760,7 @@ def exponential_map(term):
             prog.inst(X(0))
             prog.inst(PHASE(-param * coeff, 0))
         elif is_zero(term):
-            prog.inst(I(0))
+            pass
         else:
             prog += _exponentiate_general_case(term, param)
         return prog

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -722,7 +722,7 @@ def is_identity(pauli_object):
         return (len(pauli_object) == 0) and (not np.isclose(pauli_object.coefficient, 0))
     elif isinstance(pauli_object, PauliSum):
         return (len(pauli_object.terms) == 1) and (len(pauli_object.terms[0]) == 0) and \
-                (not np.isclose(pauli_object.terms[0].coefficient, 0))
+               (not np.isclose(pauli_object.terms[0].coefficient, 0))
     else:
         raise TypeError("is_identity only checks PauliTerms and PauliSum objects!")
 

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -718,7 +718,6 @@ def is_identity(pauli_object):
     :returns: True if the PauliTerm or PauliSum is a scalar multiple of identity, False otherwise
     :rtype: bool
     """
-    # return len(pauli_object) == 0
     if isinstance(pauli_object, PauliTerm):
         print ("This is a PauliTerm")
         if (len(pauli_object) == 0) and (not np.isclose(pauli_object.coefficient, 0)):

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -719,18 +719,10 @@ def is_identity(pauli_object):
     :rtype: bool
     """
     if isinstance(pauli_object, PauliTerm):
-        print ("This is a PauliTerm")
-        if (len(pauli_object) == 0) and (not np.isclose(pauli_object.coefficient, 0)):
-            return True
-        else:
-            return False
+        return (len(pauli_object) == 0) and (not np.isclose(pauli_object.coefficient, 0))
     elif isinstance(pauli_object, PauliSum):
-        print ("This is a PauliSum")
-        if (len(pauli_object.terms) == 1) and (len(pauli_object.terms[0]) == 0) and \
-                (not np.isclose(pauli_object.terms[0].coefficient, 0)):
-            return True
-        else:
-            return False
+        return (len(pauli_object.terms) == 1) and (len(pauli_object.terms[0]) == 0) and \
+                (not np.isclose(pauli_object.terms[0].coefficient, 0))
     else:
         raise TypeError("is_identity only checks PauliTerms and PauliSum objects!")
 
@@ -892,15 +884,9 @@ def is_zero(pauli_object):
     :rtype: bool
     """
     if isinstance(pauli_object, PauliTerm):
-        if np.isclose(pauli_object.coefficient, 0):
-            return True
-        else:
-            return False
+        return np.isclose(pauli_object.coefficient, 0)
     elif isinstance(pauli_object, PauliSum):
-        if len(pauli_object.terms) == 1 and np.isclose(pauli_object.terms[0].coefficient, 0):
-            return True
-        else:
-            return False
+        return len(pauli_object.terms) == 1 and np.isclose(pauli_object.terms[0].coefficient, 0)
     else:
         raise TypeError("is_zero only checks PauliTerms and PauliSum objects!")
 

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -376,7 +376,7 @@ def test_exponentiate_identity():
     generator = PauliTerm("I", 1, 0.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst(I(0))
+    result_prog = Program()
     assert prog == result_prog
 
     generator = PauliTerm("I", 1, 1.0)

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -25,7 +25,7 @@ import numpy as np
 import pytest
 from six.moves import range
 
-from pyquil.gates import RX, RZ, CNOT, H, X, PHASE
+from pyquil.gates import I, RX, RZ, CNOT, H, X, PHASE
 from pyquil.paulis import PauliTerm, PauliSum, exponential_map, exponentiate_commuting_pauli_sum, \
     ID, UnequalLengthWarning, exponentiate, trotterize, is_zero, check_commutation, commuting_sets, \
     term_with_coeff, sI, sX, sY, sZ, ZERO, is_identity
@@ -376,7 +376,7 @@ def test_exponentiate_identity():
     generator = PauliTerm("I", 1, 0.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([X(0), PHASE(-0.0, 0), X(0), PHASE(-0.0, 0)])
+    result_prog = Program().inst(I(0))
     assert prog == result_prog
 
     generator = PauliTerm("I", 1, 1.0)

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -439,16 +439,18 @@ def test_trotterize():
     assert prog == result_prog
 
 
-def test_is_zeron():
+def test_is_zero():
     with pytest.raises(TypeError):
         is_zero(1)
 
     p_term = PauliTerm("X", 0)
     ps_term = p_term + PauliTerm("Z", 1)
+    id_term = PauliTerm("I", 0)
 
     assert not is_zero(p_term)
     assert is_zero(p_term + -1 * p_term)
     assert not is_zero(ps_term)
+    assert not is_zero(id_term)
 
 
 def test_check_commutation():
@@ -484,7 +486,7 @@ def test_check_commutation_rigorous():
 
             tmp_op = _commutator(pauli_ops_pq[x], pauli_ops_pq[y])
             assert len(tmp_op.terms) == 1
-            if is_identity(tmp_op.terms[0]):
+            if is_zero(tmp_op.terms[0]):
                 commuting_pairs.append((pauli_ops_pq[x], pauli_ops_pq[y]))
             else:
                 non_commuting_pairs.append((pauli_ops_pq[x], pauli_ops_pq[y]))
@@ -644,3 +646,13 @@ def test_pauli_string():
     assert p.pauli_string([5]) == "Z"
     assert p.pauli_string([5, 6]) == "ZI"
     assert p.pauli_string([0, 1]) == "IX"
+
+
+def test_is_identity():
+    pt1 = -1.5j * sI(2)
+    pt2 = 1.5 * sX(1) * sZ(2)
+
+    assert is_identity(pt1)
+    assert is_identity(pt2 + (-1 * pt2) + sI(0))
+    assert not is_identity(0 * pt1)
+    assert not is_identity(pt2 + (-1 * pt2))

--- a/pyquil/tests/test_paulis_with_placeholders.py
+++ b/pyquil/tests/test_paulis_with_placeholders.py
@@ -334,7 +334,7 @@ def test_exponentiate_identity():
     generator = PauliTerm("I", q[1], 0.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst(I(0))
+    result_prog = Program().inst()
     assert address_qubits(prog, mapping) == address_qubits(result_prog, mapping)
 
     generator = PauliTerm("I", q[1], 1.0)

--- a/pyquil/tests/test_paulis_with_placeholders.py
+++ b/pyquil/tests/test_paulis_with_placeholders.py
@@ -25,7 +25,7 @@ import pytest
 import re
 from six.moves import range
 
-from pyquil.gates import RX, RZ, CNOT, H, X, PHASE
+from pyquil.gates import I, RX, RZ, CNOT, H, X, PHASE
 from pyquil.paulis import PauliTerm, PauliSum, exponential_map, exponentiate_commuting_pauli_sum, \
     ID, UnequalLengthWarning, exponentiate, trotterize, is_zero, check_commutation, commuting_sets, \
     term_with_coeff, sI, sX, sY, sZ, ZERO, is_identity
@@ -334,7 +334,7 @@ def test_exponentiate_identity():
     generator = PauliTerm("I", q[1], 0.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([X(q[0]), PHASE(-0.0, q[0]), X(q[0]), PHASE(-0.0, q[0])])
+    result_prog = Program().inst(I(0))
     assert address_qubits(prog, mapping) == address_qubits(result_prog, mapping)
 
     generator = PauliTerm("I", q[1], 1.0)
@@ -445,7 +445,7 @@ def test_check_commutation_rigorous():
 
             tmp_op = _commutator(pauli_ops_pq[x], pauli_ops_pq[y])
             assert len(tmp_op.terms) == 1
-            if is_identity(tmp_op.terms[0]):
+            if is_zero(tmp_op.terms[0]):
                 commuting_pairs.append((pauli_ops_pq[x], pauli_ops_pq[y]))
             else:
                 non_commuting_pairs.append((pauli_ops_pq[x], pauli_ops_pq[y]))


### PR DESCRIPTION
The functions `is_zero()` and `is_identity()` weren't always checking correctly for their respective checks. Moreover, some of the unit tests were confusing identities for zero operators, e.g. the commutator of commuting operators is the zero, and the not the identity, operator. These issues have been fixed, and a few more unit tests have been added.