### PR TITLE
Provide a non-None 10 second default timeout to get_benchmarker

### DIFF
--- a/pyquil/api/_benchmark.py
+++ b/pyquil/api/_benchmark.py
@@ -138,7 +138,7 @@ class BenchmarkConnection(AbstractBenchmarker):
         return list(reversed(programs))
 
 
-def get_benchmarker(endpoint: str = None, timeout: float = None):
+def get_benchmarker(endpoint: str = None, timeout: float = 10):
     """
     Retrieve an instance of the appropriate AbstractBenchmarker subclass for a given endpoint.
 


### PR DESCRIPTION
another one.