### PR TITLE
Compiler timeout

### DIFF
--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -198,7 +198,7 @@ class QPUCompiler(AbstractCompiler):
 
 class QVMCompiler(AbstractCompiler):
     @_record_call
-    def __init__(self, endpoint: str, device: AbstractDevice, timeout: float = None) -> None:
+    def __init__(self, endpoint: str, device: AbstractDevice, timeout: float = 5) -> None:
         """
         Client to communicate with the Compiler Server.
 

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -131,7 +131,7 @@ class QPUCompiler(AbstractCompiler):
     def __init__(self,
                  endpoint: str,
                  device: AbstractDevice,
-                 timeout: int = 5,
+                 timeout: int = 10,
                  name: Optional[str] = None) -> None:
         """
         Client to communicate with the Compiler Server.
@@ -198,7 +198,7 @@ class QPUCompiler(AbstractCompiler):
 
 class QVMCompiler(AbstractCompiler):
     @_record_call
-    def __init__(self, endpoint: str, device: AbstractDevice, timeout: float = 5) -> None:
+    def __init__(self, endpoint: str, device: AbstractDevice, timeout: float = 10) -> None:
         """
         Client to communicate with the Compiler Server.
 

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -131,7 +131,7 @@ class QPUCompiler(AbstractCompiler):
     def __init__(self,
                  endpoint: str,
                  device: AbstractDevice,
-                 timeout: int = 10,
+                 timeout: int = 5,
                  name: Optional[str] = None) -> None:
         """
         Client to communicate with the Compiler Server.


### PR DESCRIPTION
Having a `None` timeout for `QVMCompiler` objects results in indefinite hanging, so we choose a number. It also feels like 10 seconds is a bit excessive, so we set both `QVMCompiler` and `QPUCompiler` objects to be 5 seconds instead.