### PR TITLE
Fix meas obs

### DIFF
--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -1070,6 +1070,6 @@ def _calibration_program(qc: QuantumComputer, tomo_experiment: TomographyExperim
         calibr_prog += _one_q_pauli_prep(label=op, index=0, qubit=q)
     # Measure the out operator in this state
     for q, op in setting.out_operator.operations_as_set():
-        calibr_prog += _local_pauli_eig_meas(op, q) 
+        calibr_prog += _local_pauli_eig_meas(op, q)
 
     return calibr_prog

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -751,8 +751,7 @@ class ExperimentResult:
 def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperiment,
                         n_shots: int = 1000, progress_callback=None, active_reset=False,
                         readout_symmetrize: str = None, calibrate_readout: str = None,
-                        inherit_povm: bool = True, inherit_gate_defn: bool = False,
-                        inherit_defined_gate_app: bool = False, inherit_kraus: bool = False):
+                        inherit_readout_error: bool = True, inherit_gate_noise: bool = True):
     """
     Measure all the observables in a TomographyExperiment.
 
@@ -779,14 +778,10 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
         method supported is normalizing against the operator's expectation value in its +1
         eigenstate, which can be specified by setting this variable to 'plus-eig'. The preceding
         symmetrization and this step together yield a more accurate estimation of the observable.
-    :param inherit_povm: Whether the calibration program should inherit any `PRAGMA READOUT-POVM`
+    :param inherit_readout_error: Whether the calibration program should inherit any readout error
         instructions from the main TomographyExperiment's Program
-    :param inherit_gate_defn: Whether the calibration program should inherit any defined gates
-        from the main TomographyExperiment's Program
-    :param inherit_defined_gate_app: Whether the calibration program should inherit any
-        applications of any defined gates from the main TomographyExperiment's Program
-    :param inherit_kraus: Whether the calibration program should inherit any applications
-        of Kraus operators
+    :param inherit_gate_noise: Whether the calibration program should inherit any definitions of
+        noisy gates from the main TomographyExperiment's Program
     """
     # calibration readout only works with symmetrization turned on
     if calibrate_readout is not None and readout_symmetrize is None:
@@ -869,37 +864,9 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
 
             if calibrate_readout == 'plus-eig':
                 # 4 Readout calibration
-                # 4.1 Inherit any noisy attributes from main Program, including gate definitions
-                #     and applications which can be handy in creating simulating noisy channels
-                calibr_prog = Program()
-                if inherit_povm:
-                    # 4.1.2 Inherit any noisy readout instructions from main Program
-                    readout_povm_instruction = [i for i in tomo_experiment.program.out().split('\n') if 'PRAGMA READOUT-POVM' in i]
-                    calibr_prog += readout_povm_instruction
-                if inherit_gate_defn:
-                    # 4.1.3 Inherit any gate definitions from main Program
-                    defgate_instructions = [gdef for gdef in tomo_experiment.program.defined_gates]
-                    calibr_prog += defgate_instructions
-                if inherit_defined_gate_app:
-                    # 4.1.4 Inherit any applications of defined gates from main Program
-                    assert inherit_gate_defn, "Gate(s) must be defined in order to be applied"
-                    defgate_app_instructions = []
-                    for defined_gate in defgate_instructions:
-                        defn = str(defined_gate)
-                        gatename = defn[defn.find('DEFGATE') + len('DEFGATE') + 1: defn.find(':')]
-                        defgate_app_instructions += [i for i in tomo_experiment.program.instructions if gatename in (str(i)) and isinstance(i, Gate)]
-                    calibr_prog += defgate_app_instructions
-                if inherit_kraus:
-                    # 4.1.5 Inherit any applications of Kraus operators
-                    kraus_instructions = [i for i in tomo_experiment.program.out().split('\n') if 'PRAGMA ADD-KRAUS' in i]
-                    calibr_prog += kraus_instructions
-                # 4.2 Prepare the +1 eigenstate for the out operator
-                for q, op in setting.out_operator.operations_as_set():
-                    calibr_prog += _one_q_pauli_prep(label=op, index=0, qubit=q)
-                # 4.3 Measure the out operator in this state
-                for q, op in setting.out_operator.operations_as_set():
-                    calibr_prog += _local_pauli_eig_meas(op, q)
-                # 4.4 Perform symmetrization on the calibration readout
+                # 4.1 Obtain calibration program
+                calibr_prog = _calibration_program(qc, tomo_experiment, setting, inherit_readout_error, inherit_gate_noise)
+                # 4.2 Perform symmetrization on the calibration program
                 if readout_symmetrize == 'exhaustive':
                     qubs_calibr = setting.out_operator.get_qubits()
                     calibr_shots = n_shots
@@ -908,9 +875,9 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 else:
                     raise ValueError("Readout symmetrization method must be either 'exhaustive' or None")
 
-                # 4.5 Obtain statistics from the measurement process
+                # 4.3 Obtain statistics from the measurement process
                 obs_calibr_mean, obs_calibr_var = _stats_from_measurements(calibr_results, d_calibr_qub_idx, setting, calibr_shots)
-                # 4.6 Calibrate the readout results
+                # 4.3 Calibrate the readout results
                 corrected_mean = obs_mean / obs_calibr_mean
                 corrected_var = ratio_variance(obs_mean, obs_var, obs_calibr_mean, obs_calibr_var)
 
@@ -1078,3 +1045,41 @@ def _exhaustive_symmetrization(qc: QuantumComputer, qubits: List[int],
     # Gather together all the symmetrized results
     bitstrings = reduce(lambda x, y: np.vstack((x, y)), list_bitstrings_symm)
     return bitstrings, dict_qub_idx
+
+
+def _calibration_program(qc: QuantumComputer, tomo_experiment: TomographyExperiment,
+                         setting: ExperimentSetting, inherit_readout_error: bool,
+                         inherit_gate_noise: bool) -> Program:
+    """
+    Program required for calibration in a tomography-like experiment.
+
+    :param tomo_experiment: A suite of tomographic observables
+    :param ExperimentSetting: The particular tomographic observable to measure
+    :param inherit_readout_error: Whether the calibration program should inherit any readout error
+        instructions from the main TomographyExperiment's Program
+    :param inherit_gate_noise: Whether the calibration program should inherit any definitions of
+        noisy gates from the main TomographyExperiment's Program
+    :param readout_symmetrize: Method used to symmetrize the readout errors (see docstring for
+        `measure_observables` for more details)
+    :param cablir_shots: number of shots to take in the measurement process
+    :return: Program performing the calibration
+    """
+    # Inherit any noisy attributes from main Program, including gate definitions
+    # and applications which can be handy in creating simulating noisy channels
+    calibr_prog = Program()
+    if inherit_readout_error:
+        # Inherit readout errro instructions from main Program
+        readout_povm_instruction = [i for i in tomo_experiment.program.out().split('\n') if 'PRAGMA READOUT-POVM' in i]
+        calibr_prog += readout_povm_instruction
+    if inherit_gate_noise:
+        # Inherit any definitions of noisy gates from main Program
+        kraus_instructions = [i for i in tomo_experiment.program.out().split('\n') if 'PRAGMA ADD-KRAUS' in i]
+        calibr_prog += kraus_instructions
+    # Prepare the +1 eigenstate for the out operator
+    for q, op in setting.out_operator.operations_as_set():
+        calibr_prog += _one_q_pauli_prep(label=op, index=0, qubit=q)
+    # Measure the out operator in this state
+    for q, op in setting.out_operator.operations_as_set():
+        calibr_prog += _local_pauli_eig_meas(op, q) 
+
+    return calibr_prog

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -924,29 +924,6 @@ def _ops_bool_to_prog(ops_bool: Tuple[bool], qubits: List[int]) -> Program:
     return prog
 
 
-def _stack_dicts(dict1: Dict, dict2: Dict) -> Dict:
-    """
-    Given two dicts representing qubit measurements, keyed by integers (representing qubits)
-    and valued by 1-dimensional numpy arrays (representing measurements), this helper function
-    horizontally stacks the measurement results from the two dicts to produce a single
-    1-dimensional numpy array representing the measurement results in a single dict.
-
-    :param dict1: Dict keyed with integer specifying qubit, valued by 1-dimensional
-        numpy array specifying readout results
-    :param dict2: Dict keyed with integer specifying qubit, valued by 1-dimensional
-        numpy array specifying readout results
-    :return: Dict keyed with integer specifying qubit, valued by 1-dimensional
-        numpy array specifying readout results gathered from both `dict1` and `dict2`
-    """
-    assert set(dict1.keys()) == set(dict2.keys()), "Dictionaries must have same keys"
-    assert set(len(v.shape) for v in dict1.values()) == \
-           set(len(v.shape) for v in dict2.values()), "Arrays in dict values must have same dimension"
-    dict_combined = {}
-    for k, v in dict1.items():
-        dict_combined[k] = np.hstack([v, dict2[k]])
-    return dict_combined
-
-
 def _stats_from_measurements(bs_results: np.ndarray, qubit_index_map: Dict,
                              setting: ExperimentSetting, n_shots: int,
                              coeff: float = 1.0) -> Tuple[float]:

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -865,6 +865,8 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 # 4 Readout calibration
                 # 4.1 Prepare the +1 eigenstate for the out operator
                 calibr_prog = Program()
+                readout_povm_instruction = [i for i in tomo_experiment.program.out().split('\n') if 'PRAGMA READOUT-POVM' in i]
+                calibr_prog += readout_povm_instruction
                 for q, op in setting.out_operator.operations_as_set():
                     calibr_prog += _one_q_pauli_prep(label=op, index=0, qubit=q)
                 # 4.2 Measure the out operator in this state

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -751,8 +751,8 @@ class ExperimentResult:
 def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperiment,
                         n_shots: int = 1000, progress_callback=None, active_reset=False,
                         readout_symmetrize: str = None, calibrate_readout: str = None,
-                        inherit_povm : bool = True, inherit_gate_defn : bool = False,
-                        inherit_defined_gate_app : bool = False, inherit_kraus : bool = False):
+                        inherit_povm: bool = True, inherit_gate_defn: bool = False,
+                        inherit_defined_gate_app: bool = False, inherit_kraus: bool = False):
     """
     Measure all the observables in a TomographyExperiment.
 
@@ -829,9 +829,6 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 # Keep track of qubit-classical register mapping via dict
                 d_qub_idx[q] = i
             total_prog_no_symm.wrap_in_numshots_loop(n_shots)
-            print ("Here's total_prog_no_symm")
-            print (total_prog_no_symm)
-            print ("*" * 30)
             bitstrings = qc.run(total_prog_no_symm)
 
         elif len(qubits) == 0:
@@ -984,7 +981,7 @@ def _stack_dicts(dict1: Dict, dict2: Dict) -> Dict:
     return dict_combined
 
 
-def _stats_from_measurements(bs_results: np.ndarray, qubit_index_map: Dict, 
+def _stats_from_measurements(bs_results: np.ndarray, qubit_index_map: Dict,
                              setting: ExperimentSetting, n_shots: int,
                              coeff: float = 1.0) -> Tuple[float]:
     """

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -848,6 +848,7 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 # 4 Readout calibration
                 # 4.1 Prepare the +1 eigenstate for the out operator
                 calibr_prog = Program()
+                # 4.1.2 Inherit any noisy readout instructions from main Program
                 readout_povm_instruction = [i for i in tomo_experiment.program.out().split('\n') if 'PRAGMA READOUT-POVM' in i]
                 calibr_prog += readout_povm_instruction
                 for q, op in setting.out_operator.operations_as_set():

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -821,7 +821,9 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 # Keep track of qubit-classical register mapping via dict
                 d_qub_idx[q] = i
             total_prog_no_symm.wrap_in_numshots_loop(n_shots)
-            bitstrings = qc.run(total_prog_no_symm)
+            total_prog_no_symm_native = qc.compiler.quil_to_native_quil(total_prog_no_symm)
+            total_prog_no_symm_bin = qc.compiler.native_quil_to_executable(total_prog_no_symm_native)
+            bitstrings = qc.run(total_prog_no_symm_bin)
 
         elif len(qubits) == 0:
             # looks like an identity operation
@@ -1033,7 +1035,9 @@ def _exhaustive_symmetrization(qc: QuantumComputer, qubits: List[int],
             # Keep track of qubit-classical register mapping via dict
             dict_qub_idx[q] = i
         total_prog_symm.wrap_in_numshots_loop(n_shots_symm)
-        bitstrings_symm = qc.run(total_prog_symm)
+        total_prog_symm_native = qc.compiler.quil_to_native_quil(total_prog_symm)
+        total_prog_symm_bin = qc.compiler.native_quil_to_executable(total_prog_symm_native)
+        bitstrings_symm = qc.run(total_prog_symm_bin)
         # Flip the results post-measurement
         bitstrings_symm = bitstrings_symm ^ ops_bool
         # Gather together the symmetrized results into list

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -851,6 +851,12 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 # 4.1.2 Inherit any noisy readout instructions from main Program
                 readout_povm_instruction = [i for i in tomo_experiment.program.out().split('\n') if 'PRAGMA READOUT-POVM' in i]
                 calibr_prog += readout_povm_instruction
+                # 4.1.3 Inherit any gate definitions from main Program
+                defgate_instructions = [gdef for gdef in tomo_experiment.program._defined_gates]
+                calibr_prog += defgate_instructions
+                # 4.1.4 Inherit any Kraus operator instructions from main Program
+                kraus_instructions = [i for i in tomo_experiment.program.out().split('\n') if 'PRAGMA ADD-KRAUS' in i]
+                calibr_prog += kraus_instructions
                 for q, op in setting.out_operator.operations_as_set():
                     calibr_prog += _one_q_pauli_prep(label=op, index=0, qubit=q)
                 # 4.2 Measure the out operator in this state
@@ -996,7 +1002,7 @@ def ratio_variance(a: Union[float, np.ndarray],
 
 
 def _exhaustive_symmetrization(qc: QuantumComputer, qubits: List[int],
-        shots: int, prog: Program) -> Dict:
+                               shots: int, prog: Program) -> Dict:
     """
     Perform exhaustive symmetrization
 

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -851,12 +851,6 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 # 4.1.2 Inherit any noisy readout instructions from main Program
                 readout_povm_instruction = [i for i in tomo_experiment.program.out().split('\n') if 'PRAGMA READOUT-POVM' in i]
                 calibr_prog += readout_povm_instruction
-                # 4.1.3 Inherit any gate definitions from main Program
-                defgate_instructions = [gdef for gdef in tomo_experiment.program._defined_gates]
-                calibr_prog += defgate_instructions
-                # 4.1.4 Inherit any Kraus operator instructions from main Program
-                kraus_instructions = [i for i in tomo_experiment.program.out().split('\n') if 'PRAGMA ADD-KRAUS' in i]
-                calibr_prog += kraus_instructions
                 for q, op in setting.out_operator.operations_as_set():
                     calibr_prog += _one_q_pauli_prep(label=op, index=0, qubit=q)
                 # 4.2 Measure the out operator in this state

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -807,10 +807,10 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
         # 2. Symmetrization
         qubits = max_weight_out_op.get_qubits()
 
-        if readout_symmetrize == 'exhaustive':
+        if readout_symmetrize == 'exhaustive' and len(qubits) > 0:
             bitstrings, d_qub_idx = _exhaustive_symmetrization(qc, qubits, n_shots, total_prog)
 
-        elif readout_symmetrize is None:
+        elif readout_symmetrize is None and len(qubits) > 0:
             total_prog_no_symm = total_prog.copy()
             ro = total_prog_no_symm.declare('ro', 'BIT', len(qubits))
             d_qub_idx = {}
@@ -820,6 +820,10 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 d_qub_idx[q] = i
             total_prog_no_symm.wrap_in_numshots_loop(n_shots)
             bitstrings = qc.run(total_prog_no_symm)
+
+        elif len(qubits) == 0:
+            # looks like an identity operation
+            pass
 
         else:
             raise ValueError("Readout symmetrization method must be either 'exhaustive' or None")

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -19,7 +19,7 @@ from pyquil.operator_estimation import ExperimentSetting, TomographyExperiment, 
     _max_tpb_overlap, _max_weight_operator, _max_weight_state, _max_tpb_overlap, \
     TensorProductState, zeros_state, \
     group_experiments, group_experiments_greedy, ExperimentResult, measure_observables, \
-    _ops_bool_to_prog, _stack_dicts, _stats_from_measurements, \
+    _ops_bool_to_prog, _stats_from_measurements, \
     ratio_variance, _exhaustive_symmetrization, _calibration_program
 from pyquil.paulis import sI, sX, sY, sZ, PauliSum, PauliTerm
 
@@ -540,31 +540,6 @@ def test_ops_bool_to_prog():
     for op_str in ops_strings:
         p = _ops_bool_to_prog(op_str, qubits)
         assert str(p) == d_expected[op_str]
-
-
-def test_stack_dicts():
-    d1 = {0: np.array([0] * 10), 1: np.array([1] * 10)}
-    d2 = {0: np.array([10] * 10), 1: np.array([20] * 10)}
-
-    d12 = _stack_dicts(d1, d2)
-    d12_expected = {0: np.array([0] * 10 + [10] * 10), 1: np.array([1] * 10 + [20] * 10)}
-    assert d12.keys() == d12_expected.keys()
-    for k, v in d12.items():
-        np.testing.assert_allclose(v, d12_expected[k])
-
-
-def test_stack_multiple_dicts():
-    d1 = {0: np.array([0] * 10), 1: np.array([1] * 10)}
-    d2 = {0: np.array([10] * 10), 1: np.array([20] * 10)}
-    d3 = {0: np.array([100] * 10), 1: np.array([200] * 10)}
-    list_dicts = [d1, d2, d3]
-
-    d123 = functools.reduce(lambda d1, d2: _stack_dicts(d1, d2), list_dicts)
-    d123_expected = {0: np.array([0] * 10 + [10] * 10 + [100] * 10),
-                     1: np.array([1] * 10 + [20] * 10 + [200] * 10)}
-    assert d123.keys() == d123_expected.keys()
-    for k, v in d123.items():
-        np.testing.assert_allclose(v, d123_expected[k])
 
 
 def test_stats_from_measurements():

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -793,14 +793,14 @@ def test_exhaustive_symmetrization_2q():
     p7_00, p7_11 = 0.99, 0.77
     p.define_noisy_readout(5, p5_00, p5_11)
     p.define_noisy_readout(7, p7_00, p7_11)
-    
+
     bs_results, d_qub_idx = _exhaustive_symmetrization(qc, qubs, n_shots, p)
 
     assert d_qub_idx == {5: 0, 7: 1}
 
     frac5_0 = np.count_nonzero(bs_results[:, d_qub_idx[5]] == 0) / n_shots
     frac7_0 = np.count_nonzero(bs_results[:, d_qub_idx[7]] == 0) / n_shots
-    
+
     expected_frac5_0 = (p5_00 + p5_11) / 2
     expected_frac7_0 = (p7_00 + p7_11) / 2
 
@@ -840,7 +840,7 @@ def test_process_dfe_bit_flip():
 
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p,
-                                  qubits=[0])
+                                       qubits=[0])
     # list to store experiment results
     num_expts = 100
     expts = []

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -795,41 +795,6 @@ def test_exhaustive_symmetrization_2q(forest):
     assert np.isclose(frac7_0, expected_frac7_0, 2e-2)
 
 
-def test_process_dfe_bit_flip(forest):
-    qc = get_qc('9q-qvm')
-    # prepare experiment settings
-    expt1 = ExperimentSetting(TensorProductState(plusX(0)), sX(0))
-    expt2 = ExperimentSetting(TensorProductState(plusY(0)), sY(0))
-    expt3 = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
-    expt_list = [expt1, expt2, expt3]
-
-    # prepare noisy bit-flip channel as program
-    prob = 0.3
-    # the bit flip channel is composed of two Kraus operations --
-    # applying the X gate with probability `prob`, and applying the identity gate
-    # with probability `1 - prob`
-    kraus_ops = [np.sqrt(1 - prob) * np.array([[1, 0], [0, 1]]), np.sqrt(prob) * np.array([[0, 1], [1, 0]])]
-    p = Program(Pragma("PRESERVE_BLOCK"), I(0), Pragma("END_PRESERVE_BLOCK"))
-    p.define_noisy_gate("I", [0], kraus_ops)
-
-    # prepare TomographyExperiment
-    process_exp = TomographyExperiment(settings=expt_list, program=p,
-                                       qubits=[0])
-    # list to store experiment results
-    num_expts = 100
-    expts = []
-    for _ in range(num_expts):
-        expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
-            expt_results.append(res.expectation)
-        expts.append(expt_results)
-
-    expts = np.array(expts)
-    results = np.mean(expts, axis=0)
-    expected_results = np.array([1.0, 0.4, 0.4])
-    np.testing.assert_allclose(results, expected_results, atol=2e-2)
-
-
 def test_measure_observables_inherit_noise_errors(forest):
     qc = get_qc('3q-qvm')
     # specify simplest experiments
@@ -992,3 +957,164 @@ def test_measure_observables_grouped_expts(forest):
     results = np.mean(results_unavged, axis=0)
     expected_results = np.array([-1 / 3, -1, 1, -1, -1])
     np.testing.assert_allclose(results, expected_results, atol=2e-2)
+
+
+def _point_channel_fidelity_estimate(v, dim=2):
+    """:param v: array of expectation values
+    :param dim: dimensionality of the Hilbert space"""
+    return (1.0 + np.sum(v) + dim) / (dim * (dim + 1))
+
+
+def test_bit_flip_channel_fidelity(forest):
+    """
+    We use Eqn (5) of https://arxiv.org/abs/quant-ph/0701138 to compare the fidelity
+    """
+    qc = get_qc('1q-qvm')
+    # prepare experiment settings
+    expt1 = ExperimentSetting(TensorProductState(plusX(0)), sX(0))
+    expt2 = ExperimentSetting(TensorProductState(plusY(0)), sY(0))
+    expt3 = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
+    expt_list = [expt1, expt2, expt3]
+
+    # prepare noisy bit-flip channel as program for some random value of probability
+    prob = np.random.uniform(0.1, 0.5)
+    # the bit flip channel is composed of two Kraus operations --
+    # applying the X gate with probability `prob`, and applying the identity gate
+    # with probability `1 - prob`
+    kraus_ops = [np.sqrt(1 - prob) * np.array([[1, 0], [0, 1]]), np.sqrt(prob) * np.array([[0, 1], [1, 0]])]
+    p = Program(Pragma("PRESERVE_BLOCK"), I(0), Pragma("END_PRESERVE_BLOCK"))
+    p.define_noisy_gate("I", [0], kraus_ops)
+
+    # prepare TomographyExperiment
+    process_exp = TomographyExperiment(settings=expt_list, program=p,
+                                       qubits=[0])
+    # list to store experiment results
+    num_expts = 100
+    expts = []
+    for _ in range(num_expts):
+        expt_results = []
+        for res in measure_observables(qc, process_exp, n_shots=1000):
+            expt_results.append(res.expectation)
+        expts.append(expt_results)
+
+    expts = np.array(expts)
+    results = np.mean(expts, axis=0)
+    estimated_fidelity = _point_channel_fidelity_estimate(results)
+    # how close is this channel to the identity operator
+    expected_fidelity = 1 - (2 / 3) * prob
+    np.testing.assert_allclose(expected_fidelity, estimated_fidelity, atol=2e-2)
+
+
+def test_dephasing_channel_fidelity(forest):
+    """
+    We use Eqn (5) of https://arxiv.org/abs/quant-ph/0701138 to compare the fidelity
+    """
+    qc = get_qc('1q-qvm')
+    # prepare experiment settings
+    expt1 = ExperimentSetting(TensorProductState(plusX(0)), sX(0))
+    expt2 = ExperimentSetting(TensorProductState(plusY(0)), sY(0))
+    expt3 = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
+    expt_list = [expt1, expt2, expt3]
+
+    # prepare noisy dephasing channel as program for some random value of probability
+    prob = np.random.uniform(0.1, 0.5)
+    # Kraus operators for the dephasing channel
+    kraus_ops = [np.sqrt(1 - prob) * np.array([[1, 0], [0, 1]]),
+                 np.sqrt(prob) * np.array([[1, 0], [0, -1]])]
+    p = Program(Pragma("PRESERVE_BLOCK"), I(0), Pragma("END_PRESERVE_BLOCK"))
+    p.define_noisy_gate("I", [0], kraus_ops)
+
+    # prepare TomographyExperiment
+    process_exp = TomographyExperiment(settings=expt_list, program=p,
+                                       qubits=[0])
+    # list to store experiment results
+    num_expts = 100
+    expts = []
+    for _ in range(num_expts):
+        expt_results = []
+        for res in measure_observables(qc, process_exp, n_shots=1000):
+            expt_results.append(res.expectation)
+        expts.append(expt_results)
+
+    expts = np.array(expts)
+    results = np.mean(expts, axis=0)
+    estimated_fidelity = _point_channel_fidelity_estimate(results)
+    # how close is this channel to the identity operator
+    expected_fidelity = 1 - (2 / 3) * prob
+    np.testing.assert_allclose(expected_fidelity, estimated_fidelity, atol=2e-2)
+
+
+def test_depolarizing_channel_fidelity(forest):
+    """
+    We use Eqn (5) of https://arxiv.org/abs/quant-ph/0701138 to compare the fidelity
+    """
+    qc = get_qc('1q-qvm')
+    # prepare experiment settings
+    expt1 = ExperimentSetting(TensorProductState(plusX(0)), sX(0))
+    expt2 = ExperimentSetting(TensorProductState(plusY(0)), sY(0))
+    expt3 = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
+    expt_list = [expt1, expt2, expt3]
+
+    # prepare noisy depolarizing channel as program for some random value of probability
+    prob = np.random.uniform(0.1, 0.5)
+    # Kraus operators for the depolarizing channel
+    kraus_ops = [np.sqrt(3 * prob + 1) / 2 * np.array([[1, 0], [0, 1]]),
+                 np.sqrt(1 - prob) / 2 * np.array([[0, 1], [1, 0]]),
+                 np.sqrt(1 - prob) / 2 * np.array([[0, -1j], [1j, 0]]),
+                 np.sqrt(1 - prob) / 2 * np.array([[1, 0], [0, -1]])]
+    p = Program(Pragma("PRESERVE_BLOCK"), I(0), Pragma("END_PRESERVE_BLOCK"))
+    p.define_noisy_gate("I", [0], kraus_ops)
+
+    # prepare TomographyExperiment
+    process_exp = TomographyExperiment(settings=expt_list, program=p,
+                                       qubits=[0])
+    # list to store experiment results
+    num_expts = 100
+    expts = []
+    for _ in range(num_expts):
+        expt_results = []
+        for res in measure_observables(qc, process_exp, n_shots=1000):
+            expt_results.append(res.expectation)
+        expts.append(expt_results)
+
+    expts = np.array(expts)
+    results = np.mean(expts, axis=0)
+    estimated_fidelity = _point_channel_fidelity_estimate(results)
+    # how close is this channel to the identity operator
+    expected_fidelity = (1 + prob) / 2
+    np.testing.assert_allclose(expected_fidelity, estimated_fidelity, atol=2e-2)
+
+
+def test_unitary_channel_fidelity(forest):
+    """
+    We use Eqn (5) of https://arxiv.org/abs/quant-ph/0701138 to compare the fidelity
+    """
+    qc = get_qc('1q-qvm')
+    # prepare experiment settings
+    expt1 = ExperimentSetting(TensorProductState(plusX(0)), sX(0))
+    expt2 = ExperimentSetting(TensorProductState(plusY(0)), sY(0))
+    expt3 = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
+    expt_list = [expt1, expt2, expt3]
+
+    # prepare unitary channel as an RY rotation program for some random angle
+    theta = np.random.uniform(0.0, 2 * np.pi)
+    # unitary (RY) channel
+    p = Program(RY(theta, 0))
+    # prepare TomographyExperiment
+    process_exp = TomographyExperiment(settings=expt_list, program=p,
+                                       qubits=[0])
+    # list to store experiment results
+    num_expts = 100
+    expts = []
+    for _ in range(num_expts):
+        expt_results = []
+        for res in measure_observables(qc, process_exp, n_shots=1000):
+            expt_results.append(res.expectation)
+        expts.append(expt_results)
+
+    expts = np.array(expts)
+    results = np.mean(expts, axis=0)
+    estimated_fidelity = _point_channel_fidelity_estimate(results)
+    # how close is this channel to the identity operator
+    expected_fidelity = (1 / 6) * ((2 * np.cos(theta / 2)) ** 2 + 2)
+    np.testing.assert_allclose(expected_fidelity, estimated_fidelity, atol=2e-2)

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -617,8 +617,8 @@ def test_measure_observables_noisy_asymmetric_readout():
     expectations = []
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
-                                           readout_symmetrize='exhaustive',
-                                           calibrate_readout='plus-eig'))
+                                                readout_symmetrize='exhaustive',
+                                                calibrate_readout='plus-eig'))
         expectations.append([res.expectation for res in expt_results])
     expectations = np.array(expectations)
     results = np.mean(expectations, axis=0)
@@ -643,11 +643,11 @@ def test_measure_observables_uncalibrated_estimate_noisy_asymmetric_readout():
     raw_e = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                             tomo_expt,
-                                             n_shots=1000,
-                                             active_reset=True,
-                                             readout_symmetrize='exhaustive',
-                                             calibrate_readout='plus-eig')):
+                                                  tomo_expt,
+                                                  n_shots=1000,
+                                                  active_reset=True,
+                                                  readout_symmetrize='exhaustive',
+                                                  calibrate_readout='plus-eig')):
         raw_e[idx] = res.raw_expectation
 
     assert np.isclose(np.mean(raw_e[::3]), expected_expectation_z_basis, atol=2e-2)
@@ -674,8 +674,8 @@ def test_measure_observables_result_zero_symmetrization_calibration():
     raw_expectations = []
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
-                                           readout_symmetrize='exhaustive',
-                                           calibrate_readout='plus-eig'))
+                                                readout_symmetrize='exhaustive',
+                                                calibrate_readout='plus-eig'))
         expectations.append([res.expectation for res in expt_results])
         raw_expectations.append([res.raw_expectation for res in expt_results])
     expectations = np.array(expectations)
@@ -703,8 +703,8 @@ def test_measure_observables_result_zero_no_noisy_readout():
     expectations = []
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
-                                           readout_symmetrize=None,
-                                           calibrate_readout=None))
+                                                readout_symmetrize=None,
+                                                calibrate_readout=None))
         expectations.append([res.expectation for res in expt_results])
     expectations = np.array(expectations)
     results = np.mean(expectations, axis=0)
@@ -730,8 +730,8 @@ def test_measure_observables_result_zero_no_symm_calibr():
     expected_result = (p00 * 0.5 + (1 - p11) * 0.5) - ((1 - p00) * 0.5 + p11 * 0.5)
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
-                                           readout_symmetrize=None,
-                                           calibrate_readout=None))
+                                                readout_symmetrize=None,
+                                                calibrate_readout=None))
         expectations.append([res.expectation for res in expt_results])
     expectations = np.array(expectations)
     results = np.mean(expectations, axis=0)
@@ -747,18 +747,18 @@ def test_measure_observables_2q_readout_error_one_measured():
     p = Program()
     p.define_noisy_readout(0, 0.999, 0.85)
     p.define_noisy_readout(1, 0.999, 0.75)
-    tomo_experiment = TomographyExperiment(settings=[expt]*runs, program=p, qubits=[qubs[0],qubs[1]])
+    tomo_experiment = TomographyExperiment(settings=[expt] * runs, program=p, qubits=[qubs[0], qubs[1]])
 
     raw_e = np.zeros(runs)
     obs_e = np.zeros(runs)
     cal_e = np.zeros(runs)
 
     for idx, res in enumerate(measure_observables(qc,
-                                             tomo_experiment,
-                                             n_shots=1000,
-                                             active_reset=True,
-                                             readout_symmetrize='exhaustive',
-                                             calibrate_readout='plus-eig')):
+                                                  tomo_experiment,
+                                                  n_shots=1000,
+                                                  active_reset=True,
+                                                  readout_symmetrize='exhaustive',
+                                                  calibrate_readout='plus-eig')):
         raw_e[idx] = res.raw_expectation
         obs_e[idx] = res.expectation
         cal_e[idx] = res.calibration_expectation

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -786,6 +786,6 @@ def test_measure_observables_2q_readout_error_one_measured():
         obs_e[idx] = res.expectation
         cal_e[idx] = res.calibration_expectation
 
-    assert np.isclose(np.mean(raw_e), 0.84, atol=2e-2)
+    assert np.isclose(np.mean(raw_e), 0.849, atol=2e-2)
     assert np.isclose(np.mean(obs_e), 1.0, atol=2e-2)
-    assert np.isclose(np.mean(cal_e), 0.84, atol=2e-2)
+    assert np.isclose(np.mean(cal_e), 0.849, atol=2e-2)

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -1339,3 +1339,109 @@ def test_2q_unitary_channel_fidelity_readout_error(forest):
     # how close is this channel to the identity operator
     expected_fidelity = (1 / 5) * ((2 * np.cos(theta1 / 2) * np.cos(theta2 / 2)) ** 2 + 1)
     np.testing.assert_allclose(expected_fidelity, estimated_fidelity, atol=2e-2)
+
+
+def test_measure_1q_observable_raw_expectation(forest):
+    # testing that we get correct raw expectation in terms of readout errors
+    qc = get_qc('1q-qvm')
+    expt = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
+    p = Program()
+    p00, p11 = 0.99, 0.80
+    p.define_noisy_readout(0, p00=p00, p11=p11)
+    qubs = [0]
+    tomo_expt = TomographyExperiment(settings=[expt], program=p, qubits=qubs)
+
+    num_simulations = 100
+
+    raw_expectations = []
+    for _ in range(num_simulations):
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
+        raw_expectations.append([res.raw_expectation for res in expt_results])
+    raw_expectations = np.array(raw_expectations)
+    result = np.mean(raw_expectations, axis=0)
+
+    # calculate expected raw_expectation
+    eps_not = (p00 + p11) / 2
+    eps = 1 - eps_not
+    expected_result = 1 - 2 * eps
+    np.testing.assert_allclose(result, expected_result, atol=2e-2)
+
+
+def test_measure_1q_observable_raw_variance(forest):
+    # testing that we get correct raw stddev in terms of readout errors
+    qc = get_qc('1q-qvm')
+    expt = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
+    p = Program()
+    p00, p11 = 0.99, 0.80
+    p.define_noisy_readout(0, p00=p00, p11=p11)
+    qubs = [0]
+    tomo_expt = TomographyExperiment(settings=[expt], program=p, qubits=qubs)
+
+    num_simulations = 100
+    num_shots = 1000
+
+    raw_stddevs = []
+    for _ in range(num_simulations):
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
+        raw_stddevs.append([res.raw_stddev for res in expt_results])
+    raw_stddevs = np.array(raw_stddevs)
+    result = np.mean(raw_stddevs, axis=0)
+
+    # calculate expected raw_expectation
+    eps_not = (p00 + p11) / 2
+    eps = 1 - eps_not
+    expected_result = np.sqrt((1 - (1 - 2 * eps) ** 2) / num_shots)
+    np.testing.assert_allclose(result, expected_result, atol=2e-2)
+
+
+def test_measure_1q_observable_calibration_expectation(forest):
+    # testing that we get correct calibration expectation in terms of readout errors
+    qc = get_qc('1q-qvm')
+    expt = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
+    p = Program()
+    p00, p11 = 0.93, 0.77
+    p.define_noisy_readout(0, p00=p00, p11=p11)
+    qubs = [0]
+    tomo_expt = TomographyExperiment(settings=[expt], program=p, qubits=qubs)
+
+    num_simulations = 100
+
+    calibration_expectations = []
+    for _ in range(num_simulations):
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
+        calibration_expectations.append([res.calibration_expectation for res in expt_results])
+    calibration_expectations = np.array(calibration_expectations)
+    result = np.mean(calibration_expectations, axis=0)
+
+    # calculate expected raw_expectation
+    eps_not = (p00 + p11) / 2
+    eps = 1 - eps_not
+    expected_result = 1 - 2 * eps
+    np.testing.assert_allclose(result, expected_result, atol=2e-2)
+
+
+def test_measure_1q_observable_calibration_variance(forest):
+    # testing that we get correct calibration stddev in terms of readout errors
+    qc = get_qc('1q-qvm')
+    expt = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
+    p = Program()
+    p00, p11 = 0.93, 0.77
+    p.define_noisy_readout(0, p00=p00, p11=p11)
+    qubs = [0]
+    tomo_expt = TomographyExperiment(settings=[expt], program=p, qubits=qubs)
+
+    num_simulations = 100
+    num_shots = 1000
+
+    raw_stddevs = []
+    for _ in range(num_simulations):
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
+        raw_stddevs.append([res.raw_stddev for res in expt_results])
+    raw_stddevs = np.array(raw_stddevs)
+    result = np.mean(raw_stddevs, axis=0)
+
+    # calculate expected raw_expectation
+    eps_not = (p00 + p11) / 2
+    eps = 1 - eps_not
+    expected_result = np.sqrt((1 - (1 - 2 * eps) ** 2) / num_shots)
+    np.testing.assert_allclose(result, expected_result, atol=2e-2)

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -1613,7 +1613,7 @@ def test_measure_2q_observable_raw_statistics(forest):
 
 def test_raw_statistics_2q_nontrivial_nonentangled_state(forest):
     # testing that we get correct exhaustively symmetrized statistics
-    # in terms of readout errors, even for non-trivial 2q entangled states
+    # in terms of readout errors, even for non-trivial 2q nonentangled states
     # Note: this only tests for exhaustive symmetrization in the presence
     #       of uncorrelated errors
     qc = get_qc('2q-qvm')
@@ -1672,6 +1672,63 @@ def test_raw_statistics_2q_nontrivial_nonentangled_state(forest):
     pr01 = p0100 * alph00 + p0101 * alph01 + p0110 * alph10 + p0111 * alph11
     pr10 = p1000 * alph00 + p1001 * alph01 + p1010 * alph10 + p1011 * alph11
     pr11 = p1100 * alph00 + p1101 * alph01 + p1110 * alph10 + p1111 * alph11
+    # calculate Z^{\otimes 2} expectation, and error of the mean
+    z_expectation = (pr00 + pr11) - (pr01 + pr10)
+    simulated_stddev = np.sqrt((1 - z_expectation ** 2) / num_shots)
+    # compare against simulated results
+    np.testing.assert_allclose(result_expectation, z_expectation, atol=2e-2)
+    np.testing.assert_allclose(result_stddev, simulated_stddev, atol=2e-2)
+
+
+def test_raw_statistics_2q_nontrivial_entangled_state(forest):
+    # testing that we get correct exhaustively symmetrized statistics
+    # in terms of readout errors, even for non-trivial 2q entangled states
+    # Note: this only tests for exhaustive symmetrization in the presence
+    #       of uncorrelated errors
+    qc = get_qc('2q-qvm')
+    expt = ExperimentSetting(TensorProductState(), sZ(0) * sZ(1))
+    theta = np.random.uniform(0.0, 2 * np.pi)
+    p = Program(RX(theta, 0), CNOT(0, 1))
+    p00, p11, q00, q11 = np.random.uniform(0.70, 0.99, size=4)
+    p.define_noisy_readout(0, p00=p00, p11=p11)
+    p.define_noisy_readout(1, p00=q00, p11=q11)
+    qubs = [0, 1]
+    tomo_expt = TomographyExperiment(settings=[expt], program=p, qubits=qubs)
+
+    num_simulations = 100
+    num_shots = 1000
+
+    raw_expectations = []
+    raw_stddevs = []
+
+    for _ in range(num_simulations):
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
+        raw_expectations.append([res.raw_expectation for res in expt_results])
+        raw_stddevs.append([res.raw_stddev for res in expt_results])
+    raw_expectations = np.array(raw_expectations)
+    raw_stddevs = np.array(raw_stddevs)
+    result_expectation = np.mean(raw_expectations, axis=0)
+    result_stddev = np.mean(raw_stddevs, axis=0)
+
+    # calculate relevant conditional probabilities, given |00> state
+    # notation used: pijmn means p(ij|mn)
+    p0000 = (p00 + p11) * (q00 + q11) / 4
+    p0100 = (p00 + p11) * (2 - q00 - q11) / 4
+    p1000 = (q00 + q11) * (2 - p00 - p11) / 4
+    p1100 = (2 - p00 - p11) * (2 - q00 - q11) / 4
+    # calculate relevant conditional probabilities, given |11> state
+    p0011 = p1100
+    p0111 = (2 - p00 - p11) * (q00 + q11) / 4
+    p1011 = (p00 + p11) * (2 - q00 - q11) / 4
+    p1111 = p0000
+    # calculate amplitudes squared of pure state
+    alph00 = (np.cos(theta / 2)) ** 2
+    alph11 = (np.sin(theta / 2)) ** 2
+    # calculate probabilities of various bitstrings
+    pr00 = p0000 * alph00 + p0011 * alph11
+    pr01 = p0100 * alph00 + p0111 * alph11
+    pr10 = p1000 * alph00 + p1011 * alph11
+    pr11 = p1100 * alph00 + p1111 * alph11
     # calculate Z^{\otimes 2} expectation, and error of the mean
     z_expectation = (pr00 + pr11) - (pr01 + pr10)
     simulated_stddev = np.sqrt((1 - z_expectation ** 2) / num_shots)

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -601,7 +601,7 @@ def test_ratio_variance_array():
     np.testing.assert_allclose(ab_ratio_var, np.array([0.028125, 0.0028125, 0.00028125]))
 
 
-def test_measure_observables_noisy_asymmetric_readout():
+def test_measure_observables_noisy_asymmetric_readout_plus_one():
     qc = get_qc('9q-qvm')
     expt1 = ExperimentSetting(TensorProductState(plusX(0)), sX(0))
     expt2 = ExperimentSetting(TensorProductState(plusY(0)), sY(0))
@@ -614,4 +614,20 @@ def test_measure_observables_noisy_asymmetric_readout():
     for res in measure_observables(qc, tomo_expt, n_shots=1000,
                                    readout_symmetrize='exhaustive',
                                    calibrate_readout='plus-eig'):
-        print (np.isclose(1.0, res.expectation, atol=5.e-2))
+        assert (np.isclose(1.0, res.expectation, atol=1.e-1))
+
+
+def test_measure_observables_noisy_asymmetric_readout_minus_one():
+    qc = get_qc('9q-qvm')
+    expt1 = ExperimentSetting(TensorProductState(minusX(0)), sX(0))
+    expt2 = ExperimentSetting(TensorProductState(minusY(0)), sY(0))
+    expt3 = ExperimentSetting(TensorProductState(minusZ(0)), sZ(0))
+    p = Program()
+    p.define_noisy_readout(0, p00=0.99, p11=0.80)
+    qubs = [0]
+    tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=p, qubits=qubs)
+
+    for res in measure_observables(qc, tomo_expt, n_shots=1000,
+                                   readout_symmetrize='exhaustive',
+                                   calibrate_readout='plus-eig'):
+        assert (np.isclose(-1.0, res.expectation, atol=1.e-1))

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -1283,7 +1283,7 @@ def test_unitary_channel_fidelity_readout_error(forest):
     np.testing.assert_allclose(expected_fidelity, estimated_fidelity, atol=2e-2)
 
 
-def test_2q_unitary_channel_fidelity_readout_error(qvm, benchmarker):
+def test_2q_unitary_channel_fidelity_readout_error(forest):
     """
     We use Eqn (5) of https://arxiv.org/abs/quant-ph/0701138 to compare the fidelity
     This tests if our dimensionality factors are correct, even in the presence
@@ -1320,9 +1320,10 @@ def test_2q_unitary_channel_fidelity_readout_error(qvm, benchmarker):
     p = Program(RY(theta1, 0), RY(theta2, 1))
     # add some readout error
     p.define_noisy_readout(0, 0.95, 0.82)
+    p.define_noisy_readout(1, 0.99, 0.73)
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p,
-                                       qubits=[0])
+                                       qubits=[0, 1])
     # list to store experiment results
     num_expts = 100
     expts = []

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -916,6 +916,52 @@ def test_expectations_sic1(forest):
     np.testing.assert_allclose(results, expected_results, atol=2e-2)
 
 
+def test_expectations_sic2(forest):
+    qc = get_qc('1q-qvm')
+    expt1 = ExperimentSetting(SIC2(0), sX(0))
+    expt2 = ExperimentSetting(SIC2(0), sY(0))
+    expt3 = ExperimentSetting(SIC2(0), sZ(0))
+    tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=Program(), qubits=[0])
+
+    num_simulations = 100
+    results_unavged = []
+    for _ in range(num_simulations):
+        measured_results = []
+        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+            measured_results.append(res.expectation)
+        results_unavged.append(measured_results)
+
+    results_unavged = np.array(results_unavged)
+    results = np.mean(results_unavged, axis=0)
+    expected_results = np.array([(2 * np.sqrt(2) / 3) * np.cos(2 * np.pi / 3),
+                                 -(2 * np.sqrt(2) / 3) * np.sin(2 * np.pi / 3),
+                                 -1 / 3])
+    np.testing.assert_allclose(results, expected_results, atol=2e-2)
+
+
+def test_expectations_sic3(forest):
+    qc = get_qc('1q-qvm')
+    expt1 = ExperimentSetting(SIC3(0), sX(0))
+    expt2 = ExperimentSetting(SIC3(0), sY(0))
+    expt3 = ExperimentSetting(SIC3(0), sZ(0))
+    tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=Program(), qubits=[0])
+
+    num_simulations = 100
+    results_unavged = []
+    for _ in range(num_simulations):
+        measured_results = []
+        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+            measured_results.append(res.expectation)
+        results_unavged.append(measured_results)
+
+    results_unavged = np.array(results_unavged)
+    results = np.mean(results_unavged, axis=0)
+    expected_results = np.array([(2 * np.sqrt(2) / 3) * np.cos(2 * np.pi / 3),
+                                 (2 * np.sqrt(2) / 3) * np.sin(2 * np.pi / 3),
+                                 -1 / 3])
+    np.testing.assert_allclose(results, expected_results, atol=2e-2)
+
+
 def test_measure_observables_grouped_expts(forest):
     qc = get_qc('3q-qvm')
     # this more explicitly uses the list-of-lists-of-ExperimentSettings in TomographyExperiment

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -761,7 +761,8 @@ def test_measure_observables_result_zero_no_symm_calibr():
     np.testing.assert_allclose(results, expected_result, atol=2e-2)
 
 
-def test_measure_observables_2q_readout_error():
+def test_measure_observables_2q_readout_error_one_measured():
+    # 2q readout errors, but only 1 qubit measured
     qc = get_qc('9q-qvm')
     qubs = [0, 1]
     runs = 50

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -818,6 +818,9 @@ def test_process_dfe_bit_flip(forest):
 
     # prepare noisy bit-flip channel as program
     prob = 0.3
+    # the bit flip channel is composed of two Kraus operations --
+    # applying the X gate with probability `prob`, and applying the identity gate
+    # with probability `1 - prob`
     kraus_ops = [np.sqrt(1 - prob) * np.array([[1, 0], [0, 1]]), np.sqrt(prob) * np.array([[0, 1], [1, 0]])]
     p = Program(I(0))
     p.define_noisy_gate("I", [0], kraus_ops)

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -599,3 +599,19 @@ def test_ratio_variance_array():
     var_b = np.array([0.05, 0.5, 5.0])
     ab_ratio_var = ratio_variance(a, var_a, b, var_b)
     np.testing.assert_allclose(ab_ratio_var, np.array([0.028125, 0.0028125, 0.00028125]))
+
+
+def test_measure_observables_noisy_asymmetric_readout():
+    qc = get_qc('9q-qvm')
+    expt1 = ExperimentSetting(TensorProductState(plusX(0)), sX(0))
+    expt2 = ExperimentSetting(TensorProductState(plusY(0)), sY(0))
+    expt3 = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
+    p = Program()
+    p.define_noisy_readout(0, p00=0.99, p11=0.80)
+    qubs = [0]
+    tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=p, qubits=qubs)
+
+    for res in measure_observables(qc, tomo_expt, n_shots=1000,
+                                   readout_symmetrize='exhaustive',
+                                   calibrate_readout='plus-eig'):
+        print (np.isclose(1.0, res.expectation, atol=5.e-2))

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -808,20 +808,6 @@ def test_exhaustive_symmetrization_2q(forest):
     assert np.isclose(frac7_0, expected_frac7_0, 2e-2)
 
 
-def _random_unitary(n):
-    """
-    :return: array of shape (N, N) representing random unitary matrix drawn from Haar measure
-    """
-    # draw complex matrix from Ginibre ensemble
-    z = np.random.randn(n, n) + 1j * np.random.randn(n, n)
-    # QR decompose this complex matrix
-    q, r = np.linalg.qr(z)
-    # make this decomposition unique
-    d = np.diagonal(r)
-    l = np.diag(d) / np.abs(d)
-    return np.matmul(q, l)
-
-
 def test_process_dfe_bit_flip(forest):
     qc = get_qc('9q-qvm')
     # prepare experiment settings
@@ -833,10 +819,8 @@ def test_process_dfe_bit_flip(forest):
     # prepare noisy channel as program
     prob = 0.3
     kraus_ops = [np.sqrt(1 - prob) * np.array([[1, 0], [0, 1]]), np.sqrt(prob) * np.array([[0, 1], [1, 0]])]
-    p = Program()
-    p.defgate("DummyGate", _random_unitary(2))
-    p.inst(("DummyGate", 0))
-    p.define_noisy_gate("DummyGate", [0], kraus_ops)
+    p = Program(I(0))
+    p.define_noisy_gate("I", [0], kraus_ops)
 
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p,

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -528,7 +528,7 @@ def test_measure_observables_no_symm_calibr_raises_error(forest):
                                  program=Program(I(0)), qubits=[0])
     with pytest.raises(ValueError):
         result = list(measure_observables(qc, suite, readout_symmetrize=None,
-            calibrate_readout='plus-eig'))
+                                          calibrate_readout='plus-eig'))
 
 
 def test_ops_bool_to_prog():
@@ -839,11 +839,11 @@ def test_measure_observables_inherit_noise_errors(forest):
     # specify a Program with multiple sources of noise
     p = Program(X(0), Y(1), H(2))
     # defining several bit-flip channels
-    kraus_ops_X = [np.sqrt(1-0.3) * np.array([[1, 0],[0,1]]),
+    kraus_ops_X = [np.sqrt(1 - 0.3) * np.array([[1, 0], [0, 1]]),
                    np.sqrt(0.3) * np.array([[0, 1], [1, 0]])]
-    kraus_ops_Y = [np.sqrt(1-0.2) * np.array([[1, 0],[0,1]]),
+    kraus_ops_Y = [np.sqrt(1 - 0.2) * np.array([[1, 0], [0, 1]]),
                    np.sqrt(0.2) * np.array([[0, 1], [1, 0]])]
-    kraus_ops_H = [np.sqrt(1-0.1) * np.array([[1, 0],[0,1]]),
+    kraus_ops_H = [np.sqrt(1 - 0.1) * np.array([[1, 0], [0, 1]]),
                    np.sqrt(0.1) * np.array([[0, 1], [1, 0]])]
     # replacing all the gates with bit-flip channels
     p.define_noisy_gate("X", [0], kraus_ops_X)
@@ -912,7 +912,7 @@ def test_expectations_sic1(forest):
 
     results_unavged = np.array(results_unavged)
     results = np.mean(results_unavged, axis=0)
-    expected_results = np.array([2 * np.sqrt(2)/3, 0, -1/3])
+    expected_results = np.array([2 * np.sqrt(2) / 3, 0, -1 / 3])
     np.testing.assert_allclose(results, expected_results, atol=2e-2)
 
 
@@ -944,5 +944,5 @@ def test_measure_observables_grouped_expts(forest):
 
     results_unavged = np.array(results_unavged)
     results = np.mean(results_unavged, axis=0)
-    expected_results = np.array([-1/3, -1, 1, -1, -1])
+    expected_results = np.array([-1 / 3, -1, 1, -1, -1])
     np.testing.assert_allclose(results, expected_results, atol=2e-2)

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -816,7 +816,7 @@ def test_process_dfe_bit_flip(forest):
     expt3 = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
     expt_list = [expt1, expt2, expt3]
 
-    # prepare noisy channel as program
+    # prepare noisy bit-flip channel as program
     prob = 0.3
     kraus_ops = [np.sqrt(1 - prob) * np.array([[1, 0], [0, 1]]), np.sqrt(prob) * np.array([[0, 1], [1, 0]])]
     p = Program(I(0))

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -1760,7 +1760,6 @@ def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
     #       of uncorrelated errors
     qc = get_qc('2q-qvm')
     expt = ExperimentSetting(TensorProductState(), sZ(0) * sZ(1))
-    np.random.seed(0)
     theta1, theta2 = np.random.uniform(0.0, 2 * np.pi, size=2)
     p = Program(RX(theta1, 0), RX(theta2, 1))
     p00, p11, q00, q11 = np.random.uniform(0.70, 0.99, size=4)
@@ -1790,11 +1789,11 @@ def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
     alph10 = (np.sin(theta1 / 2) * np.cos(theta2 / 2)) ** 2
     alph11 = (np.sin(theta1 / 2) * np.sin(theta2 / 2)) ** 2
     # calculate Z^{\otimes 2} expectation, and error of the mean
-    z_expectation = (alph00 + alph11) - (alph01 + alph10)
-    simulated_stddev = np.sqrt((1 - z_expectation ** 2) / num_shots)
+    expected_expectation = (alph00 + alph11) - (alph01 + alph10)
+    expected_stddev = np.sqrt(np.var(expectations))
     # compare against simulated results
-    np.testing.assert_allclose(result_expectation, z_expectation, atol=2e-2)
-    np.testing.assert_allclose(result_stddev, simulated_stddev, atol=2e-2)
+    np.testing.assert_allclose(result_expectation, expected_expectation, atol=2e-2)
+    np.testing.assert_allclose(result_stddev, expected_stddev, atol=2e-2)
 
 
 def _point_state_fidelity_estimate(v, dim=2):

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -602,7 +602,7 @@ def test_ratio_variance_array():
     np.testing.assert_allclose(ab_ratio_var, np.array([0.028125, 0.0028125, 0.00028125]))
 
 
-def test_measure_observables_noisy_asymmetric_readout():
+def test_measure_observables_noisy_asymmetric_readout(forest):
     # expecting the result +1 for calibrated readout
     qc = get_qc('9q-qvm')
     expt1 = ExperimentSetting(TensorProductState(plusX(0)), sX(0))
@@ -626,7 +626,7 @@ def test_measure_observables_noisy_asymmetric_readout():
     np.testing.assert_allclose(results, 1.0, atol=2e-2)
 
 
-def test_measure_observables_uncalibrated_estimate_noisy_asymmetric_readout():
+def test_measure_observables_uncalibrated_estimate_noisy_asymmetric_readout(forest):
     qc = get_qc('9q-qvm')
     expt1 = ExperimentSetting(TensorProductState(plusX(0)), sX(0))
     expt2 = ExperimentSetting(TensorProductState(plusY(0)), sY(0))
@@ -656,7 +656,7 @@ def test_measure_observables_uncalibrated_estimate_noisy_asymmetric_readout():
     assert np.isclose(np.mean(raw_e[2::3]), expected_expectation_z_basis, atol=2e-2)
 
 
-def test_measure_observables_result_zero_symmetrization_calibration():
+def test_measure_observables_result_zero_symmetrization_calibration(forest):
     # expecting expectation value to be 0 with symmetrization/calibration
     qc = get_qc('9q-qvm')
     expt1 = ExperimentSetting(TensorProductState(plusX(0)), sZ(0))
@@ -687,7 +687,7 @@ def test_measure_observables_result_zero_symmetrization_calibration():
     np.testing.assert_allclose(raw_results, 0.0, atol=2e-2)
 
 
-def test_measure_observables_result_zero_no_noisy_readout():
+def test_measure_observables_result_zero_no_noisy_readout(forest):
     # expecting expectation value to be 0 with symmetrization/calibration
     # and no noisy readout
     qc = get_qc('9q-qvm')
@@ -712,7 +712,7 @@ def test_measure_observables_result_zero_no_noisy_readout():
     np.testing.assert_allclose(results, 0.0, atol=2e-2)
 
 
-def test_measure_observables_result_zero_no_symm_calibr():
+def test_measure_observables_result_zero_no_symm_calibr(forest):
     # expecting expectation value to be nonzero with symmetrization/calibration
     qc = get_qc('9q-qvm')
     expt1 = ExperimentSetting(TensorProductState(plusX(0)), sZ(0))
@@ -739,7 +739,7 @@ def test_measure_observables_result_zero_no_symm_calibr():
     np.testing.assert_allclose(results, expected_result, atol=2e-2)
 
 
-def test_measure_observables_2q_readout_error_one_measured():
+def test_measure_observables_2q_readout_error_one_measured(forest):
     # 2q readout errors, but only 1 qubit measured
     qc = get_qc('9q-qvm')
     qubs = [0, 1]
@@ -769,7 +769,7 @@ def test_measure_observables_2q_readout_error_one_measured():
     assert np.isclose(np.mean(cal_e), 0.849, atol=2e-2)
 
 
-def test_exhaustive_symmetrization_1q():
+def test_exhaustive_symmetrization_1q(forest):
     qc = get_qc('9q-qvm')
     qubs = [5]
     n_shots = 10000
@@ -784,7 +784,7 @@ def test_exhaustive_symmetrization_1q():
     assert np.isclose(frac0, expected_frac0, 2e-2)
 
 
-def test_exhaustive_symmetrization_2q():
+def test_exhaustive_symmetrization_2q(forest):
     qc = get_qc('9q-qvm')
     qubs = [5, 7]
     n_shots = 10000
@@ -822,7 +822,7 @@ def _random_unitary(n):
     return np.matmul(q, l)
 
 
-def test_process_dfe_bit_flip():
+def test_process_dfe_bit_flip(forest):
     qc = get_qc('9q-qvm')
     # prepare experiment settings
     expt1 = ExperimentSetting(TensorProductState(plusX(0)), sX(0))

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -871,9 +871,9 @@ def test_measure_observables_inherit_noise_errors(forest):
 
     tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=p, qubits=[0, 1, 2])
 
-    calibr_prog1 = _calibration_program(qc, tomo_expt, expt1, inherit_readout_error=True, inherit_gate_noise=True)
-    calibr_prog2 = _calibration_program(qc, tomo_expt, expt1, inherit_readout_error=True, inherit_gate_noise=True)
-    calibr_prog3 = _calibration_program(qc, tomo_expt, expt1, inherit_readout_error=True, inherit_gate_noise=True)
+    calibr_prog1 = _calibration_program(qc, tomo_expt, expt1)
+    calibr_prog2 = _calibration_program(qc, tomo_expt, expt2)
+    calibr_prog3 = _calibration_program(qc, tomo_expt, expt3)
     expected_prog = '''PRAGMA READOUT-POVM 0 "(0.99 0.19999999999999996 0.010000000000000009 0.8)"
 PRAGMA READOUT-POVM 1 "(0.95 0.15000000000000002 0.050000000000000044 0.85)"
 PRAGMA READOUT-POVM 2 "(0.97 0.21999999999999997 0.030000000000000027 0.78)"

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -1737,6 +1737,51 @@ def test_raw_statistics_2q_nontrivial_entangled_state(forest):
     np.testing.assert_allclose(result_stddev, simulated_stddev, atol=2e-2)
 
 
+def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
+    # testing that we can successfully correct for observed statistics
+    # in the presence of readout errors, even for 2q nontrivial but
+    # nonentangled states
+    # Note: this only tests for exhaustive symmetrization in the presence
+    #       of uncorrelated errors
+    qc = get_qc('2q-qvm')
+    expt = ExperimentSetting(TensorProductState(), sZ(0) * sZ(1))
+    np.random.seed(0)
+    theta1, theta2 = np.random.uniform(0.0, 2 * np.pi, size=2)
+    p = Program(RX(theta1, 0), RX(theta2, 1))
+    p00, p11, q00, q11 = np.random.uniform(0.70, 0.99, size=4)
+    p.define_noisy_readout(0, p00=p00, p11=p11)
+    p.define_noisy_readout(1, p00=q00, p11=q11)
+    qubs = [0, 1]
+    tomo_expt = TomographyExperiment(settings=[expt], program=p, qubits=qubs)
+
+    num_simulations = 100
+    num_shots = 10000
+
+    expectations = []
+    stddevs = []
+
+    for _ in range(num_simulations):
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
+        expectations.append([res.expectation for res in expt_results])
+        stddevs.append([res.stddev for res in expt_results])
+    expectations = np.array(expectations)
+    stddevs = np.array(stddevs)
+    result_expectation = np.mean(expectations, axis=0)
+    result_stddev = np.mean(stddevs, axis=0)
+
+    # calculate amplitudes squared of pure state
+    alph00 = (np.cos(theta1 / 2) * np.cos(theta2 / 2)) ** 2
+    alph01 = (np.cos(theta1 / 2) * np.sin(theta2 / 2)) ** 2
+    alph10 = (np.sin(theta1 / 2) * np.cos(theta2 / 2)) ** 2
+    alph11 = (np.sin(theta1 / 2) * np.sin(theta2 / 2)) ** 2
+    # calculate Z^{\otimes 2} expectation, and error of the mean
+    z_expectation = (alph00 + alph11) - (alph01 + alph10)
+    simulated_stddev = np.sqrt((1 - z_expectation ** 2) / num_shots)
+    # compare against simulated results
+    np.testing.assert_allclose(result_expectation, z_expectation, atol=2e-2)
+    np.testing.assert_allclose(result_stddev, simulated_stddev, atol=2e-2)
+
+
 def _point_state_fidelity_estimate(v, dim=2):
     """:param v: array of expectation values
     :param dim: dimensionality of the Hilbert space"""

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -1599,3 +1599,42 @@ def test_measure_2q_observable_raw_expectation(forest):
     expected_result = (p0000 + p1100) - (p0100 + p1000)
     # compare against simulated result
     np.testing.assert_allclose(result, expected_result, atol=2e-2)
+
+
+def test_measure_2q_observable_raw_variance(forest):
+    # testing that we get correct exhaustively symmetrized variance
+    # in terms of readout errors
+    # Note: this only tests for exhaustive symmetrization in the presence
+    #       of uncorrelated errors
+    qc = get_qc('2q-qvm')
+    expt = ExperimentSetting(TensorProductState(), sZ(0) * sZ(1))
+    p = Program()
+    p00, p11 = 0.99, 0.80
+    q00, q11 = 0.93, 0.76
+    p.define_noisy_readout(0, p00=p00, p11=p11)
+    p.define_noisy_readout(1, p00=q00, p11=q11)
+    qubs = [0, 1]
+    tomo_expt = TomographyExperiment(settings=[expt], program=p, qubits=qubs)
+
+    num_simulations = 100
+    num_shots = 1000
+
+    raw_stddevs = []
+    for _ in range(num_simulations):
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
+        raw_stddevs.append([res.raw_stddev for res in expt_results])
+    raw_stddevs = np.array(raw_stddevs)
+    result = np.mean(raw_stddevs, axis=0)
+
+    # calculate relevant conditional probabilities, given |00> state
+    # notation used: pijmn means p(ij|mn)
+    p0000 = (p00 + p11) * (q00 + q11) / 4
+    p0100 = (p00 + p11) * (2 - q00 - q11) / 4
+    p1000 = (q00 + q11) * (2 - p00 - p11) / 4
+    p1100 = (2 - p00 - p11) * (2 - q00 - q11) / 4
+    # calculate expectation value of Z^{\otimes 2}
+    z_expectation = (p0000 + p1100) - (p0100 + p1000)
+    # calculate standard deviation of the mean
+    expected_result = np.sqrt((1 - z_expectation ** 2) / num_shots)
+    # compare against simulated result
+    np.testing.assert_allclose(result, expected_result, atol=2e-2)


### PR DESCRIPTION
Addresses #825 and (partly) #826 . This fixes a few issues:

- The calibration program should be aware of the readout error model introduced in TomographyExperiment's Program
- The calibration program should be symmetrized as well
- Using `run` instead of `run_and_measure` (see https://github.com/rigetti/pyquil/issues/830)

Additionally, this also makes the calibration program inherit noisy gate definitions from the main TomographyExperiment's program.

Note however that the calibration program is wholly composed of parametric gates, for which we cannot currently define noisy gates (see [#832](https://github.com/rigetti/pyquil/issues/832)), so the calibration won't actually be sensitive to anything but the readout errors for now. Nevertheless, for forward compatibility, we introduce the noisy inheritance now.