### PR TITLE
Making `apply_clifford_to_pauli` work with identity input

### DIFF
--- a/pyquil/api/_benchmark.py
+++ b/pyquil/api/_benchmark.py
@@ -22,7 +22,7 @@ from pyquil.api._base_connection import get_session, post_json
 from pyquil.api._config import PyquilConfig
 from pyquil.api._error_reporting import _record_call
 from pyquil.api._qac import AbstractBenchmarker
-from pyquil.paulis import PauliTerm
+from pyquil.paulis import PauliTerm, is_identity
 from pyquil.quil import address_qubits, Program
 
 
@@ -54,6 +54,9 @@ class BenchmarkConnection(AbstractBenchmarker):
         :param PauliTerm pauli_in: A PauliTerm to be acted on by clifford via conjugation.
         :return: A PauliTerm corresponding to pauli_in * clifford * pauli_in^{\dagger}
         """
+        # do nothing if `pauli_in` is the identity
+        if is_identity(pauli_in):
+            return pauli_in
 
         indices_and_terms = list(zip(*list(pauli_in.operations_as_set())))
 

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -375,3 +375,8 @@ def test_local_conjugate_request(benchmarker):
         response = cxn.apply_clifford_to_pauli(Program("H 0"), PauliTerm("X", 0, 1.0))
         assert isinstance(response, PauliTerm)
         assert str(response) == "(1+0j)*Z0"
+
+
+def test_apply_clifford_to_pauli(benchmarker, mock_rb_cxn):
+    response = mock_rb_cxn.apply_clifford_to_pauli(Program("H 0"), PauliTerm("I", 0, 0.34))
+    assert response == PauliTerm("I", 0, 0.34)


### PR DESCRIPTION
Returning identity if `pauli_in` input to `apply_clifford_to_pauli` is identity. Previously, that function would throw an error if `pauli_in` was the identity. This assumes the action specified in PR #836.