### PR TITLE
Replace standard deviation in operator estimation with standard error

### DIFF
--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -1000,7 +1000,7 @@ def _exhaustive_symmetrization(qc: QuantumComputer, qubits: List[int],
     # Symmetrize -- flip qubits pre-measurement
     n_shots_symm = int(round(np.ceil(shots / 2**len(qubits))))
     if n_shots_symm * 2**len(qubits) > shots:
-        warnings.warn("Symmetrization increasing number of shots from {} to {}".format(shots, round(n_shots_symm * 2**len(qubits))))
+        warnings.warn(f"Symmetrization increasing number of shots from {shots} to {round(n_shots_symm * 2**len(qubits))}")
     list_bitstrings_symm = []
     for ops_bool in itertools.product([0, 1], repeat=len(qubits)):
         total_prog_symm = prog.copy()

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -719,16 +719,16 @@ class ExperimentResult:
 
     setting: ExperimentSetting
     expectation: Union[float, complex]
-    stddev: Union[float, complex]
+    std_err: Union[float, complex]
     total_counts: int
     raw_expectation: Union[float, complex] = None
-    raw_stddev: float = None
+    raw_std_err: float = None
     calibration_expectation: Union[float, complex] = None
-    calibration_stddev: Union[float, complex] = None
+    calibration_std_err: Union[float, complex] = None
     calibration_counts: int = None
 
     def __str__(self):
-        return f'{self.setting}: {self.expectation} +- {self.stddev}'
+        return f'{self.setting}: {self.expectation} +- {self.std_err}'
 
     def __repr__(self):
         return f'ExperimentResult[{self}]'
@@ -738,12 +738,12 @@ class ExperimentResult:
             'type': 'ExperimentResult',
             'setting': self.setting,
             'expectation': self.expectation,
-            'stddev': self.stddev,
+            'std_err': self.std_err,
             'total_counts': self.total_counts,
             'raw_expectation': self.raw_expectation,
-            'raw_stddev': self.raw_stddev,
+            'raw_std_err': self.raw_std_err,
             'calibration_expectation': self.calibration_expectation,
-            'calibration_stddev': self.calibration_stddev,
+            'calibration_std_err': self.calibration_std_err,
             'calibration_counts': self.calibration_counts,
         }
 
@@ -853,7 +853,7 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 yield ExperimentResult(
                     setting=setting,
                     expectation=coeff,
-                    stddev=0.0,
+                    std_err=0.0,
                     total_counts=n_shots,
                 )
                 continue
@@ -883,12 +883,12 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 yield ExperimentResult(
                     setting=setting,
                     expectation=corrected_mean.item(),
-                    stddev=np.sqrt(corrected_var).item(),
+                    std_err=np.sqrt(corrected_var).item(),
                     total_counts=n_shots,
                     raw_expectation=obs_mean.item(),
-                    raw_stddev=np.sqrt(obs_var).item(),
+                    raw_std_err=np.sqrt(obs_var).item(),
                     calibration_expectation=obs_calibr_mean.item(),
-                    calibration_stddev=np.sqrt(obs_calibr_var).item(),
+                    calibration_std_err=np.sqrt(obs_calibr_var).item(),
                     calibration_counts=calibr_shots,
                 )
 
@@ -897,7 +897,7 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 yield ExperimentResult(
                     setting=setting,
                     expectation=obs_mean.item(),
-                    stddev=np.sqrt(obs_var).item(),
+                    std_err=np.sqrt(obs_var).item(),
                     total_counts=n_shots,
                 )
 

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -171,7 +171,7 @@ def test_experiment_result_compat():
     er = ExperimentResult(
         setting=ExperimentSetting(sX(0), sZ(0)),
         expectation=0.9,
-        stddev=0.05,
+        std_err=0.05,
         total_counts=100,
     )
     assert str(er) == 'X0_0→(1+0j)*Z0: 0.9 +- 0.05'
@@ -181,7 +181,7 @@ def test_experiment_result():
     er = ExperimentResult(
         setting=ExperimentSetting(plusX(0), sZ(0)),
         expectation=0.9,
-        stddev=0.05,
+        std_err=0.05,
         total_counts=100,
     )
     assert str(er) == 'X0_0→(1+0j)*Z0: 0.9 +- 0.05'
@@ -527,7 +527,7 @@ def test_measure_observables_no_symm_calibr_raises_error(forest):
     suite = TomographyExperiment([exptsetting],
                                  program=Program(I(0)), qubits=[0])
     with pytest.raises(ValueError):
-        result = list(measure_observables(qc, suite, readout_symmetrize=None,
+        result = list(measure_observables(qc, suite, symmetrize_readout=None,
                                           calibrate_readout='plus-eig'))
 
 
@@ -593,7 +593,7 @@ def test_measure_observables_uncalibrated_asymmetric_readout(forest):
 
     for idx, res in enumerate(measure_observables(qc,
                                                   tomo_expt, n_shots=1000,
-                                                  readout_symmetrize=None,
+                                                  symmetrize_readout=None,
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
 
@@ -697,7 +697,7 @@ def test_measure_observables_result_zero_no_noisy_readout(forest):
     expectations = []
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
-                                                readout_symmetrize=None,
+                                                symmetrize_readout=None,
                                                 calibrate_readout=None))
         expectations.append([res.expectation for res in expt_results])
     expectations = np.array(expectations)
@@ -724,7 +724,7 @@ def test_measure_observables_result_zero_no_symm_calibr(forest):
     expected_result = (p00 * 0.5 + (1 - p11) * 0.5) - ((1 - p00) * 0.5 + p11 * 0.5)
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
-                                                readout_symmetrize=None,
+                                                symmetrize_readout=None,
                                                 calibrate_readout=None))
         expectations.append([res.expectation for res in expt_results])
     expectations = np.array(expectations)
@@ -1411,7 +1411,7 @@ def test_measure_1q_observable_raw_expectation(forest):
 
 
 def test_measure_1q_observable_raw_variance(forest):
-    # testing that we get correct raw stddev in terms of readout errors
+    # testing that we get correct raw std_err in terms of readout errors
     qc = get_qc('1q-qvm')
     expt = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
     p = Program()
@@ -1423,12 +1423,12 @@ def test_measure_1q_observable_raw_variance(forest):
     num_simulations = 100
     num_shots = 1000
 
-    raw_stddevs = []
+    raw_std_errs = []
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
-        raw_stddevs.append([res.raw_stddev for res in expt_results])
-    raw_stddevs = np.array(raw_stddevs)
-    result = np.mean(raw_stddevs, axis=0)
+        raw_std_errs.append([res.raw_std_err for res in expt_results])
+    raw_std_errs = np.array(raw_std_errs)
+    result = np.mean(raw_std_errs, axis=0)
 
     # calculate expected raw_expectation
     eps_not = (p00 + p11) / 2
@@ -1464,7 +1464,7 @@ def test_measure_1q_observable_calibration_expectation(forest):
 
 
 def test_measure_1q_observable_calibration_variance(forest):
-    # testing that we get correct calibration stddev in terms of readout errors
+    # testing that we get correct calibration std_err in terms of readout errors
     qc = get_qc('1q-qvm')
     expt = ExperimentSetting(TensorProductState(plusZ(0)), sZ(0))
     p = Program()
@@ -1476,12 +1476,12 @@ def test_measure_1q_observable_calibration_variance(forest):
     num_simulations = 100
     num_shots = 1000
 
-    raw_stddevs = []
+    raw_std_errs = []
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
-        raw_stddevs.append([res.raw_stddev for res in expt_results])
-    raw_stddevs = np.array(raw_stddevs)
-    result = np.mean(raw_stddevs, axis=0)
+        raw_std_errs.append([res.raw_std_err for res in expt_results])
+    raw_std_errs = np.array(raw_std_errs)
+    result = np.mean(raw_std_errs, axis=0)
 
     # calculate expected raw_expectation
     eps_not = (p00 + p11) / 2
@@ -1513,7 +1513,7 @@ def test_uncalibrated_asymmetric_readout_nontrivial_1q_state(forest):
 
     for idx, res in enumerate(measure_observables(qc,
                                                   tomo_expt, n_shots=1000,
-                                                  readout_symmetrize=None,
+                                                  symmetrize_readout=None,
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
 
@@ -1544,7 +1544,7 @@ def test_uncalibrated_symmetric_readout_nontrivial_1q_state(forest):
 
     for idx, res in enumerate(measure_observables(qc,
                                                   tomo_expt, n_shots=1000,
-                                                  readout_symmetrize='exhaustive',
+                                                  symmetrize_readout='exhaustive',
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
 
@@ -1573,7 +1573,7 @@ def test_calibrated_symmetric_readout_nontrivial_1q_state(forest):
 
     for idx, res in enumerate(measure_observables(qc,
                                                   tomo_expt, n_shots=1000,
-                                                  readout_symmetrize='exhaustive',
+                                                  symmetrize_readout='exhaustive',
                                                   calibrate_readout='plus-eig')):
         expect_arr[idx] = res.expectation
 
@@ -1599,17 +1599,17 @@ def test_measure_2q_observable_raw_statistics(forest):
     num_shots = 1000
 
     raw_expectations = []
-    raw_stddevs = []
+    raw_std_errs = []
 
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
         raw_expectations.append([res.raw_expectation for res in expt_results])
-        raw_stddevs.append([res.raw_stddev for res in expt_results])
+        raw_std_errs.append([res.raw_std_err for res in expt_results])
 
     raw_expectations = np.array(raw_expectations)
-    raw_stddevs = np.array(raw_stddevs)
+    raw_std_errs = np.array(raw_std_errs)
     result_expectation = np.mean(raw_expectations, axis=0)
-    result_stddev = np.mean(raw_stddevs, axis=0)
+    result_std_err = np.mean(raw_std_errs, axis=0)
 
     # calculate relevant conditional probabilities, given |00> state
     # notation used: pijmn means p(ij|mn)
@@ -1620,10 +1620,10 @@ def test_measure_2q_observable_raw_statistics(forest):
     # calculate expectation value of Z^{\otimes 2}
     z_expectation = (p0000 + p1100) - (p0100 + p1000)
     # calculate standard deviation of the mean
-    simulated_stddev = np.sqrt((1 - z_expectation ** 2) / num_shots)
+    simulated_std_err = np.sqrt((1 - z_expectation ** 2) / num_shots)
     # compare against simulated results
     np.testing.assert_allclose(result_expectation, z_expectation, atol=2e-2)
-    np.testing.assert_allclose(result_stddev, simulated_stddev, atol=2e-2)
+    np.testing.assert_allclose(result_std_err, simulated_std_err, atol=2e-2)
 
 
 def test_raw_statistics_2q_nontrivial_nonentangled_state(forest):
@@ -1645,16 +1645,16 @@ def test_raw_statistics_2q_nontrivial_nonentangled_state(forest):
     num_shots = 1000
 
     raw_expectations = []
-    raw_stddevs = []
+    raw_std_errs = []
 
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
         raw_expectations.append([res.raw_expectation for res in expt_results])
-        raw_stddevs.append([res.raw_stddev for res in expt_results])
+        raw_std_errs.append([res.raw_std_err for res in expt_results])
     raw_expectations = np.array(raw_expectations)
-    raw_stddevs = np.array(raw_stddevs)
+    raw_std_errs = np.array(raw_std_errs)
     result_expectation = np.mean(raw_expectations, axis=0)
-    result_stddev = np.mean(raw_stddevs, axis=0)
+    result_std_err = np.mean(raw_std_errs, axis=0)
 
     # calculate relevant conditional probabilities, given |00> state
     # notation used: pijmn means p(ij|mn)
@@ -1689,10 +1689,10 @@ def test_raw_statistics_2q_nontrivial_nonentangled_state(forest):
     pr11 = p1100 * alph00 + p1101 * alph01 + p1110 * alph10 + p1111 * alph11
     # calculate Z^{\otimes 2} expectation, and error of the mean
     z_expectation = (pr00 + pr11) - (pr01 + pr10)
-    simulated_stddev = np.sqrt((1 - z_expectation ** 2) / num_shots)
+    simulated_std_err = np.sqrt((1 - z_expectation ** 2) / num_shots)
     # compare against simulated results
     np.testing.assert_allclose(result_expectation, z_expectation, atol=2e-2)
-    np.testing.assert_allclose(result_stddev, simulated_stddev, atol=2e-2)
+    np.testing.assert_allclose(result_std_err, simulated_std_err, atol=2e-2)
 
 
 def test_raw_statistics_2q_nontrivial_entangled_state(forest):
@@ -1714,16 +1714,16 @@ def test_raw_statistics_2q_nontrivial_entangled_state(forest):
     num_shots = 1000
 
     raw_expectations = []
-    raw_stddevs = []
+    raw_std_errs = []
 
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
         raw_expectations.append([res.raw_expectation for res in expt_results])
-        raw_stddevs.append([res.raw_stddev for res in expt_results])
+        raw_std_errs.append([res.raw_std_err for res in expt_results])
     raw_expectations = np.array(raw_expectations)
-    raw_stddevs = np.array(raw_stddevs)
+    raw_std_errs = np.array(raw_std_errs)
     result_expectation = np.mean(raw_expectations, axis=0)
-    result_stddev = np.mean(raw_stddevs, axis=0)
+    result_std_err = np.mean(raw_std_errs, axis=0)
 
     # calculate relevant conditional probabilities, given |00> state
     # notation used: pijmn means p(ij|mn)
@@ -1746,10 +1746,10 @@ def test_raw_statistics_2q_nontrivial_entangled_state(forest):
     pr11 = p1100 * alph00 + p1111 * alph11
     # calculate Z^{\otimes 2} expectation, and error of the mean
     z_expectation = (pr00 + pr11) - (pr01 + pr10)
-    simulated_stddev = np.sqrt((1 - z_expectation ** 2) / num_shots)
+    simulated_std_err = np.sqrt((1 - z_expectation ** 2) / num_shots)
     # compare against simulated results
     np.testing.assert_allclose(result_expectation, z_expectation, atol=2e-2)
-    np.testing.assert_allclose(result_stddev, simulated_stddev, atol=2e-2)
+    np.testing.assert_allclose(result_std_err, simulated_std_err, atol=2e-2)
 
 
 def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
@@ -1772,16 +1772,16 @@ def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
     num_shots = 10000
 
     expectations = []
-    stddevs = []
+    std_errs = []
 
     for _ in range(num_simulations):
         expt_results = list(measure_observables(qc, tomo_expt, n_shots=num_shots))
         expectations.append([res.expectation for res in expt_results])
-        stddevs.append([res.stddev for res in expt_results])
+        std_errs.append([res.std_err for res in expt_results])
     expectations = np.array(expectations)
-    stddevs = np.array(stddevs)
+    std_errs = np.array(std_errs)
     result_expectation = np.mean(expectations, axis=0)
-    result_stddev = np.mean(stddevs, axis=0)
+    result_std_err = np.mean(std_errs, axis=0)
 
     # calculate amplitudes squared of pure state
     alph00 = (np.cos(theta1 / 2) * np.cos(theta2 / 2)) ** 2
@@ -1790,10 +1790,10 @@ def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
     alph11 = (np.sin(theta1 / 2) * np.sin(theta2 / 2)) ** 2
     # calculate Z^{\otimes 2} expectation, and error of the mean
     expected_expectation = (alph00 + alph11) - (alph01 + alph10)
-    expected_stddev = np.sqrt(np.var(expectations))
+    expected_std_err = np.sqrt(np.var(expectations))
     # compare against simulated results
     np.testing.assert_allclose(result_expectation, expected_expectation, atol=2e-2)
-    np.testing.assert_allclose(result_stddev, expected_stddev, atol=2e-2)
+    np.testing.assert_allclose(result_std_err, expected_std_err, atol=2e-2)
 
 
 def _point_state_fidelity_estimate(v, dim=2):


### PR DESCRIPTION
Resolves Issue #864. Also introduces a few other minor cosmetic changes:

- Changes the name of the optional argument `readout_symmetrize` to `symmetrize_readout` in `measure_observables(..)`, to make it read more similar to the optional argument `calibrate_readout`
- Updates the warning message in `_exhaustive_symmetrization` to use f-strings instead of the old way of using `format`