### PR TITLE
Update start.rst

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -218,7 +218,7 @@ terminal.
 
 
     ### CONSOLE 2
-    $ quilc -R
+    $ quilc -R -p 6000
 
     ... - Launching quilc.
     ... - Spawning server at (tcp://*:5555) .


### PR DESCRIPTION
Updated the quilc server start sentence to "quilc -R -p 6000"

Since The HTTP endpoint has been deprecated in favor of the RPCQ endpoint, now the RPCQ must be run in port 6000 to run natively with the config files, if not it starts in port 5555 and the get_qc sentence fails with this error:

""" 
ConnectionError                           Traceback (most recent call last)
<ipython-input-5-32c855c94878> in <module>()
      1 # run the program on a QVM
      2 qc = get_qc('9q-square-qvm')
----> 3 result = qc.run_and_measure(p, trials=10)
      4 print(result[0])
      5 print(result[1])

~/.Envs/forest/lib/python3.6/site-packages/pyquil/api/_error_reporting.py in wrapper(*args, **kwargs)
    236             global_error_context.log[key] = pre_entry
    237 
--> 238         val = func(*args, **kwargs)
    239 
    240         # poke the return value of that call in

~/.Envs/forest/lib/python3.6/site-packages/pyquil/api/_quantum_computer.py in run_and_measure(self, program, trials)
    225             program.inst(MEASURE(q, ro[i]))
    226         program.wrap_in_numshots_loop(trials)
--> 227         executable = self.compile(program)
    228         bitstring_array = self.run(executable=executable)
    229         bitstring_dict = {}

~/.Envs/forest/lib/python3.6/site-packages/pyquil/api/_error_reporting.py in wrapper(*args, **kwargs)
    236             global_error_context.log[key] = pre_entry
    237 
--> 238         val = func(*args, **kwargs)
    239 
    240         # poke the return value of that call in

~/.Envs/forest/lib/python3.6/site-packages/pyquil/api/_quantum_computer.py in compile(self, program, to_native_gates, optimize)
    255 
    256         if quilc:
--> 257             nq_program = self.compiler.quil_to_native_quil(program)
    258         else:
    259             nq_program = program

~/.Envs/forest/lib/python3.6/site-packages/pyquil/api/_compiler.py in quil_to_native_quil(self, program)
    239 
    240     def quil_to_native_quil(self, program: Program) -> Program:
--> 241         response = self._connection._quilc_compile(program, self.isa, self.specs)
    242 
    243         compiled_program = Program(response['compiled-quil'])

~/.Envs/forest/lib/python3.6/site-packages/pyquil/api/_base_connection.py in _quilc_compile(self, quil_program, isa, specs)
    392         """
    393         payload = quilc_compile_payload(quil_program, isa, specs)
--> 394         response = post_json(self.session, self.sync_endpoint + "/", payload)
    395         unpacked_response = response.json()
    396         return unpacked_response

~/.Envs/forest/lib/python3.6/site-packages/pyquil/api/_base_connection.py in post_json(session, url, json)
     54     Post JSON to the Forest endpoint.
     55     """
---> 56     res = session.post(url, json=json)
     57     if res.status_code >= 400:
     58         raise parse_error(res)

~/.Envs/forest/lib/python3.6/site-packages/requests/sessions.py in post(self, url, data, json, **kwargs)
    579         """
    580 
--> 581         return self.request('POST', url, data=data, json=json, **kwargs)
    582 
    583     def put(self, url, data=None, **kwargs):

~/.Envs/forest/lib/python3.6/site-packages/requests/sessions.py in request(self, method, url, params, data, headers, cookies, files, auth, timeout, allow_redirects, proxies, hooks, stream, verify, cert, json)
    531         }
    532         send_kwargs.update(settings)
--> 533         resp = self.send(prep, **send_kwargs)
    534 
    535         return resp

~/.Envs/forest/lib/python3.6/site-packages/requests/sessions.py in send(self, request, **kwargs)
    644 
    645         # Send the request
--> 646         r = adapter.send(request, **kwargs)
    647 
    648         # Total elapsed time of the request (approximately)

~/.Envs/forest/lib/python3.6/site-packages/requests/adapters.py in send(self, request, stream, timeout, verify, cert, proxies)
    514                 raise SSLError(e, request=request)
    515 
--> 516             raise ConnectionError(e, request=request)
    517 
    518         except ClosedPoolError as e:

ConnectionError: HTTPConnectionPool(host='127.0.0.1', port=6000): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x11619ec50>: Failed to establish a new connection: [Errno 61] Connection refused',))
"""