### PR TITLE
add quilc protocol check

### DIFF
--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -70,7 +70,7 @@ where
  -  ``compiler_server_address``: This is the endpoint where pyQuil will try to communicate with the compiler server. On a
     QMI, this points to a provided compiler server instance. On a local installation, this should be set to the server
     endpoint for a locally running ``quilc`` instance. However, pyQuil will use the default value ``tcp://localhost:5555``
-    if this isn't set, which is the correct endpoint when you run ``quilc`` locally with ``quilc -R``.
+    if this isn't set, which is the correct endpoint when you run ``quilc`` locally with ``quilc -S``.
 
 .. note::
 

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -19,11 +19,11 @@ Interacting with the Compiler
 -----------------------------
 
 After :ref:`downloading the SDK <sdkinstall>`, the Quil Compiler, ``quilc`` is available on your local machine.
-You can initialize a local ``quilc`` server by typing ``quilc -R`` into your terminal. You should see the following message.
+You can initialize a local ``quilc`` server by typing ``quilc -S`` into your terminal. You should see the following message.
 
 .. code:: python
 
-    $ quilc -R
+    $ quilc -S
     +-----------------+
     |  W E L C O M E  |
     |   T O   T H E   |

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -227,10 +227,9 @@ terminal.
 That's it! You're all set up to run pyQuil locally. Your programs will make requests to these server endpoints to compile your Quil
 programs to native Quil, and to simulate those programs on the QVM.
 
-**NOTE**: We are transitioning from using an HTTP ``quilc`` server to an RPCQ one. In the near term,
-``-S`` will spawn an HTTP server at port 6000 and an RPCQ server (accessible via tcp://domain:port)
-at port 5555. The RPCQ port is configurable with the ``-p`` option on ``quilc`` and the HTTP port
-is not configurable.
+**NOTE**: We are transitioning from using an HTTP ``quilc`` server to an RPCQ one.
+In the near term, ``-S`` will spawn an HTTP server at port 6000 and an RPCQ server
+at port 5555 (accessible via ``tcp://localhost:5555``).
 
 Run Your First Program
 ----------------------

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -218,7 +218,7 @@ terminal.
 
 
     ### CONSOLE 2
-    $ quilc -R
+    $ quilc -S
 
     ... - Launching quilc.
     ... - Spawning server at (tcp://*:5555) .
@@ -226,6 +226,11 @@ terminal.
 
 That's it! You're all set up to run pyQuil locally. Your programs will make requests to these server endpoints to compile your Quil
 programs to native Quil, and to simulate those programs on the QVM.
+
+**NOTE**: We are transitioning from using an HTTP ``quilc`` server to an RPCQ one. In the near term,
+``-S`` will spawn an HTTP server at port 6000 and an RPCQ server (accessible via tcp://domain:port)
+at port 5555. The RPCQ port is configurable with the ``-p`` option on ``quilc`` and the HTTP port
+is not configurable.
 
 Run Your First Program
 ----------------------

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -142,6 +142,15 @@ class QPUCompiler(AbstractCompiler):
         :param name: Name of the lattice being targeted
         """
 
+        if not endpoint.startswith('tcp://'):
+            raise ValueError(f"PyQuil versions >= 2.4 can only talk to quilc "
+                f"versions >= 1.4 over network RPCQ.  You've supplied the "
+                f"endpoint '{endpoint}', but this doesn't look like a network "
+                f"ZeroMQ address, which has the form 'tcp://domain:port'. "
+                f"You might try clearing (or correcting) your COMPILER_URL "
+                f"environment variable and removing (or correcting) the "
+                f"compiler_server_address line from your .forest_config file.")
+
         self.client = Client(endpoint, timeout=timeout)
         self.target_device = TargetDevice(isa=device.get_isa().to_dict(),
                                           specs=device.get_specs().to_dict())
@@ -196,6 +205,16 @@ class QVMCompiler(AbstractCompiler):
         :param endpoint: TCP or IPC endpoint of the Compiler Server
         :param device: PyQuil Device object to use as compilation target
         """
+
+        if not endpoint.startswith('tcp://'):
+            raise ValueError(f"PyQuil versions >= 2.4 can only talk to quilc "
+                f"versions >= 1.4 over network RPCQ.  You've supplied the "
+                f"endpoint '{endpoint}', but this doesn't look like a network "
+                f"ZeroMQ address, which has the form 'tcp://domain:port'. "
+                f"You might try clearing (or correcting) your COMPILER_URL "
+                f"environment variable and removing (or correcting) the "
+                f"compiler_server_address line from your .forest_config file.")
+
         self.client = Client(endpoint, timeout=timeout)
         self.target_device = TargetDevice(isa=device.get_isa().to_dict(),
                                           specs=device.get_specs().to_dict())

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -144,12 +144,12 @@ class QPUCompiler(AbstractCompiler):
 
         if not endpoint.startswith('tcp://'):
             raise ValueError(f"PyQuil versions >= 2.4 can only talk to quilc "
-                f"versions >= 1.4 over network RPCQ.  You've supplied the "
-                f"endpoint '{endpoint}', but this doesn't look like a network "
-                f"ZeroMQ address, which has the form 'tcp://domain:port'. "
-                f"You might try clearing (or correcting) your COMPILER_URL "
-                f"environment variable and removing (or correcting) the "
-                f"compiler_server_address line from your .forest_config file.")
+                             f"versions >= 1.4 over network RPCQ.  You've supplied the "
+                             f"endpoint '{endpoint}', but this doesn't look like a network "
+                             f"ZeroMQ address, which has the form 'tcp://domain:port'. "
+                             f"You might try clearing (or correcting) your COMPILER_URL "
+                             f"environment variable and removing (or correcting) the "
+                             f"compiler_server_address line from your .forest_config file.")
 
         self.client = Client(endpoint, timeout=timeout)
         self.target_device = TargetDevice(isa=device.get_isa().to_dict(),
@@ -208,12 +208,12 @@ class QVMCompiler(AbstractCompiler):
 
         if not endpoint.startswith('tcp://'):
             raise ValueError(f"PyQuil versions >= 2.4 can only talk to quilc "
-                f"versions >= 1.4 over network RPCQ.  You've supplied the "
-                f"endpoint '{endpoint}', but this doesn't look like a network "
-                f"ZeroMQ address, which has the form 'tcp://domain:port'. "
-                f"You might try clearing (or correcting) your COMPILER_URL "
-                f"environment variable and removing (or correcting) the "
-                f"compiler_server_address line from your .forest_config file.")
+                             f"versions >= 1.4 over network RPCQ.  You've supplied the "
+                             f"endpoint '{endpoint}', but this doesn't look like a network "
+                             f"ZeroMQ address, which has the form 'tcp://domain:port'. "
+                             f"You might try clearing (or correcting) your COMPILER_URL "
+                             f"environment variable and removing (or correcting) the "
+                             f"compiler_server_address line from your .forest_config file.")
 
         self.client = Client(endpoint, timeout=timeout)
         self.target_device = TargetDevice(isa=device.get_isa().to_dict(),


### PR DESCRIPTION
Checks the quilc URL to ensure that it at least looks like a ZMQ address. This will help users migrate their config files, should they have customized that address and forgotten to change it during the upgrade.