### PR TITLE
Remove requirements used for RAM-style sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changelog
 
 ### Improvements and Changes
 
+-  The ProtoQuil restrictions built in to PyQVM have been removed
+   (@ecpeterson, gh-874).
+
 ### Bugfixes
 
 -   The `MemoryReference` warnings from have been removed from the unit

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -155,16 +155,7 @@ def _vet_program(program):
     new_prog = program.copy_everything_except_instructions()
 
     for instr in program:
-        if isinstance(instr, Pragma) or isinstance(instr, Declare):
-            new_prog += instr
-        elif isinstance(instr, Gate):
-            new_prog += instr
-        elif isinstance(instr, Measurement):
-            if instr.classical_reg is None:
-                raise NotRunAndMeasureProgramError("No measure-for-effect allowed")
-            new_prog += instr
-        else:
-            raise NotRunAndMeasureProgramError(f"Unsupported r_a_m instruction {instr}")
+        new_prog += instr
 
     return new_prog
 

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -140,26 +140,6 @@ class AbstractQuantumSimulator(ABC):
         """
 
 
-class NotRunAndMeasureProgramError(ValueError):
-    pass
-
-
-def _vet_program(program):
-    """
-    Check that this program is a series of quantum gates with terminal MEASURE instructions; pop
-    MEASURE instructions.
-
-    :param program: The program
-    :return: A new program with MEASURE instructions removed.
-    """
-    new_prog = program.copy_everything_except_instructions()
-
-    for instr in program:
-        new_prog += instr
-
-    return new_prog
-
-
 class PyQVM(QAM):
     def __init__(self, n_qubits, quantum_simulator_type: Type[AbstractQuantumSimulator] = None,
                  seed=None,
@@ -218,8 +198,6 @@ class PyQVM(QAM):
         else:
             program = executable
 
-        program = _vet_program(program)
-        
         # initialize program counter
         self.program = program
         self.program_counter = 0
@@ -270,7 +248,7 @@ class PyQVM(QAM):
         return self
 
     def read_memory(self, *, region_name: str):
-        return self.ram[region_name]
+        return np.asarray(self._memory_results[region_name])
 
     def find_label(self, label: Label):
         """
@@ -457,7 +435,7 @@ class PyQVM(QAM):
 
     def execute(self, program: Program):
         """
-        Execute a one outer loop of a program on the QVM.
+        Execute one outer loop of a program on the QVM.
 
         Note that the QAM is stateful. Subsequent calls to :py:func:`execute` will not
         automatically reset the wavefunction or the classical RAM. If this is desired,

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -144,7 +144,7 @@ class NotRunAndMeasureProgramError(ValueError):
     pass
 
 
-def _make_ram_program(program):
+def _vet_program(program):
     """
     Check that this program is a series of quantum gates with terminal MEASURE instructions; pop
     MEASURE instructions.
@@ -153,49 +153,20 @@ def _make_ram_program(program):
     :return: A new program with MEASURE instructions removed.
     """
     new_prog = program.copy_everything_except_instructions()
-    last_qubit_operation = {}
-    times_qubit_measured = defaultdict(lambda: 0)
-    ro_size = None
-    qubit_to_ram = {}
 
     for instr in program:
-        if isinstance(instr, Pragma):
-            new_prog += instr
-        elif isinstance(instr, Declare):
-            if instr.name == 'ro':
-                if instr.memory_type != 'BIT':
-                    raise NotRunAndMeasureProgramError("The readout register `ro` "
-                                                       "must be of type BIT")
-                ro_size = instr.memory_size
+        if isinstance(instr, Pragma) or isinstance(instr, Declare):
             new_prog += instr
         elif isinstance(instr, Gate):
-            for qubit in instr.qubits:
-                last_qubit_operation[qubit.index] = 'gate'
             new_prog += instr
         elif isinstance(instr, Measurement):
             if instr.classical_reg is None:
                 raise NotRunAndMeasureProgramError("No measure-for-effect allowed")
-            if instr.classical_reg.name != 'ro':
-                raise NotRunAndMeasureProgramError("The readout register must be named `ro`, "
-                                                   "not {}".format(instr.classical_reg.name))
-            last_qubit_operation[instr.qubit.index] = 'measure'
-            times_qubit_measured[instr.qubit.index] += 1
-            qubit_to_ram[instr.qubit.index] = instr.classical_reg.offset
+            new_prog += instr
         else:
             raise NotRunAndMeasureProgramError(f"Unsupported r_a_m instruction {instr}")
 
-    for q, lqo in last_qubit_operation.items():
-        if lqo != 'measure':
-            raise NotRunAndMeasureProgramError(f"Qubit {q}'s last operation is a gate")
-
-    for q, tqm in times_qubit_measured.items():
-        if tqm > 1:
-            raise NotRunAndMeasureProgramError(f"Qubit {q} is measured {tqm} times")
-
-    if ro_size is None:
-        raise NotRunAndMeasureProgramError("Please declare a readout register")
-
-    return new_prog, qubit_to_ram, ro_size
+    return new_prog
 
 
 class PyQVM(QAM):
@@ -256,12 +227,8 @@ class PyQVM(QAM):
         else:
             program = executable
 
-        try:
-            program, self._qubit_to_ram, self._ro_size = _make_ram_program(program)
-        except NotRunAndMeasureProgramError as e:
-            raise ValueError("PyQVM can only run run-and-measure style programs: {}"
-                             .format(e))
-
+        program = _vet_program(program)
+        
         # initialize program counter
         self.program = program
         self.program_counter = 0
@@ -269,6 +236,15 @@ class PyQVM(QAM):
 
         # clear RAM, although it's not strictly clear if this should happen here
         self.ram = {}
+        # if we're clearing RAM, we ought to clear the WF too
+        self.wf_simulator.reset()
+
+        # grab the gate definitions for future use
+        self.defined_gates = list()
+        for dg in self.program.defined_gates:
+            if dg.parameters is not None and len(dg.parameters) > 0:
+                raise NotImplementedError("PyQVM does not support parameterized DEFGATEs")
+            self.defined_gates[dg.name] = dg.matrix
 
         self.status = 'loaded'
         return self
@@ -281,31 +257,20 @@ class PyQVM(QAM):
 
     def run(self):
         self.status = 'running'
-        assert self._qubit_to_ram is not None
-        assert self._ro_size is not None
+        p = self.program
 
-        # TODO: why are DEFGATEs not just included in the list of instructions?
-        for dg in self.program.defined_gates:
-            if dg.parameters is not None and len(dg.parameters) > 0:
-                raise NotImplementedError("PyQVM does not support parameterized DEFGATEs")
-            self.defined_gates[dg.name] = dg.matrix
+        self._memory_results = {}
+        for n in range(0, self.program.num_shots):
+            self.wf_simulator.reset()
+            self.execute(p)
+            for name in self.ram.keys():
+                if name not in self._memory_results:
+                    self._memory_results[name] = list()
+                self._memory_results[name].append(self.ram[name])
 
-        halted = len(self.program) == 0
-        while not halted:
-            halted = self.transition()
+        # TODO: this will need to be removed in merge conflict with #873
+        self._bitstrings = self._memory_results['ro']
 
-        bitstrings = self.wf_simulator.sample_bitstrings(self.program.num_shots)
-
-        n_shots = self.program.num_shots
-        self.ram['ro'] = np.zeros((n_shots, self._ro_size), dtype=int)
-        for q in range(bitstrings.shape[1]):
-            if q in self._qubit_to_ram:
-                ram_offset = self._qubit_to_ram[q]
-                self.ram['ro'][:, ram_offset] = bitstrings[:, q]
-
-        # Finally, we RESET the system because it isn't mandated yet that programs
-        # contain RESET instructions.
-        self.wf_simulator.reset()
         return self
 
     def wait(self):
@@ -501,7 +466,7 @@ class PyQVM(QAM):
 
     def execute(self, program: Program):
         """
-        Execute a program on the QVM.
+        Execute a one outer loop of a program on the QVM.
 
         Note that the QAM is stateful. Subsequent calls to :py:func:`execute` will not
         automatically reset the wavefunction or the classical RAM. If this is desired,
@@ -509,11 +474,6 @@ class PyQVM(QAM):
 
         :return: ``self`` to support method chaining.
         """
-        # TODO: why are DEFGATEs not just included in the list of instructions?
-        for dg in program.defined_gates:
-            if dg.parameters is not None:
-                raise NotImplementedError("PyQVM does not support parameterized DEFGATEs")
-            self.defined_gates[dg.name] = dg.matrix
 
         # initialize program counter
         self.program = program

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -233,7 +233,7 @@ class PyQVM(QAM):
             self.execute(self.program)
             for name in self.ram.keys():
                 self._memory_results.setdefault(name, list())
-                self._memory_results.append(self.ram[name])
+                self._memory_results[name].append(self.ram[name])
 
         # TODO: this will need to be removed in merge conflict with #873
         self._bitstrings = self._memory_results['ro']

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -240,7 +240,7 @@ class PyQVM(QAM):
         self.wf_simulator.reset()
 
         # grab the gate definitions for future use
-        self.defined_gates = list()
+        self.defined_gates = dict()
         for dg in self.program.defined_gates:
             if dg.parameters is not None and len(dg.parameters) > 0:
                 raise NotImplementedError("PyQVM does not support parameterized DEFGATEs")

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -226,16 +226,14 @@ class PyQVM(QAM):
 
     def run(self):
         self.status = 'running'
-        p = self.program
 
         self._memory_results = {}
-        for n in range(0, self.program.num_shots):
+        for _ in range(self.program.num_shots):
             self.wf_simulator.reset()
-            self.execute(p)
+            self.execute(self.program)
             for name in self.ram.keys():
-                if name not in self._memory_results:
-                    self._memory_results[name] = list()
-                self._memory_results[name].append(self.ram[name])
+                self._memory_results.setdefault(name, list())
+                self._memory_results.append(self.ram[name])
 
         # TODO: this will need to be removed in merge conflict with #873
         self._bitstrings = self._memory_results['ro']

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -101,15 +101,13 @@ def test_run_pyqvm_noiseless():
         device=device,
         compiler=DummyCompiler()
     )
-    bitstrings = qc.run(
-        Program(
-            H(0),
+    prog = Program(H(0),
             CNOT(0, 1),
-            CNOT(1, 2),
-            MEASURE(0, MemoryReference("ro", 0)),
-            MEASURE(1, MemoryReference("ro", 1)),
-            MEASURE(2, MemoryReference("ro", 2))).wrap_in_numshots_loop(1000)
-    )
+            CNOT(1, 2))
+    ro = prog.declare('ro', 'BIT', 3)
+    for q in range(3):
+        prog += MEASURE(q, ro[q])
+    bitstrings = qc.run(prog.wrap_in_numshots_loop(1000))
 
     assert bitstrings.shape == (1000, 3)
     parity = np.sum(bitstrings, axis=1) % 3
@@ -124,15 +122,13 @@ def test_run_pyqvm_noisy():
         device=device,
         compiler=DummyCompiler()
     )
-    bitstrings = qc.run(
-        Program(
-            H(0),
+    prog = Program(H(0),
             CNOT(0, 1),
-            CNOT(1, 2),
-            MEASURE(0, MemoryReference("ro", 0)),
-            MEASURE(1, MemoryReference("ro", 1)),
-            MEASURE(2, MemoryReference("ro", 2))).wrap_in_numshots_loop(1000)
-    )
+            CNOT(1, 2))
+    ro = prog.declare('ro', 'BIT', 3)
+    for q in range(3):
+        prog += MEASURE(q, ro[q])
+    bitstrings = qc.run(prog.wrap_in_numshots_loop(1000))
 
     assert bitstrings.shape == (1000, 3)
     parity = np.sum(bitstrings, axis=1) % 3

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -101,9 +101,7 @@ def test_run_pyqvm_noiseless():
         device=device,
         compiler=DummyCompiler()
     )
-    prog = Program(H(0),
-            CNOT(0, 1),
-            CNOT(1, 2))
+    prog = Program(H(0), CNOT(0, 1), CNOT(1, 2))
     ro = prog.declare('ro', 'BIT', 3)
     for q in range(3):
         prog += MEASURE(q, ro[q])
@@ -122,9 +120,7 @@ def test_run_pyqvm_noisy():
         device=device,
         compiler=DummyCompiler()
     )
-    prog = Program(H(0),
-            CNOT(0, 1),
-            CNOT(1, 2))
+    prog = Program(H(0), CNOT(0, 1), CNOT(1, 2))
     ro = prog.declare('ro', 'BIT', 3)
     for q in range(3):
         prog += MEASURE(q, ro[q])


### PR DESCRIPTION
This PR removes the requirements enforced in PyQVM that let it _always_ do efficient `run_and_measure`-style sampling of bitstrings.

On reflection, it might be desirable to offer a separate pathway that does do `run_and_measure`-style sampling, rather than remove it outright. I'll return to this before making this a real PR.