### PR TITLE
Refactor get_qc helper functions

### DIFF
--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -455,7 +455,7 @@ def _get_unrestricted_qvm(name: str, noisy: bool,
     return _get_qvm_with_topology(name=name, connection=connection,
                                   topology=topology,
                                   noisy=noisy,
-                                  requires_executable=True)
+                                  requires_executable=False)
 
 
 def _get_qvm_based_on_real_device(name: str, device: Device,
@@ -477,8 +477,8 @@ def _get_qvm_based_on_real_device(name: str, device: Device,
         noise_model = device.noise_model
     else:
         noise_model = None
-    return _get_qvm_qc(name=name, connection=connection, device=device, noise_model=noise_model,
-                       requires_executable=True)
+    return _get_qvm_qc(name=name, connection=connection, device=device,
+                       noise_model=noise_model, requires_executable=True)
 
 
 @_record_call

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -358,9 +358,11 @@ def _get_qvm_compiler_based_on_endpoint(endpoint: str = None,
         raise ValueError("Protocol for QVM compiler endpoints must be HTTP or TCP.")
 
 
-def _get_qvm_qc(name: str, connection: ForestConnection,
-                device: AbstractDevice, noise_model: Optional[NoiseModel],
-                requires_executable: bool) -> QuantumComputer:
+def _get_qvm_qc(name: str, device: AbstractDevice, noise_model: Optional[NoiseModel],
+                requires_executable: bool, connection: ForestConnection = None) -> QuantumComputer:
+    if connection is None:
+        connection = ForestConnection()
+
     return QuantumComputer(name=name,
                            qam=QVM(connection=connection,
                                    noise_model=noise_model,
@@ -371,8 +373,9 @@ def _get_qvm_qc(name: str, connection: ForestConnection,
                                endpoint=connection.compiler_endpoint))
 
 
-def _get_qvm_with_topology(name: str, connection: ForestConnection, topology: nx.Graph, noisy: bool,
-                           requires_executable: bool) -> QuantumComputer:
+def _get_qvm_with_topology(name: str, topology: nx.Graph, noisy: bool,
+                           requires_executable: bool,
+                           connection: ForestConnection = None) -> QuantumComputer:
     device = NxDevice(topology=topology)
     if noisy:
         noise_model = decoherence_noise_with_asymmetric_ro(gates=gates_in_isa(device.get_isa()))
@@ -382,7 +385,8 @@ def _get_qvm_with_topology(name: str, connection: ForestConnection, topology: nx
                        requires_executable=requires_executable)
 
 
-def _get_9q_square_qvm(name: str, connection: ForestConnection, noisy: bool) -> QuantumComputer:
+def _get_9q_square_qvm(name: str, noisy: bool,
+                       connection: ForestConnection = None) -> QuantumComputer:
     """
     A nine-qubit 3x3 square lattice.
 
@@ -402,8 +406,9 @@ def _get_9q_square_qvm(name: str, connection: ForestConnection, noisy: bool) -> 
                                   requires_executable=True)
 
 
-def _get_unrestricted_qvm(name: str, connection: ForestConnection, noisy: bool,
-                          n_qubits: int = 34) -> QuantumComputer:
+def _get_unrestricted_qvm(name: str, noisy: bool,
+                          n_qubits: int = 34,
+                          connection: ForestConnection = None) -> QuantumComputer:
     """
     A qvm with a fully-connected topology.
 
@@ -423,8 +428,8 @@ def _get_unrestricted_qvm(name: str, connection: ForestConnection, noisy: bool,
                                   requires_executable=True)
 
 
-def _get_qvm_based_on_real_device(name: str, connection: ForestConnection, device: Device,
-                                  noisy: bool):
+def _get_qvm_based_on_real_device(name: str, device: Device,
+                                  noisy: bool, connection: ForestConnection = None):
     """
     A qvm with a based on a real device.
 
@@ -513,9 +518,6 @@ def get_qc(name: str, *, as_qvm: bool = None, noisy: bool = None,
         of these parameters, pass your own :py:class:`ForestConnection` object.
     :return: A pre-configured QuantumComputer
     """
-    if connection is None:
-        connection = ForestConnection()
-
     # 1. Parse name, check for redundant options, canonicalize names.
     prefix, as_qvm, noisy = _parse_name(name, as_qvm, noisy)
     if noisy:

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -558,7 +558,9 @@ def get_qc(name: str, *, as_qvm: bool = None, noisy: bool = None,
             warnings.warn("You have specified `noisy=True`, but you're getting a QPU. This flag "
                           "is meant for controlling noise models on QVMs.")
         return QuantumComputer(name=name,
-                               qam=QPU(endpoint=pyquil_config.qpu_url, user=pyquil_config.user_id),
+                               qam=QPU(
+                                   endpoint=pyquil_config.qpu_url,
+                                   user=pyquil_config.user_id),
                                device=device,
                                compiler=QPUCompiler(
                                    endpoint=pyquil_config.compiler_url,

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -402,7 +402,9 @@ def _get_9q_square_qvm(name: str, noisy: bool,
     :return: A pre-configured QuantumComputer
     """
     topology = nx.convert_node_labels_to_integers(nx.grid_2d_graph(3, 3))
-    return _get_qvm_with_topology(name=name, connection=connection, topology=topology, noisy=noisy,
+    return _get_qvm_with_topology(name=name, connection=connection,
+                                  topology=topology,
+                                  noisy=noisy,
                                   requires_executable=True)
 
 
@@ -424,7 +426,8 @@ def _get_unrestricted_qvm(name: str, noisy: bool,
     :return: A pre-configured QuantumComputer
     """
     return _get_qvm_with_topology(name=name, connection=connection,
-                                  topology=nx.complete_graph(n_qubits), noisy=noisy,
+                                  topology=nx.complete_graph(n_qubits),
+                                  noisy=noisy,
                                   requires_executable=True)
 
 
@@ -547,7 +550,7 @@ def get_qc(name: str, *, as_qvm: bool = None, noisy: bool = None,
     device = get_lattice(prefix)
     if as_qvm:
         # 4.1 QVM based on a real device.
-        return _get_qvm_based_on_real_device(name=prefix, device=device,
+        return _get_qvm_based_on_real_device(name=name, device=device,
                                              noisy=noisy, connection=connection)
     if not as_qvm:
         # 4.2 A real device

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -389,7 +389,8 @@ def _get_qvm_qc(name: str, device: AbstractDevice, noise_model: NoiseModel = Non
                                endpoint=connection.compiler_endpoint))
 
 
-def _get_qvm_with_topology(name: str, topology: nx.Graph, noisy: bool,
+def _get_qvm_with_topology(name: str, topology: nx.Graph,
+                           noisy: bool = False,
                            requires_executable: bool = True,
                            connection: ForestConnection = None) -> QuantumComputer:
     """Construct a QVM with the provided topology.

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -7,7 +7,8 @@ import pytest
 from pyquil import Program, get_qc, list_quantum_computers
 from pyquil.api import QVM, QuantumComputer, local_qvm
 from pyquil.api._qac import AbstractCompiler
-from pyquil.api._quantum_computer import _get_flipped_protoquil_program, _parse_name
+from pyquil.api._quantum_computer import _get_flipped_protoquil_program, _parse_name, \
+    _get_qvm_with_topology
 from pyquil.device import NxDevice, gates_in_isa
 from pyquil.gates import *
 from pyquil.quilbase import Declare, MemoryReference
@@ -378,3 +379,26 @@ def test_reset(forest):
     assert qc.qam._executable is None
     assert qc.qam._bitstrings is None
     assert qc.qam.status == 'connected'
+
+
+def test_get_qvm_with_topology():
+    topo = nx.from_edgelist([
+        (5, 6),
+        (6, 7),
+        (10, 11),
+    ])
+    # Note to developers: perhaps make `get_qvm_with_topology` public in the future
+    qc = _get_qvm_with_topology(name='test-qvm', topology=topo)
+    assert len(qc.qubits()) == 5
+    assert min(qc.qubits()) == 5
+
+
+def test_get_qvm_with_topology_2(forest):
+    topo = nx.from_edgelist([
+        (5, 6),
+        (6, 7),
+    ])
+    qc = _get_qvm_with_topology(name='test-qvm', topology=topo)
+    results = qc.run_and_measure(Program(X(5)), trials=5)
+    assert sorted(results.keys()) == [5, 6, 7]
+    assert all(x == 1 for x in results[5])


### PR DESCRIPTION
`get_qc` will return a qpu with the given name or a qvm based off of the named qpu. It also has two "hardcoded" qvms that aren't based on a real device: `9q-square-qvm` and `{n}q-qvm`. Users probably want the ability to give their own topology and/or noise model. This refactors the creation of qvms-not-based-on-a-real-device in anticipation of supporting functionality to have the user create a qvm of their liking.

In particular, `_get_qvm_with_topology` can be made public, documented, and advertised for building a qvm with a custom topology.