### PR TITLE
add local_qvm to getting started docs

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -256,6 +256,12 @@ The :py:class:`~pyquil.quil.Program` object allows us to build up a Quil program
 :py:class:`~pyquil.api.QuantumComputer` object, which specifies what our program should run on (see: :ref:`qvm`). We've also imported all (``*``)
 gates from the ``pyquil.gates`` module, which allows us to add operations to our program (:ref:`basics`).
 
+.. note::
+
+    PyQuil also provides a handy function for you to ensure that a local qvm and quilc are currently running in
+    your environment. To make sure both are available you import `from pyquil.api import local_qvm` and then run
+    `local_qvm()`. This will start a qvm and quilc instances using subprocesses if they have not already been started.
+
 Next, let's construct our Bell State.
 
 .. code:: python

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -261,6 +261,19 @@ gates from the ``pyquil.gates`` module, which allows us to add operations to our
     PyQuil also provides a handy function for you to ensure that a local qvm and quilc are currently running in
     your environment. To make sure both are available you import `from pyquil.api import local_qvm` and then run
     `local_qvm()`. This will start a qvm and quilc instances using subprocesses if they have not already been started.
+    You can also use it as a context manager as in the following example:
+
+    .. code:: python
+
+        from pyquil import get_qc, Program
+        from pyquil.gates import CNOT, Z
+        from pyquil.api import local_qvm
+
+        qvm = get_qc('9q-square-qvm')
+        prog = Program(Z(0), CNOT(0, 1))
+
+        with local_qvm():
+            results = qvm.run_and_measure(prog, trials=10)
 
 Next, let's construct our Bell State.
 


### PR DESCRIPTION
The `local_qvm` function is great for beginners (or anyone really) to ensure that the local QVM and Quilc are running without needing to jump into a terminal. Particularly when one is developing in jupyter notebooks and jumping between them it is a good way to make sure the env is set up right. 

This PR surfaces this functionality to the getting started so that developers are aware that this quality of life function exists. 