### PR TITLE
Clear up usage of 'protoquil'

### DIFF
--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -11,7 +11,7 @@ gate operators are constrained to lie in ``RZ(θ)``, ``RX(k*π/2)``, and ``CZ``;
 gates are required to act on physically available hardware (for single-qubit gates, this means
 acting only on live qubits, and for qubit-pair gates, this means acting on neighboring qubits). However, as a programmer, it is often (though not always) desirable to to be able to write programs which don't take these details into account. These generally leads to more portable code if one isn't tied to a specific set of gates or QPU architecture.
 To ameliorate these limitations, the Rigetti software toolkit contains an optimizing compiler that
-translates arbitrary Quil to native Quil and native ProtoQuil to executables suitable for Rigetti
+translates arbitrary Quil to native Quil and native Quil to executables suitable for Rigetti
 hardware.
 
 
@@ -84,7 +84,7 @@ class of this object changes based on context (e.g., ``QPUCompiler``, ``QVMCompi
   :py:class:`~pyquil.quil.Program` object, and the output is given as a new ``Program`` object, equipped with a
   ``.metadata`` property that gives extraneous information about the compilation output (e.g., gate
   depth, as well as many others).  This call blocks until Quil compilation finishes.
-* ``compiler.native_quil_to_executable(nq_program)``: This method converts a ProtoQuil program, which
+* ``compiler.native_quil_to_executable(nq_program)``: This method converts a native Quil program, which
   is promised to consist only of native gates for a given ISA, into an executable suitable for
   submission to one of a QVM or a QPU.  This call blocks until the executable is generated.
 

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -36,7 +36,7 @@ from pyquil.device import AbstractDevice, NxDevice, gates_in_isa, ISA, Device
 from pyquil.gates import RX, MEASURE
 from pyquil.noise import decoherence_noise_with_asymmetric_ro, NoiseModel
 from pyquil.pyqvm import PyQVM
-from pyquil.quil import Program, validate_protoquil
+from pyquil.quil import Program, validate_supported_quil
 from pyquil.quilbase import Measurement, Pragma, Gate, Reset
 
 pyquil_config = PyquilConfig()
@@ -47,8 +47,7 @@ Executable = Union[BinaryExecutableResponse, PyQuilExecutableResponse]
 def _get_flipped_protoquil_program(program: Program) -> Program:
     """For symmetrization, generate a program where X gates are added before measurement.
 
-    Forest 1.3 is really picky about where the measure instructions happen. It has to be
-    at the end!
+    Forest is picky about where the measure instructions happen. It has to be at the end!
     """
     program = program.copy()
     to_measure = []
@@ -219,7 +218,7 @@ class QuantumComputer:
             measured bits.
         """
         program = program.copy()
-        validate_protoquil(program)
+        validate_supported_quil(program)
         ro = program.declare('ro', 'BIT', len(self.qubits()))
         for i, q in enumerate(self.qubits()):
             program.inst(MEASURE(q, ro[i]))

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -1143,19 +1143,19 @@ def test_is_protoquil():
         H(1),
         RESET())
     validate_protoquil(prog)
-    assert prog.is_protoquil() == True
+    assert prog.is_protoquil()
 
     prog = Program(Declare('ro', 'BIT'), H(0), Y(1), CNOT(0, 1)) \
         .measure(0, MemoryReference("ro", 0)) \
         .if_then(MemoryReference("ro", 0), Program(X(0)), Program())
     with pytest.raises(ValueError):
         validate_protoquil(prog)
-    assert prog.is_protoquil() == False
+    assert not prog.is_protoquil()
 
     prog = Program(Declare('ro', 'BIT'), ClassicalNot(MemoryReference("ro", 0)))
     with pytest.raises(ValueError):
         validate_protoquil(prog)
-    assert prog.is_protoquil() == False
+    assert not prog.is_protoquil()
 
 
 def test_subtracting_memory_regions():


### PR DESCRIPTION
Update docs to say native quil rather than protoquil, update quantum computer to validate that the program being ran is SUPPORTED quil rather than protoquil, update definition of protoquil to be in the spirit of its original intended usage, update tests.

The idea is that Protoquil is a subset of Quil without control flow or classical instructions. Its definition shouldn't change. We were using it to validate whether programs will run on our hardware, which isn't a perfect mapping. Supported Quil is currently more restrictive, but is also a definition that will change over time as we support more operations on hardware. At some point in the future, it should even be less restrictive than ProtoQuil.

Open to ideas/changes if I've gotten anything wrong :)