### PR TITLE
Strict version lower-bounds on RPCQ and NetworkX

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ numpy
 antlr4-python3-runtime
 requests
 six
-networkx
+networkx >= 2.0.0
 
 # rigetti packages
-rpcq == 2.2.1
+rpcq >= 2.2.1
 
 # test deps
 pytest

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         'antlr4-python3-runtime',
         'requests',
         'six',
-        'networkx',
+        'networkx>=2.0.0',
         'rpcq>=2.2.1',
 
         # dependency of contextvars, which we vendor


### PR DESCRIPTION
RPCQ had a lower-bound in setup.py but not requirements.txt.

Closes #822.