### PR TITLE
Use the OSS qvm/quilc Docker images in gitlab CI services instead

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,10 +4,10 @@ before_script:
   - pip install tox
 
 services:
-  - name: rigetticomputing/qvm
+  - name: rigetti/qvm
     alias: qvm
     command: ["-S"]
-  - name: rigetticomputing/quilc
+  - name: rigetti/quilc
     alias: quilc
     command: ["-S"]
 


### PR DESCRIPTION
public quilc image: https://hub.docker.com/r/rigetti/quilc
public qvm image: https://hub.docker.com/r/rigetti/qvm