### PR TITLE
 Added PauliTerm.matrix() and PauliSum.matrix() methods

### DIFF
--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -676,3 +676,48 @@ def test_identity_no_qubit():
 def test_qubit_validation():
     with pytest.raises(ValueError):
         op = sX(None)
+
+def test_PauliSum_from_str():
+    Sum = (1.5+.5j)*sX(0)*sZ(2) + 0.7*sZ(1)
+    assert PauliSum.from_compact_str(str(Sum)) == Sum
+    with pytest.raises(ValueError):
+        PauliSum.from_compact_str("(1.0+0j)*X0 + (1.0+0j)*A0")
+
+def test_PauliTerm_matrix():
+    term = 1.5*sX(0) * sZ(2)
+    matrix1 = term.matrix()
+    matrix2 = np.array([[0, 1.5, 0, 0, 0, 0, 0, 0],
+                         [1.5, 0, 0, 0, 0, 0, 0, 0],
+                         [0, 0, 0, 1.5, 0, 0, 0, 0],
+                         [0, 0, 1.5, 0, 0, 0, 0, 0],
+                         [0, 0, 0, 0, 0, -1.5, 0, 0],
+                         [0, 0, 0, 0, -1.5, 0, 0, 0],
+                         [0, 0, 0, 0, 0, 0, 0, -1.5],
+                         [0, 0, 0, 0, 0, 0, -1.5, 0]])
+    assert np.allclose(matrix1, matrix2)
+    matrix1 = term.matrix(nqubits=4)
+    matrix2 = np.kron(np.array([[1, 0], [0, 1]]), matrix2)
+    assert np.allclose(matrix1, matrix2)
+
+    with pytest.raises(ValueError):
+        term.matrix(nqubits=2)
+
+def test_PauliSum_matrix():
+    Sum = 1.5*sX(0)*sZ(2) + 0.7*sZ(1)
+    matrix1 = Sum.matrix()
+    matrix2 = np.array([[0, 1.5, 0, 0, 0, 0, 0, 0],
+                         [1.5, 0, 0, 0, 0, 0, 0, 0],
+                         [0, 0, 0, 1.5, 0, 0, 0, 0],
+                         [0, 0, 1.5, 0, 0, 0, 0, 0],
+                         [0, 0, 0, 0, 0, -1.5, 0, 0],
+                         [0, 0, 0, 0, -1.5, 0, 0, 0],
+                         [0, 0, 0, 0, 0, 0, 0, -1.5],
+                         [0, 0, 0, 0, 0, 0, -1.5, 0]])
+    matrix2 += np.diag([0.7,0.7,-0.7,-0.7,0.7,0.7,-0.7,-0.7])
+    assert(np.allclose(matrix1, matrix2))
+    matrix1 = Sum.matrix(nqubits=4)
+    matrix2 = np.kron(np.array([[1, 0], [0, 1]]), matrix2)
+    assert np.allclose(matrix1, matrix2)
+
+    with pytest.raises(ValueError):
+            Sum.matrix(nqubits=2)

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -677,14 +677,16 @@ def test_qubit_validation():
     with pytest.raises(ValueError):
         op = sX(None)
 
+
 def test_PauliSum_from_str():
-    Sum = (1.5+.5j)*sX(0)*sZ(2) + 0.7*sZ(1)
+    Sum = (1.5 + .5j) * sX(0) * sZ(2) + 0.7 * sZ(1)
     assert PauliSum.from_compact_str(str(Sum)) == Sum
     with pytest.raises(ValueError):
         PauliSum.from_compact_str("(1.0+0j)*X0 + (1.0+0j)*A0")
 
+
 def test_PauliTerm_matrix():
-    term = 1.5*sX(0) * sZ(2)
+    term = 1.5 * sX(0) * sZ(2)
     matrix1 = term.matrix()
     matrix2 = np.array([[0, 1.5, 0, 0, 0, 0, 0, 0],
                          [1.5, 0, 0, 0, 0, 0, 0, 0],
@@ -702,8 +704,9 @@ def test_PauliTerm_matrix():
     with pytest.raises(ValueError):
         term.matrix(nqubits=2)
 
+
 def test_PauliSum_matrix():
-    Sum = 1.5*sX(0)*sZ(2) + 0.7*sZ(1)
+    Sum = 1.5 * sX(0) * sZ(2) + 0.7 * sZ(1)
     matrix1 = Sum.matrix()
     matrix2 = np.array([[0, 1.5, 0, 0, 0, 0, 0, 0],
                          [1.5, 0, 0, 0, 0, 0, 0, 0],
@@ -713,11 +716,11 @@ def test_PauliSum_matrix():
                          [0, 0, 0, 0, -1.5, 0, 0, 0],
                          [0, 0, 0, 0, 0, 0, 0, -1.5],
                          [0, 0, 0, 0, 0, 0, -1.5, 0]])
-    matrix2 += np.diag([0.7,0.7,-0.7,-0.7,0.7,0.7,-0.7,-0.7])
+    matrix2 += np.diag([0.7, 0.7, -0.7, -0.7, 0.7, 0.7, -0.7, -0.7])
     assert(np.allclose(matrix1, matrix2))
     matrix1 = Sum.matrix(nqubits=4)
     matrix2 = np.kron(np.array([[1, 0], [0, 1]]), matrix2)
     assert np.allclose(matrix1, matrix2)
 
     with pytest.raises(ValueError):
-            Sum.matrix(nqubits=2)
+        Sum.matrix(nqubits=2)

--- a/pyquil/tests/test_paulis_with_placeholders.py
+++ b/pyquil/tests/test_paulis_with_placeholders.py
@@ -608,3 +608,55 @@ def test_simplify_warning():
 
     assert tsum == 2 * sZ(q[0]) * sZ(q[1])
     assert 'will be combined with' in str(e[0].message)
+
+
+def test_PauliTerm_matrix():
+    q0 = QubitPlaceholder()
+    q1 = QubitPlaceholder()
+    term = 1.5*sX(q0) * sZ(2)
+    matrix1 = term.matrix(qubit_mapping={q0: 0, q1: 1})
+    matrix2 = np.array([[0, 1.5, 0, 0, 0, 0, 0, 0],
+                         [1.5, 0, 0, 0, 0, 0, 0, 0],
+                         [0, 0, 0, 1.5, 0, 0, 0, 0],
+                         [0, 0, 1.5, 0, 0, 0, 0, 0],
+                         [0, 0, 0, 0, 0, -1.5, 0, 0],
+                         [0, 0, 0, 0, -1.5, 0, 0, 0],
+                         [0, 0, 0, 0, 0, 0, 0, -1.5],
+                         [0, 0, 0, 0, 0, 0, -1.5, 0]])
+    assert np.allclose(matrix1, matrix2)
+    matrix1 = term.matrix(qubit_mapping = {q0:0}, nqubits=4)
+    matrix2 = np.kron(np.array([[1, 0], [0, 1]]), matrix2)
+    assert np.allclose(matrix1, matrix2)
+
+    with pytest.raises(AssertionError):
+        term.matrix(qubit_mapping={q0: 2})
+    with pytest.raises(AssertionError):
+        term.matrix(qubit_mapping = {q1: 2})
+    with pytest.raises(AssertionError):
+        term.matrix(qubit_mapping = {q1: 2, q0: 2})
+
+def test_PauliSum_matrix():
+    q0 = QubitPlaceholder()
+    q1 = QubitPlaceholder()
+    Sum = 1.5*sX(q0)*sZ(2) + 0.7*sZ(1)
+    matrix1 = Sum.matrix(qubit_mapping={q0: 0})
+    matrix2 = np.array([[0, 1.5, 0, 0, 0, 0, 0, 0],
+                         [1.5, 0, 0, 0, 0, 0, 0, 0],
+                         [0, 0, 0, 1.5, 0, 0, 0, 0],
+                         [0, 0, 1.5, 0, 0, 0, 0, 0],
+                         [0, 0, 0, 0, 0, -1.5, 0, 0],
+                         [0, 0, 0, 0, -1.5, 0, 0, 0],
+                         [0, 0, 0, 0, 0, 0, 0, -1.5],
+                         [0, 0, 0, 0, 0, 0, -1.5, 0]])
+    matrix2 += np.diag([0.7,0.7,-0.7,-0.7,0.7,0.7,-0.7,-0.7])
+    assert(np.allclose(matrix1, matrix2))
+    matrix1 = Sum.matrix(qubit_mapping={q0: 0}, nqubits=4)
+    matrix2 = np.kron(np.array([[1, 0], [0, 1]]), matrix2)
+    assert np.allclose(matrix1, matrix2)
+
+    with pytest.raises(AssertionError):
+        Sum.matrix(qubit_mapping={q0: 2})
+    with pytest.raises(AssertionError):
+        Sum.matrix(qubit_mapping = {q1: 2})
+    with pytest.raises(AssertionError):
+        Sum.matrix(qubit_mapping = {q1: 2, q0: 2})

--- a/pyquil/tests/test_paulis_with_placeholders.py
+++ b/pyquil/tests/test_paulis_with_placeholders.py
@@ -613,7 +613,7 @@ def test_simplify_warning():
 def test_PauliTerm_matrix():
     q0 = QubitPlaceholder()
     q1 = QubitPlaceholder()
-    term = 1.5*sX(q0) * sZ(2)
+    term = 1.5 * sX(q0) * sZ(2)
     matrix1 = term.matrix(qubit_mapping={q0: 0, q1: 1})
     matrix2 = np.array([[0, 1.5, 0, 0, 0, 0, 0, 0],
                          [1.5, 0, 0, 0, 0, 0, 0, 0],
@@ -624,21 +624,22 @@ def test_PauliTerm_matrix():
                          [0, 0, 0, 0, 0, 0, 0, -1.5],
                          [0, 0, 0, 0, 0, 0, -1.5, 0]])
     assert np.allclose(matrix1, matrix2)
-    matrix1 = term.matrix(qubit_mapping = {q0:0}, nqubits=4)
+    matrix1 = term.matrix(qubit_mapping={q0: 0}, nqubits=4)
     matrix2 = np.kron(np.array([[1, 0], [0, 1]]), matrix2)
     assert np.allclose(matrix1, matrix2)
 
     with pytest.raises(AssertionError):
         term.matrix(qubit_mapping={q0: 2})
     with pytest.raises(AssertionError):
-        term.matrix(qubit_mapping = {q1: 2})
+        term.matrix(qubit_mapping={q1: 2})
     with pytest.raises(AssertionError):
-        term.matrix(qubit_mapping = {q1: 2, q0: 2})
+        term.matrix(qubit_mapping={q1: 2, q0: 2})
+
 
 def test_PauliSum_matrix():
     q0 = QubitPlaceholder()
     q1 = QubitPlaceholder()
-    Sum = 1.5*sX(q0)*sZ(2) + 0.7*sZ(1)
+    Sum = 1.5 * sX(q0) * sZ(2) + 0.7 * sZ(1)
     matrix1 = Sum.matrix(qubit_mapping={q0: 0})
     matrix2 = np.array([[0, 1.5, 0, 0, 0, 0, 0, 0],
                          [1.5, 0, 0, 0, 0, 0, 0, 0],
@@ -648,7 +649,7 @@ def test_PauliSum_matrix():
                          [0, 0, 0, 0, -1.5, 0, 0, 0],
                          [0, 0, 0, 0, 0, 0, 0, -1.5],
                          [0, 0, 0, 0, 0, 0, -1.5, 0]])
-    matrix2 += np.diag([0.7,0.7,-0.7,-0.7,0.7,0.7,-0.7,-0.7])
+    matrix2 += np.diag([0.7, 0.7, -0.7, -0.7, 0.7, 0.7, -0.7, -0.7])
     assert(np.allclose(matrix1, matrix2))
     matrix1 = Sum.matrix(qubit_mapping={q0: 0}, nqubits=4)
     matrix2 = np.kron(np.array([[1, 0], [0, 1]]), matrix2)
@@ -657,6 +658,6 @@ def test_PauliSum_matrix():
     with pytest.raises(AssertionError):
         Sum.matrix(qubit_mapping={q0: 2})
     with pytest.raises(AssertionError):
-        Sum.matrix(qubit_mapping = {q1: 2})
+        Sum.matrix(qubit_mapping={q1: 2})
     with pytest.raises(AssertionError):
-        Sum.matrix(qubit_mapping = {q1: 2, q0: 2})
+        Sum.matrix(qubit_mapping={q1: 2, q0: 2})


### PR DESCRIPTION
Added PauliTerm.matrix() and PauliSum.matrix() methods
Added support for multi-qubit strings to PauliTerm.from_compact_str
Added Tests for all of the above
	changed:       pyquil/paulis.py
	changed:       pyquil/tests/test_paulis.py
	changed:       pyquil/tests/test_paulis_with_placeholders.py