### PR TITLE
reflect quilc URI strictness

### DIFF
--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -392,7 +392,7 @@ class ForestConnection:
         directly.
         """
         payload = quilc_compile_payload(quil_program, isa, specs)
-        response = post_json(self.session, self.sync_endpoint + "/quilc", payload)
+        response = post_json(self.session, self.sync_endpoint + "/", payload)
         unpacked_response = response.json()
         return unpacked_response
 


### PR DESCRIPTION
In version 1.2.0, quilc changed its URI matching strategy during dispatch from "does the prefix match?" to "is it an exact match?" Internally, the main compilation endpoint is named "/", but pyQuil (confirming to the 1.3 URIs) was sending requests to "/quilc". This won't work anymore.

Looks like `pyquil/api/_benchmark.py` and all of the QVM methods are safe from this.

Another option is to merge the RPCQ-enabled-quilc pyQuil branch ( https://github.com/rigetti/pyquil/pull/730 ), now that an RPCQ-enabled version of quilc is available. Because that branch removes HTTP endpoint support entirely, it dodges this bug, but it also requires some user education, since the startup flags for quilc change from `-S` to `-R`. I don't know what the right move here is.