### PR TITLE
add rpm dependencies install command for local SDK

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -170,6 +170,12 @@ libffi. On a Debian-derivative system, this could be accomplished with
 
    sudo apt-get install liblapack-dev libblas-dev libffi-dev
 
+Or on rpm systems (e.g. Amazon Linux) with
+
+::
+
+   sudo yum install -y lapack-devel blas-devel
+
 To uninstall, remove the directory ``~/rigetti``.
 
 .. _exampleprogram:

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -170,7 +170,7 @@ libffi. On a Debian-derivative system, this could be accomplished with
 
    sudo apt-get install liblapack-dev libblas-dev libffi-dev
 
-Or on rpm systems (e.g. Amazon Linux) with
+Or on any rhel-derivative systems (e.g. Amazon Linux) with
 
 ::
 


### PR DESCRIPTION
Used this during a fresh install and figured it may as well be in the docs.