### PR TITLE
Raise IndexError in MemoryReference.__getitem__()

### DIFF
--- a/examples/forest2-simple-prog.py
+++ b/examples/forest2-simple-prog.py
@@ -40,7 +40,7 @@ def run_bell_medium_level(n_shots=1000):
     program += CNOT(q[0], q[1])
 
     # Step 2.1. Manage read-out memory
-    ro = program.declare('ro', memory_type='BIT', memory_size='2')
+    ro = program.declare('ro', memory_type='BIT', memory_size=2)
     program += MEASURE(q[0], ro[0])
     program += MEASURE(q[1], ro[1])
 
@@ -76,7 +76,7 @@ def run_bell_low_level(n_shots=1000):
     program += CNOT(q[0], q[1])
 
     # Step 2.1. Manage read-out memory
-    ro = program.declare('ro', memory_type='BIT', memory_size='2')
+    ro = program.declare('ro', memory_type='BIT', memory_size=2)
     program += MEASURE(q[0], ro[0])
     program += MEASURE(q[1], ro[1])
 

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -613,6 +613,7 @@ class MemoryReference(QuilAtom, Expression):
 
         return MemoryReference(name=self.name, offset=offset)
 
+
 class Addr(MemoryReference):
     """
     Representation of a classical bit address.

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -604,8 +604,14 @@ class MemoryReference(QuilAtom, Expression):
         if self.offset != 0:
             raise ValueError("Please only index off of the base MemoryReference (offset = 0)")
 
-        return MemoryReference(name=self.name, offset=offset)
+        # NOTE If a MemoryReference is the result of parsing (not
+        # manually instantiated), it will likely be instantiated
+        # without a declared_size, and so bounds checking will be
+        # impossible.
+        if self.declared_size and offset >= self.declared_size:
+            raise IndexError("MemoryReference index out of range")
 
+        return MemoryReference(name=self.name, offset=offset)
 
 class Addr(MemoryReference):
     """

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -1171,10 +1171,12 @@ def test_subtracting_memory_regions():
     assert parsed_param.op1 == alpha
     assert parsed_param.op2 == beta
 
+
 def test_out_of_bounds_memory():
     r = Program().declare('ro', 'BIT', 1)
     with pytest.raises(IndexError):
         r[1]
+
 
 @pytest.mark.timeout(5)
 def test_memory_reference_iteration():

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -1170,3 +1170,13 @@ def test_subtracting_memory_regions():
     assert isinstance(parsed_param, Sub)
     assert parsed_param.op1 == alpha
     assert parsed_param.op2 == beta
+
+def test_out_of_bounds_memory():
+    r = Program().declare('ro', 'BIT', 1)
+    with pytest.raises(IndexError):
+        r[1]
+
+@pytest.mark.timeout(5)
+def test_memory_reference_iteration():
+    r = Program().declare('ro', 'BIT', 10)
+    assert len([i for i in r]) == 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ rpcq == 2.2.1
 
 # test deps
 pytest
+pytest-timeout
 requests-mock
 flake8
 tox


### PR DESCRIPTION
Closes #599, #667.   

It's not a complete fix since you can still get a `MemoryReference` that has no `declared_size` from the pyQuil parser, but it at least guards against the manually-instantiated case.