### PR TITLE
Pad + and - with space to disambiguate from hyphenated variables

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v2.2 (Development)
+------------------
+
+- Parameter expressions involving addition and subtraction are now converted to Quil with spaces
+  around the operators, e.g. ``theta + 2`` instead of ``theta+2``. This disambiguates subtracting
+  two parameters, e.g. ``alpha - beta`` is not one variable named ``alpha-beta``.
+
+
 v2.1 (November 30, 2018)
 ------------------------
 

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -416,7 +416,7 @@ class BinaryExp(Expression):
 
 
 class Add(BinaryExp):
-    operator = '+'
+    operator = ' + '
     precedence = 1
     associates = 'both'
 
@@ -429,7 +429,7 @@ class Add(BinaryExp):
 
 
 class Sub(BinaryExp):
-    operator = '-'
+    operator = ' - '
     precedence = 1
     associates = 'left'
 

--- a/pyquil/tests/test_parameters.py
+++ b/pyquil/tests/test_parameters.py
@@ -45,23 +45,23 @@ def test_expression_to_string():
     y = Parameter('y')
     assert str(y) == '%y'
 
-    assert str(x + y) == '%x+%y'
-    assert str(3 * x + y) == '3*%x+%y'
-    assert str(3 * (x + y)) == '3*(%x+%y)'
+    assert str(x + y) == '%x + %y'
+    assert str(3 * x + y) == '3*%x + %y'
+    assert str(3 * (x + y)) == '3*(%x + %y)'
 
-    assert str(x + y + 2) == '%x+%y+2'
-    assert str(x - y - 2) == '%x-%y-2'
-    assert str(x - (y - 2)) == '%x-(%y-2)'
+    assert str(x + y + 2) == '%x + %y + 2'
+    assert str(x - y - 2) == '%x - %y - 2'
+    assert str(x - (y - 2)) == '%x - (%y - 2)'
 
-    assert str((x + y) - 2) == '%x+%y-2'
-    assert str(x + (y - 2)) == '%x+%y-2'
+    assert str((x + y) - 2) == '%x + %y - 2'
+    assert str(x + (y - 2)) == '%x + %y - 2'
 
     assert str(x ** y ** 2) == '%x^%y^2'
     assert str(x ** (y ** 2)) == '%x^%y^2'
     assert str((x ** y) ** 2) == '(%x^%y)^2'
 
     assert str(quil_sin(x)) == 'sin(%x)'
-    assert str(3 * quil_sin(x + y)) == '3*sin(%x+%y)'
+    assert str(3 * quil_sin(x + y)) == '3*sin(%x + %y)'
 
 
 def test_contained_parameters():


### PR DESCRIPTION
Fixes #709