### PR TITLE
Distinguish between quilc and the QPU compiler endpoints

### DIFF
--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -298,7 +298,7 @@ class ForestConnection:
         if sync_endpoint is None:
             sync_endpoint = pyquil_config.qvm_url
         if compiler_endpoint is None:
-            compiler_endpoint = pyquil_config.compiler_url
+            compiler_endpoint = pyquil_config.quilc_url
         if forest_cloud_endpoint is None:
             forest_cloud_endpoint = pyquil_config.forest_url
 

--- a/pyquil/api/_benchmark.py
+++ b/pyquil/api/_benchmark.py
@@ -152,6 +152,6 @@ def get_benchmarker(endpoint: str = None, timeout: float = 10):
     """
     if endpoint is None:
         config = PyquilConfig()
-        endpoint = config.compiler_url
+        endpoint = config.quilc_url
 
     return BenchmarkConnection(endpoint=endpoint, timeout=timeout)

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -185,10 +185,9 @@ class QPUCompiler(AbstractCompiler):
     @_record_call
     def native_quil_to_executable(self, nq_program: Program) -> Optional[BinaryExecutableResponse]:
         if not self.qpu_compiler_client:
-            warnings.warn("It looks like you're trying to compile to an executable, but "
-                          "do not have access to the QPU compiler endpoint. Make sure you "
-                          "are engaged to the QPU before trying to do this.")
-            return
+            raise ValueError("It looks like you're trying to compile to an executable, but "
+                             "do not have access to the QPU compiler endpoint. Make sure you "
+                             "are engaged to the QPU before trying to do this.")
 
         if nq_program.native_quil_metadata is None:
             warnings.warn("It looks like you're trying to call `native_quil_to_binary` on a "

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -129,40 +129,50 @@ def _collect_memory_descriptors(program: Program) -> Dict[str, ParameterSpec]:
 class QPUCompiler(AbstractCompiler):
     @_record_call
     def __init__(self,
-                 endpoint: str,
+                 quilc_endpoint: str,
+                 qpu_compiler_endpoint: Optional[str],
                  device: AbstractDevice,
                  timeout: int = 10,
                  name: Optional[str] = None) -> None:
         """
         Client to communicate with the Compiler Server.
 
-        :param endpoint: TCP or IPC endpoint of the Compiler Server
+        :param quilc_endpoint: TCP or IPC endpoint of the Quil Compiler (quilc)
+        :param qpu_compiler_endpoint: TCP or IPC endpoint of the QPU Compiler
         :param device: PyQuil Device object to use as compilation target
         :param timeout: Number of seconds to wait for a response from the client.
         :param name: Name of the lattice being targeted
         """
 
-        if not endpoint.startswith('tcp://'):
+        if not quilc_endpoint.startswith('tcp://'):
             raise ValueError(f"PyQuil versions >= 2.4 can only talk to quilc "
                              f"versions >= 1.4 over network RPCQ.  You've supplied the "
-                             f"endpoint '{endpoint}', but this doesn't look like a network "
+                             f"endpoint '{quilc_endpoint}', but this doesn't look like a network "
                              f"ZeroMQ address, which has the form 'tcp://domain:port'. "
                              f"You might try clearing (or correcting) your COMPILER_URL "
                              f"environment variable and removing (or correcting) the "
                              f"compiler_server_address line from your .forest_config file.")
 
-        self.client = Client(endpoint, timeout=timeout)
+        self.quilc_client = Client(quilc_endpoint, timeout=timeout)
+        if qpu_compiler_endpoint is not None:
+            self.qpu_compiler_client = Client(qpu_compiler_endpoint, timeout=timeout)
+        else:
+            self.qpu_compiler_client = None
         self.target_device = TargetDevice(isa=device.get_isa().to_dict(),
                                           specs=device.get_specs().to_dict())
         self.name = name
 
     def get_version_info(self) -> dict:
-        return self.client.call('get_version_info')
+        quilc_version_info = self.quilc_client.call('get_version_info')
+        if self.qpu_compiler_client:
+            qpu_compiler_version_info = self.qpu_compiler_client.call('get_version_info')
+            return {'quilc': quilc_version_info, 'qpu_compiler': qpu_compiler_version_info}
+        return {'quilc': quilc_version_info}
 
     @_record_call
     def quil_to_native_quil(self, program: Program) -> Program:
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
-        response = self.client.call('quil_to_native_quil', request).asdict()  # type: Dict
+        response = self.quilc_client.call('quil_to_native_quil', request).asdict()  # type: Dict
         nq_program = parse_program(response['quil'])
         nq_program.native_quil_metadata = response['metadata']
         nq_program.num_shots = program.num_shots
@@ -170,30 +180,36 @@ class QPUCompiler(AbstractCompiler):
 
     @_record_call
     def native_quil_to_executable(self, nq_program: Program) -> BinaryExecutableResponse:
-        if nq_program.native_quil_metadata is None:
-            warnings.warn("It looks like you're trying to call `native_quil_to_binary` on a "
-                          "Program that hasn't been compiled via `quil_to_native_quil`. This is "
-                          "ok if you've hand-compiled your program to our native gateset, "
-                          "but be careful!")
-        if self.name is not None:
-            targeted_lattice = self.client.call('get_config_info')['lattice_name']
-            if targeted_lattice and targeted_lattice != self.name:
-                warnings.warn(f'You requested compilation for device {self.name}, '
-                              f'but you are engaged on device {targeted_lattice}.')
+        if self.qpu_compiler_client:
+            if nq_program.native_quil_metadata is None:
+                warnings.warn("It looks like you're trying to call `native_quil_to_binary` on a "
+                              "Program that hasn't been compiled via `quil_to_native_quil`. This is "
+                              "ok if you've hand-compiled your program to our native gateset, "
+                              "but be careful!")
+            if self.name is not None:
+                targeted_lattice = self.qpu_compiler_client.call('get_config_info')['lattice_name']
+                if targeted_lattice and targeted_lattice != self.name:
+                    warnings.warn(f'You requested compilation for device {self.name}, '
+                                  f'but you are engaged on device {targeted_lattice}.')
 
-        arithmetic_request = RewriteArithmeticRequest(quil=nq_program.out())
-        arithmetic_response = self.client.call('rewrite_arithmetic', arithmetic_request)
+            arithmetic_request = RewriteArithmeticRequest(quil=nq_program.out())
+            arithmetic_response = self.quilc_client.call('rewrite_arithmetic', arithmetic_request)
 
-        request = BinaryExecutableRequest(quil=arithmetic_response.quil, num_shots=nq_program.num_shots)
-        response = self.client.call('native_quil_to_binary', request)
+            request = BinaryExecutableRequest(quil=arithmetic_response.quil,
+                                              num_shots=nq_program.num_shots)
+            response = self.qpu_compiler_client.call('native_quil_to_binary', request)
 
-        # hack! we're storing a little extra info in the executable binary that we don't want to
-        # expose to anyone outside of our own private lives: not the user, not the Forest server,
-        # not anyone.
-        response.recalculation_table = arithmetic_response.recalculation_table
-        response.memory_descriptors = _collect_memory_descriptors(nq_program)
-        response.ro_sources = _collect_classical_memory_write_locations(nq_program)
-        return response
+            # hack! we're storing a little extra info in the executable binary that we don't want to
+            # expose to anyone outside of our own private lives: not the user, not the Forest server,
+            # not anyone.
+            response.recalculation_table = arithmetic_response.recalculation_table
+            response.memory_descriptors = _collect_memory_descriptors(nq_program)
+            response.ro_sources = _collect_classical_memory_write_locations(nq_program)
+            return response
+        else:
+            warnings.warn("It looks like you're trying to compile to an executable, but "
+                          "do not have access to the QPU compiler endpoint. Make sure you "
+                          "are engaged to the QPU before trying to do this.")
 
 
 class QVMCompiler(AbstractCompiler):

--- a/pyquil/api/_config.py
+++ b/pyquil/api/_config.py
@@ -81,12 +81,20 @@ class PyquilConfig(object):
         "default": "http://127.0.0.1:5000"
     }
 
-    COMPILER_URL = {
-        "env": "COMPILER_URL",
+    QUILC_URL = {
+        "env": "QUILC_URL",
         "file": FOREST_CONFIG,
         "section": "Rigetti Forest",
-        "name": "compiler_server_address",
+        "name": "quilc_address",
         "default": "tcp://127.0.0.1:5555"
+    }
+
+    QPU_COMPILER_URL = {
+        "env": "QPU_COMPILER_URL",
+        "file": FOREST_CONFIG,
+        "section": "Rigetti Forest",
+        "name": "qpu_compiler_address",
+        "default": None
     }
 
     def __init__(self):
@@ -142,5 +150,9 @@ class PyquilConfig(object):
         return self._env_or_config_or_default(**self.QVM_URL)
 
     @property
-    def compiler_url(self):
-        return self._env_or_config_or_default(**self.COMPILER_URL)
+    def quilc_url(self):
+        return self._env_or_config_or_default(**self.QUILC_URL)
+
+    @property
+    def qpu_compiler_url(self):
+        return self._env_or_config_or_default(**self.QPU_COMPILER_URL)

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -16,13 +16,13 @@
 import re
 import warnings
 from math import pi
-from typing import List, Dict, Tuple, Iterator, Union, Optional
+from typing import List, Dict, Tuple, Iterator, Union
 import subprocess
 from contextlib import contextmanager
 
 import networkx as nx
 import numpy as np
-from rpcq.messages import BinaryExecutableResponse, Message, PyQuilExecutableResponse
+from rpcq.messages import BinaryExecutableResponse, PyQuilExecutableResponse
 
 from pyquil.api._compiler import QPUCompiler, QVMCompiler
 from pyquil.api._config import PyquilConfig
@@ -37,7 +37,7 @@ from pyquil.gates import RX, MEASURE
 from pyquil.noise import decoherence_noise_with_asymmetric_ro, NoiseModel
 from pyquil.pyqvm import PyQVM
 from pyquil.quil import Program, validate_supported_quil
-from pyquil.quilbase import Measurement, Pragma, Gate, Reset
+from pyquil.quilbase import Measurement, Pragma
 
 pyquil_config = PyquilConfig()
 
@@ -622,7 +622,8 @@ def get_qc(name: str, *, as_qvm: bool = None, noisy: bool = None,
                                    user=pyquil_config.user_id),
                                device=device,
                                compiler=QPUCompiler(
-                                   endpoint=pyquil_config.compiler_url,
+                                   quilc_endpoint=pyquil_config.quilc_url,
+                                   qpu_compiler_endpoint=pyquil_config.qpu_compiler_url,
                                    device=device,
                                    name=prefix))
 

--- a/pyquil/api/_qvm.py
+++ b/pyquil/api/_qvm.py
@@ -67,7 +67,7 @@ class QVMConnection(object):
 
         if compiler_endpoint is None:
             pyquil_config = PyquilConfig()
-            compiler_endpoint = pyquil_config.compiler_url
+            compiler_endpoint = pyquil_config.quilc_url
 
         if (device is not None and device.noise_model is not None) and \
                 (gate_noise is not None or measurement_noise is not None):

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -998,7 +998,7 @@ def _exhaustive_symmetrization(qc: QuantumComputer, qubits: List[int],
                     bitstring results
     """
     # Symmetrize -- flip qubits pre-measurement
-    n_shots_symm = round(np.ceil(shots / 2**len(qubits)))
+    n_shots_symm = int(round(np.ceil(shots / 2**len(qubits))))
     if n_shots_symm * 2**len(qubits) > shots:
         warnings.warn("Symmetrization increasing number of shots from {} to {}".format(shots, round(n_shots_symm * 2**len(qubits))))
     list_bitstrings_symm = []

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -166,7 +166,7 @@ def forest():
 @pytest.fixture(scope='session')
 def benchmarker():
     try:
-        bm = get_benchmarker(timeout=1)
+        bm = get_benchmarker(timeout=2)
         bm.apply_clifford_to_pauli(Program(I(0)), sX(0))
         return bm
     except (RequestException, TimeoutError) as e:

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -146,7 +146,7 @@ def qvm():
 def compiler(test_device):
     try:
         config = PyquilConfig()
-        compiler = QVMCompiler(endpoint=config.compiler_url, device=test_device, timeout=1)
+        compiler = QVMCompiler(endpoint=config.quilc_url, device=test_device, timeout=1)
         compiler.quil_to_native_quil(Program(I(0)))
         return compiler
     except (RequestException, UnknownApiError, TimeoutError) as e:
@@ -168,6 +168,7 @@ def benchmarker():
     try:
         bm = get_benchmarker(timeout=1)
         bm.apply_clifford_to_pauli(Program(I(0)), sX(0))
+        return bm
     except (RequestException, TimeoutError) as e:
         return pytest.skip("This test requires a running local benchmarker endpoint (ie quilc): {}"
                            .format(e))

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -271,9 +271,8 @@ def server(request, m_endpoints):
 
 
 @pytest.fixture
-def mock_qpu_compiler(request, m_endpoints):
-    config = PyquilConfig()
-    return QPUCompiler(quilc_endpoint=config.quilc_url,
+def mock_qpu_compiler(request, m_endpoints, compiler: QVMCompiler):
+    return QPUCompiler(quilc_endpoint=compiler.client.endpoint,
                        qpu_compiler_endpoint=m_endpoints[0],
                        device=NxDevice(nx.Graph([(0, 1)])))
 

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -30,7 +30,7 @@ import requests_mock
 from rpcq import Server
 from rpcq.messages import BinaryExecutableRequest, BinaryExecutableResponse
 
-from pyquil.api import QVMConnection, QPUCompiler,get_qc, QVMCompiler
+from pyquil.api import QVMConnection, QPUCompiler, get_qc, QVMCompiler
 from pyquil.api._base_connection import (validate_noise_probabilities, validate_qubit_list,
                                          prepare_register_list)
 from pyquil.api._config import PyquilConfig
@@ -276,7 +276,6 @@ def mock_qpu_compiler(request, m_endpoints):
     return QPUCompiler(quilc_endpoint=config.quilc_url,
                        qpu_compiler_endpoint=m_endpoints[0],
                        device=NxDevice(nx.Graph([(0, 1)])))
-
 
 
 def test_quil_to_native_quil(compiler):

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -837,9 +837,9 @@ PRAGMA ADD-KRAUS Y 1 "(0.0 0.4472135954999579 0.4472135954999579 0.0)"
 PRAGMA ADD-KRAUS H 2 "(0.9486832980505138 0.0 0.0 0.9486832980505138)"
 PRAGMA ADD-KRAUS H 2 "(0.0 0.31622776601683794 0.31622776601683794 0.0)"
 '''
-    assert calibr_prog1 == Program(expected_prog)
-    assert calibr_prog2 == Program(expected_prog)
-    assert calibr_prog3 == Program(expected_prog)
+    assert calibr_prog1.out() == Program(expected_prog).out()
+    assert calibr_prog2.out() == Program(expected_prog).out()
+    assert calibr_prog3.out() == Program(expected_prog).out()
 
 
 def test_expectations_sic0(forest):


### PR DESCRIPTION
`COMPILER_URL` is being replaced by `QUILC_URL` and `QPU_COMPILER_URL` as they are now separate services within QCS.