### PR TITLE
add WavefunctionSimulator to top level pyquil package imports

### DIFF
--- a/pyquil/__init__.py
+++ b/pyquil/__init__.py
@@ -1,4 +1,4 @@
 __version__ = "2.5.2"
 
 from pyquil.quil import Program
-from pyquil.api import list_quantum_computers, get_qc
+from pyquil.api import list_quantum_computers, get_qc, WavefunctionSimulator


### PR DESCRIPTION
This is a super small PR. Given that Wavefunction simulation is at the same top usage level in pyquil as using a QuantumComputer object I propose that it be included as a possible `from pyquil import WavefunctionSimulator` import. This makes UX a bit easier than having to remember that its in api.