### PR TITLE
TypeError in PauliTerm.from_list

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -329,6 +329,10 @@ class PauliTerm(object):
         :param list terms_list: A list of tuples, e.g. [("X", 0), ("Y", 1)]
         :return: PauliTerm
         """
+        if not all([isinstance(op, tuple) for op in terms_list]):
+            raise TypeError("The type of terms_list should be a list of (name, index) "
+                            "tuples suitable for PauliTerm().")
+
         pterm = PauliTerm("I", 0)
         assert all([op[0] in PAULI_OPS for op in terms_list])
 


### PR DESCRIPTION
A PauliTerm and tuple of (name, index) are *almost* similar enough for
duck typing to work, but not quite.

Would see a confusing error if doing something like
  `PauliTerm.from_list([sZ(0), sX(1)])`

Closes #762.