### PR TITLE
Extra parameters for writing a LaTeX to enable generating a PNG image

### DIFF
--- a/pyquil/latex/latex_config.py
+++ b/pyquil/latex/latex_config.py
@@ -73,7 +73,7 @@ def header(settings):
     :return: Header of the LaTeX document.
     :rtype: string
     """
-    packages = (r"\documentclass{standalone}",
+    packages = (r"\documentclass[convert={density=300,outext=.png}]{standalone}",
                 r"\usepackage[margin=1in]{geometry}",
                 r"\usepackage[hang,small,bf]{caption}",
                 r"\usepackage{tikz}",


### PR DESCRIPTION
The preamble was extended with a few options. It does not affect normal compilation with `pdflatex`. If `pdflatex` is run with the `-shell-escape` flag, it will generate a PNG along with the PDF. This makes it easier to read the image of the circuit in a Jupyter notebook.