### PR TITLE
Bump version to 2.7.1 for a patch release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,14 +11,11 @@ services:
     alias: quilc
     command: ["-R"]
 
-
 test:
   tags:
     - github
   script:
-    - export QVM_URL='http://qvm:5000'
-    - export QUILC_URL='tcp://quilc:5555'
-    - tox -e py36
+    - QVM_URL='http://qvm:5000' QUILC_URL='tcp://quilc:5555' tox -e py36
 
 style:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,9 @@ test:
   tags:
     - github
   script:
-    - QVM_URL='http://qvm:5000' QUILC_URL='tcp://quilc:5555' tox -e py36
+    - export QVM_URL='http://qvm:5000'
+    - export QUILC_URL='tcp://quilc:5555'
+    - tox -e py36
 
 style:
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,15 +9,15 @@ services:
     command: ["-S"]
   - name: rigetti/quilc
     alias: quilc
-    command: ["-S"]
+    command: ["-R"]
 
 
 test:
   tags:
     - github
   script:
-    - export QVM_URL="http://qvm:5000"
-    - export COMPILER_URL='http://quilc:6000'
+    - export QVM_URL='http://qvm:5000'
+    - export QUILC_URL='tcp://quilc:5555'
     - tox -e py36
 
 style:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 A library for easily generating Quil programs to be executed using the Rigetti Forest platform.
 pyQuil is licensed under the [Apache 2.0 license](https://github.com/rigetti/pyQuil/blob/master/LICENSE).
 
-[![Build Status](https://semaphoreci.com/api/v1/rigetti/pyquil/branches/master/badge.svg)](https://semaphoreci.com/rigetti/pyquil)
-[![Documentation Status](https://readthedocs.org/projects/pyquil/badge/?version=latest)](http://pyquil.readthedocs.io/en/latest/?badge=latest)
 [![pipeline status](https://gitlab.com/rigetti/forest/pyquil/badges/master/pipeline.svg)](https://gitlab.com/rigetti/forest/pyquil/commits/master)
+[![Build Status](https://semaphoreci.com/api/v1/rigetti/pyquil/branches/master/shields_badge.svg)](https://semaphoreci.com/rigetti/pyquil)
+[![Documentation Status](https://readthedocs.org/projects/pyquil/badge/?version=latest)](http://pyquil.readthedocs.io/en/latest/?badge=latest)
+
 
 **Please note: To make full use of our SDK, in addition to installing
 pyQuil, you will need to have installed quilc and the QVM (compiler

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+v2.7.1 (April 30, 2019)
+-----------------------
+
+Bugfixes:
+
+- The changes to operator estimation (gh-870, gh-896) were not made in a backwards-compatible
+  fashion, and therefore this patch release aims to remedy that. Going forward, there will be
+  much more stringent requirements around backwards compatibility and deprecation.
+
+
 v2.7 (April 29, 2019)
 ---------------------
 

--- a/pyquil/__init__.py
+++ b/pyquil/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.7.0"
+__version__ = "2.7.1"
 
 from pyquil.quil import Program
 from pyquil.api import list_quantum_computers, get_qc

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -766,17 +766,17 @@ class ExperimentResult:
         warnings.warn("'stddev' has been renamed to 'std_err'")
         return self.std_err
 
-    def set_stddev(self, value):
+    def set_stddev(self, value: Union[float, complex]):
         warnings.warn("'stddev' has been renamed to 'std_err'")
         object.__setattr__(self, 'std_err', value)
 
     stddev = property(get_stddev, set_stddev)
 
-    def get_raw_stddev(self) -> Union[float, complex]:
+    def get_raw_stddev(self) -> float:
         warnings.warn("'raw_stddev' has been renamed to 'raw_std_err'")
         return self.raw_std_err
 
-    def set_raw_stddev(self, value):
+    def set_raw_stddev(self, value: float):
         warnings.warn("'raw_stddev' has been renamed to 'raw_std_err'")
         object.__setattr__(self, 'raw_std_err', value)
 
@@ -786,7 +786,7 @@ class ExperimentResult:
         warnings.warn("'calibration_stddev' has been renamed to 'calibration_std_err'")
         return self.calibration_std_err
 
-    def set_calibration_stddev(self, value):
+    def set_calibration_stddev(self, value: Union[float, complex]):
         warnings.warn("'calibration_stddev' has been renamed to 'calibration_std_err'")
         object.__setattr__(self, 'calibration_std_err', value)
 

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -272,7 +272,8 @@ class TomographyExperiment:
 
     def __init__(self,
                  settings: Union[List[ExperimentSetting], List[List[ExperimentSetting]]],
-                 program: Program):
+                 program: Program,
+                 qubits: List[int] = None):
         if len(settings) == 0:
             settings = []
         else:
@@ -282,6 +283,10 @@ class TomographyExperiment:
 
         self._settings = settings  # type: List[List[ExperimentSetting]]
         self.program = program
+        if qubits is not None:
+            warnings.warn("The 'qubits' parameter has been deprecated and will be removed"
+                          "in a future release of pyquil")
+        self.qubits = qubits
 
     def __len__(self):
         return len(self._settings)

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -714,13 +714,78 @@ class ExperimentResult:
 
     setting: ExperimentSetting
     expectation: Union[float, complex]
-    std_err: Union[float, complex]
     total_counts: int
+    std_err: Union[float, complex] = None
     raw_expectation: Union[float, complex] = None
     raw_std_err: float = None
     calibration_expectation: Union[float, complex] = None
     calibration_std_err: Union[float, complex] = None
     calibration_counts: int = None
+
+    def __init__(self, setting: ExperimentSetting,
+                 expectation: Union[float, complex],
+                 total_counts: int,
+                 stddev: Union[float, complex] = None,
+                 std_err: Union[float, complex] = None,
+                 raw_expectation: Union[float, complex] = None,
+                 raw_stddev: float = None,
+                 raw_std_err: float = None,
+                 calibration_expectation: Union[float, complex] = None,
+                 calibration_stddev: Union[float, complex] = None,
+                 calibration_std_err: Union[float, complex] = None,
+                 calibration_counts: int = None):
+
+        object.__setattr__(self, 'setting', setting)
+        object.__setattr__(self, 'expectation', expectation)
+        object.__setattr__(self, 'total_counts', total_counts)
+        object.__setattr__(self, 'raw_expectation', raw_expectation)
+        object.__setattr__(self, 'calibration_expectation', calibration_expectation)
+        object.__setattr__(self, 'calibration_counts', calibration_counts)
+
+        if stddev is not None:
+            warnings.warn("'stddev' has been renamed to 'std_err'")
+            std_err = stddev
+        object.__setattr__(self, 'std_err', std_err)
+
+        if raw_stddev is not None:
+            warnings.warn("'raw_stddev' has been renamed to 'raw_std_err'")
+            raw_std_err = raw_stddev
+        object.__setattr__(self, 'raw_std_err', raw_std_err)
+
+        if calibration_stddev is not None:
+            warnings.warn("'calibration_stddev' has been renamed to 'calibration_std_err'")
+            calibration_std_err = calibration_stddev
+        object.__setattr__(self, 'calibration_std_err', calibration_std_err)
+
+    def get_stddev(self) -> Union[float, complex]:
+        warnings.warn("'stddev' has been renamed to 'std_err'")
+        return self.std_err
+
+    def set_stddev(self, value):
+        warnings.warn("'stddev' has been renamed to 'std_err'")
+        object.__setattr__(self, 'std_err', value)
+
+    stddev = property(get_stddev, set_stddev)
+
+    def get_raw_stddev(self) -> Union[float, complex]:
+        warnings.warn("'raw_stddev' has been renamed to 'raw_std_err'")
+        return self.raw_std_err
+
+    def set_raw_stddev(self, value):
+        warnings.warn("'raw_stddev' has been renamed to 'raw_std_err'")
+        object.__setattr__(self, 'raw_std_err', value)
+
+    raw_stddev = property(get_raw_stddev, set_raw_stddev)
+
+    def get_calibration_stddev(self) -> Union[float, complex]:
+        warnings.warn("'calibration_stddev' has been renamed to 'calibration_std_err'")
+        return self.calibration_std_err
+
+    def set_calibration_stddev(self, value):
+        warnings.warn("'calibration_stddev' has been renamed to 'calibration_std_err'")
+        object.__setattr__(self, 'calibration_std_err', value)
+
+    calibration_stddev = property(get_calibration_stddev, set_calibration_stddev)
 
     def __str__(self):
         return f'{self.setting}: {self.expectation} +- {self.std_err}'

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -761,7 +761,7 @@ def test_exhaustive_symmetrization_1q(forest):
 def test_exhaustive_symmetrization_2q(forest):
     qc = get_qc('9q-qvm')
     qubs = [5, 7]
-    n_shots = 2000
+    n_shots = 4000
     p = Program()
     p5_00, p5_11 = 0.90, 0.80
     p7_00, p7_11 = 0.99, 0.77

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -195,7 +195,7 @@ def test_measure_observables(forest):
     assert len(gsuite) == 3 * 3  # can get all the terms with I for free in this case
 
     qc = get_qc('2q-qvm')
-    for res in measure_observables(qc, gsuite, n_shots=500):
+    for res in measure_observables(qc, gsuite, n_shots=1000):
         if res.setting.out_operator in [sI(), sZ(0), sZ(1), sZ(0) * sZ(1)]:
             assert np.abs(res.expectation) > 0.9
         else:
@@ -265,7 +265,7 @@ def test_no_complex_coeffs(forest):
     qc = get_qc('2q-qvm')
     suite = TomographyExperiment([ExperimentSetting(sI(), 1.j * sY(0))], program=Program(X(0)))
     with pytest.raises(ValueError):
-        res = list(measure_observables(qc, suite, n_shots=500))
+        res = list(measure_observables(qc, suite, n_shots=1000))
 
 
 def test_max_weight_operator_1():
@@ -536,7 +536,7 @@ def test_stats_from_measurements():
     bs_results = np.array([[0, 1] * 10])
     d_qub_idx = {0: 0, 1: 1}
     setting = ExperimentSetting(TensorProductState(), sZ(0) * sX(1))
-    n_shots = 500
+    n_shots = 1000
 
     obs_mean, obs_var = _stats_from_measurements(bs_results, d_qub_idx, setting, n_shots)
     assert obs_mean == -1.0
@@ -573,7 +573,7 @@ def test_measure_observables_uncalibrated_asymmetric_readout(forest):
     p = Program()
     p00, p11 = 0.90, 0.80
     p.define_noisy_readout(0, p00=p00, p11=p11)
-    runs = 50
+    runs = 25
     expt_list = [expt1, expt2, expt3]
     tomo_expt = TomographyExperiment(settings=expt_list * runs, program=p)
     expected_expectation_z_basis = 2 * p00 - 1
@@ -581,7 +581,7 @@ def test_measure_observables_uncalibrated_asymmetric_readout(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=500,
+                                                  tomo_expt, n_shots=1000,
                                                   symmetrize_readout=None,
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
@@ -599,7 +599,7 @@ def test_measure_observables_uncalibrated_symmetric_readout(forest):
     p = Program()
     p00, p11 = 0.90, 0.80
     p.define_noisy_readout(0, p00=p00, p11=p11)
-    runs = 50
+    runs = 25
     expt_list = [expt1, expt2, expt3]
     tomo_expt = TomographyExperiment(settings=expt_list * runs, program=p)
     expected_symm_error = (p00 + p11) / 2
@@ -608,7 +608,7 @@ def test_measure_observables_uncalibrated_symmetric_readout(forest):
     uncalibr_e = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=500,
+                                                  tomo_expt, n_shots=1000,
                                                   calibrate_readout=None)):
         uncalibr_e[idx] = res.expectation
 
@@ -627,11 +627,11 @@ def test_measure_observables_calibrated_symmetric_readout(forest):
     p.define_noisy_readout(0, p00=0.99, p11=0.80)
     tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=p)
 
-    num_simulations = 50
+    num_simulations = 25
 
     expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
         expectations.append([res.expectation for res in expt_results])
     expectations = np.array(expectations)
     results = np.mean(expectations, axis=0)
@@ -650,12 +650,12 @@ def test_measure_observables_result_zero_symmetrization_calibration(forest):
     p.define_noisy_readout(0, p00=p00, p11=p11)
     tomo_expt = TomographyExperiment(settings=expt_settings, program=p)
 
-    num_simulations = 50
+    num_simulations = 25
 
     expectations = []
     raw_expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
         expectations.append([res.expectation for res in expt_results])
         raw_expectations.append([res.raw_expectation for res in expt_results])
     expectations = np.array(expectations)
@@ -677,11 +677,11 @@ def test_measure_observables_result_zero_no_noisy_readout(forest):
     p = Program()
     tomo_expt = TomographyExperiment(settings=expt_settings, program=p)
 
-    num_simulations = 50
+    num_simulations = 25
 
     expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500,
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
                                                 symmetrize_readout=None,
                                                 calibrate_readout=None))
         expectations.append([res.expectation for res in expt_results])
@@ -702,12 +702,12 @@ def test_measure_observables_result_zero_no_symm_calibr(forest):
     p.define_noisy_readout(0, p00=p00, p11=p11)
     tomo_expt = TomographyExperiment(settings=expt_settings, program=p)
 
-    num_simulations = 50
+    num_simulations = 25
 
     expectations = []
     expected_result = (p00 * 0.5 + (1 - p11) * 0.5) - ((1 - p00) * 0.5 + p11 * 0.5)
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500,
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
                                                 symmetrize_readout=None,
                                                 calibrate_readout=None))
         expectations.append([res.expectation for res in expt_results])
@@ -719,7 +719,7 @@ def test_measure_observables_result_zero_no_symm_calibr(forest):
 def test_measure_observables_2q_readout_error_one_measured(forest):
     # 2q readout errors, but only 1 qubit measured
     qc = get_qc('9q-qvm')
-    runs = 50
+    runs = 25
     qubs = [0, 1]
     expt = ExperimentSetting(TensorProductState(plusZ(qubs[0]) * plusZ(qubs[1])), sZ(qubs[0]))
     p = Program()
@@ -733,7 +733,7 @@ def test_measure_observables_2q_readout_error_one_measured(forest):
 
     for idx, res in enumerate(measure_observables(qc,
                                                   tomo_experiment,
-                                                  n_shots=500)):
+                                                  n_shots=1000)):
         raw_e[idx] = res.raw_expectation
         obs_e[idx] = res.expectation
         cal_e[idx] = res.calibration_expectation
@@ -746,7 +746,7 @@ def test_measure_observables_2q_readout_error_one_measured(forest):
 def test_exhaustive_symmetrization_1q(forest):
     qc = get_qc('9q-qvm')
     qubs = [5]
-    n_shots = 500
+    n_shots = 1000
     p = Program()
     p00, p11 = 0.90, 0.80
     p.define_noisy_readout(5, p00, p11)
@@ -833,11 +833,11 @@ def test_expectations_sic0(forest):
     expt3 = ExperimentSetting(SIC0(0), sZ(0))
     tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=Program())
 
-    num_simulations = 50
+    num_simulations = 25
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=500):
+        for res in measure_observables(qc, tomo_expt, n_shots=1000):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -854,11 +854,11 @@ def test_expectations_sic1(forest):
     expt3 = ExperimentSetting(SIC1(0), sZ(0))
     tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=Program())
 
-    num_simulations = 50
+    num_simulations = 25
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=500):
+        for res in measure_observables(qc, tomo_expt, n_shots=1000):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -875,11 +875,11 @@ def test_expectations_sic2(forest):
     expt3 = ExperimentSetting(SIC2(0), sZ(0))
     tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=Program())
 
-    num_simulations = 50
+    num_simulations = 25
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=500):
+        for res in measure_observables(qc, tomo_expt, n_shots=1000):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -898,11 +898,11 @@ def test_expectations_sic3(forest):
     expt3 = ExperimentSetting(SIC3(0), sZ(0))
     tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=Program())
 
-    num_simulations = 50
+    num_simulations = 25
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=500):
+        for res in measure_observables(qc, tomo_expt, n_shots=1000):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -975,7 +975,7 @@ def test_measure_observables_grouped_expts(forest):
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=500):
+        for res in measure_observables(qc, tomo_expt, n_shots=1000):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -1018,7 +1018,7 @@ def test_bit_flip_channel_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1056,7 +1056,7 @@ def test_dephasing_channel_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1096,7 +1096,7 @@ def test_depolarizing_channel_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1130,7 +1130,7 @@ def test_unitary_channel_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1171,7 +1171,7 @@ def test_bit_flip_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1211,7 +1211,7 @@ def test_dephasing_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1253,7 +1253,7 @@ def test_depolarizing_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1289,7 +1289,7 @@ def test_unitary_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1346,7 +1346,7 @@ def test_2q_unitary_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1371,7 +1371,7 @@ def test_measure_1q_observable_raw_expectation(forest):
 
     raw_expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
         raw_expectations.append([res.raw_expectation for res in expt_results])
     raw_expectations = np.array(raw_expectations)
     result = np.mean(raw_expectations, axis=0)
@@ -1393,7 +1393,7 @@ def test_measure_1q_observable_raw_variance(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 500
+    num_shots = 1000
 
     raw_std_errs = []
     for _ in range(num_simulations):
@@ -1422,7 +1422,7 @@ def test_measure_1q_observable_calibration_expectation(forest):
 
     calibration_expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
         calibration_expectations.append([res.calibration_expectation for res in expt_results])
     calibration_expectations = np.array(calibration_expectations)
     result = np.mean(calibration_expectations, axis=0)
@@ -1444,7 +1444,7 @@ def test_measure_1q_observable_calibration_variance(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 500
+    num_shots = 1000
 
     raw_std_errs = []
     for _ in range(num_simulations):
@@ -1481,7 +1481,7 @@ def test_uncalibrated_asymmetric_readout_nontrivial_1q_state(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=500,
+                                                  tomo_expt, n_shots=1000,
                                                   symmetrize_readout=None,
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
@@ -1511,7 +1511,7 @@ def test_uncalibrated_symmetric_readout_nontrivial_1q_state(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=500,
+                                                  tomo_expt, n_shots=1000,
                                                   symmetrize_readout='exhaustive',
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
@@ -1539,7 +1539,7 @@ def test_calibrated_symmetric_readout_nontrivial_1q_state(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=500,
+                                                  tomo_expt, n_shots=1000,
                                                   symmetrize_readout='exhaustive',
                                                   calibrate_readout='plus-eig')):
         expect_arr[idx] = res.expectation
@@ -1562,7 +1562,7 @@ def test_measure_2q_observable_raw_statistics(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 500
+    num_shots = 1000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1607,7 +1607,7 @@ def test_raw_statistics_2q_nontrivial_nonentangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 500
+    num_shots = 1000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1675,7 +1675,7 @@ def test_raw_statistics_2q_nontrivial_entangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 500
+    num_shots = 1000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1732,7 +1732,7 @@ def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 500
+    num_shots = 1000
 
     expectations = []
     std_errs = []
@@ -1786,7 +1786,7 @@ def test_bit_flip_state_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1818,7 +1818,7 @@ def test_dephasing_state_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1852,7 +1852,7 @@ def test_depolarizing_state_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1880,7 +1880,7 @@ def test_unitary_state_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1914,7 +1914,7 @@ def test_bit_flip_state_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1947,7 +1947,7 @@ def test_dephasing_state_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1982,7 +1982,7 @@ def test_depolarizing_state_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -2011,7 +2011,7 @@ def test_unitary_state_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=500):
+        for res in measure_observables(qc, process_exp, n_shots=1000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -733,7 +733,7 @@ def test_measure_observables_2q_readout_error_one_measured(forest):
 
     for idx, res in enumerate(measure_observables(qc,
                                                   tomo_experiment,
-                                                  n_shots=2000)):
+                                                  n_shots=4000)):
         raw_e[idx] = res.raw_expectation
         obs_e[idx] = res.expectation
         cal_e[idx] = res.calibration_expectation
@@ -1348,7 +1348,7 @@ def test_2q_unitary_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=2000):
+        for res in measure_observables(qc, process_exp, n_shots=4000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1564,7 +1564,7 @@ def test_measure_2q_observable_raw_statistics(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 2000
+    num_shots = 4000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1609,7 +1609,7 @@ def test_raw_statistics_2q_nontrivial_nonentangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 2000
+    num_shots = 4000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1677,7 +1677,7 @@ def test_raw_statistics_2q_nontrivial_entangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 2000
+    num_shots = 4000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1734,7 +1734,7 @@ def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 2000
+    num_shots = 4000
 
     expectations = []
     std_errs = []

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -195,7 +195,7 @@ def test_measure_observables(forest):
     assert len(gsuite) == 3 * 3  # can get all the terms with I for free in this case
 
     qc = get_qc('2q-qvm')
-    for res in measure_observables(qc, gsuite, n_shots=10_000):
+    for res in measure_observables(qc, gsuite, n_shots=500):
         if res.setting.out_operator in [sI(), sZ(0), sZ(1), sZ(0) * sZ(1)]:
             assert np.abs(res.expectation) > 0.9
         else:
@@ -265,7 +265,7 @@ def test_no_complex_coeffs(forest):
     qc = get_qc('2q-qvm')
     suite = TomographyExperiment([ExperimentSetting(sI(), 1.j * sY(0))], program=Program(X(0)))
     with pytest.raises(ValueError):
-        res = list(measure_observables(qc, suite))
+        res = list(measure_observables(qc, suite, n_shots=500))
 
 
 def test_max_weight_operator_1():
@@ -536,7 +536,7 @@ def test_stats_from_measurements():
     bs_results = np.array([[0, 1] * 10])
     d_qub_idx = {0: 0, 1: 1}
     setting = ExperimentSetting(TensorProductState(), sZ(0) * sX(1))
-    n_shots = 1000
+    n_shots = 500
 
     obs_mean, obs_var = _stats_from_measurements(bs_results, d_qub_idx, setting, n_shots)
     assert obs_mean == -1.0
@@ -581,7 +581,7 @@ def test_measure_observables_uncalibrated_asymmetric_readout(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=1000,
+                                                  tomo_expt, n_shots=500,
                                                   symmetrize_readout=None,
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
@@ -608,7 +608,7 @@ def test_measure_observables_uncalibrated_symmetric_readout(forest):
     uncalibr_e = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=1000,
+                                                  tomo_expt, n_shots=500,
                                                   calibrate_readout=None)):
         uncalibr_e[idx] = res.expectation
 
@@ -631,7 +631,7 @@ def test_measure_observables_calibrated_symmetric_readout(forest):
 
     expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500))
         expectations.append([res.expectation for res in expt_results])
     expectations = np.array(expectations)
     results = np.mean(expectations, axis=0)
@@ -655,7 +655,7 @@ def test_measure_observables_result_zero_symmetrization_calibration(forest):
     expectations = []
     raw_expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500))
         expectations.append([res.expectation for res in expt_results])
         raw_expectations.append([res.raw_expectation for res in expt_results])
     expectations = np.array(expectations)
@@ -681,7 +681,7 @@ def test_measure_observables_result_zero_no_noisy_readout(forest):
 
     expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500,
                                                 symmetrize_readout=None,
                                                 calibrate_readout=None))
         expectations.append([res.expectation for res in expt_results])
@@ -707,7 +707,7 @@ def test_measure_observables_result_zero_no_symm_calibr(forest):
     expectations = []
     expected_result = (p00 * 0.5 + (1 - p11) * 0.5) - ((1 - p00) * 0.5 + p11 * 0.5)
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500,
                                                 symmetrize_readout=None,
                                                 calibrate_readout=None))
         expectations.append([res.expectation for res in expt_results])
@@ -733,7 +733,7 @@ def test_measure_observables_2q_readout_error_one_measured(forest):
 
     for idx, res in enumerate(measure_observables(qc,
                                                   tomo_experiment,
-                                                  n_shots=1000)):
+                                                  n_shots=500)):
         raw_e[idx] = res.raw_expectation
         obs_e[idx] = res.expectation
         cal_e[idx] = res.calibration_expectation
@@ -746,7 +746,7 @@ def test_measure_observables_2q_readout_error_one_measured(forest):
 def test_exhaustive_symmetrization_1q(forest):
     qc = get_qc('9q-qvm')
     qubs = [5]
-    n_shots = 10000
+    n_shots = 500
     p = Program()
     p00, p11 = 0.90, 0.80
     p.define_noisy_readout(5, p00, p11)
@@ -761,7 +761,7 @@ def test_exhaustive_symmetrization_1q(forest):
 def test_exhaustive_symmetrization_2q(forest):
     qc = get_qc('9q-qvm')
     qubs = [5, 7]
-    n_shots = 10000
+    n_shots = 1000
     p = Program()
     p5_00, p5_11 = 0.90, 0.80
     p7_00, p7_11 = 0.99, 0.77
@@ -833,11 +833,11 @@ def test_expectations_sic0(forest):
     expt3 = ExperimentSetting(SIC0(0), sZ(0))
     tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=Program())
 
-    num_simulations = 100
+    num_simulations = 50
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+        for res in measure_observables(qc, tomo_expt, n_shots=500):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -854,11 +854,11 @@ def test_expectations_sic1(forest):
     expt3 = ExperimentSetting(SIC1(0), sZ(0))
     tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=Program())
 
-    num_simulations = 100
+    num_simulations = 50
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+        for res in measure_observables(qc, tomo_expt, n_shots=500):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -875,11 +875,11 @@ def test_expectations_sic2(forest):
     expt3 = ExperimentSetting(SIC2(0), sZ(0))
     tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=Program())
 
-    num_simulations = 100
+    num_simulations = 50
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+        for res in measure_observables(qc, tomo_expt, n_shots=500):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -898,11 +898,11 @@ def test_expectations_sic3(forest):
     expt3 = ExperimentSetting(SIC3(0), sZ(0))
     tomo_expt = TomographyExperiment(settings=[expt1, expt2, expt3], program=Program())
 
-    num_simulations = 100
+    num_simulations = 50
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+        for res in measure_observables(qc, tomo_expt, n_shots=500):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -971,11 +971,11 @@ def test_measure_observables_grouped_expts(forest):
     # and use this to create a TomographyExperiment suite
     tomo_expt = TomographyExperiment(settings=expt_settings, program=Program())
 
-    num_simulations = 100
+    num_simulations = 25
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+        for res in measure_observables(qc, tomo_expt, n_shots=500):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -1014,11 +1014,11 @@ def test_bit_flip_channel_fidelity(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1052,11 +1052,11 @@ def test_dephasing_channel_fidelity(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1092,11 +1092,11 @@ def test_depolarizing_channel_fidelity(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1126,11 +1126,11 @@ def test_unitary_channel_fidelity(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1167,11 +1167,11 @@ def test_bit_flip_channel_fidelity_readout_error(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1207,11 +1207,11 @@ def test_dephasing_channel_fidelity_readout_error(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1249,11 +1249,11 @@ def test_depolarizing_channel_fidelity_readout_error(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1285,11 +1285,11 @@ def test_unitary_channel_fidelity_readout_error(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1342,11 +1342,11 @@ def test_2q_unitary_channel_fidelity_readout_error(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=expt_list, program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1367,11 +1367,11 @@ def test_measure_1q_observable_raw_expectation(forest):
     p.define_noisy_readout(0, p00=p00, p11=p11)
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
-    num_simulations = 100
+    num_simulations = 25
 
     raw_expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500))
         raw_expectations.append([res.raw_expectation for res in expt_results])
     raw_expectations = np.array(raw_expectations)
     result = np.mean(raw_expectations, axis=0)
@@ -1392,8 +1392,8 @@ def test_measure_1q_observable_raw_variance(forest):
     p.define_noisy_readout(0, p00=p00, p11=p11)
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
-    num_simulations = 100
-    num_shots = 1000
+    num_simulations = 25
+    num_shots = 500
 
     raw_std_errs = []
     for _ in range(num_simulations):
@@ -1418,11 +1418,11 @@ def test_measure_1q_observable_calibration_expectation(forest):
     p.define_noisy_readout(0, p00=p00, p11=p11)
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
-    num_simulations = 100
+    num_simulations = 25
 
     calibration_expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=500))
         calibration_expectations.append([res.calibration_expectation for res in expt_results])
     calibration_expectations = np.array(calibration_expectations)
     result = np.mean(calibration_expectations, axis=0)
@@ -1443,8 +1443,8 @@ def test_measure_1q_observable_calibration_variance(forest):
     p.define_noisy_readout(0, p00=p00, p11=p11)
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
-    num_simulations = 100
-    num_shots = 1000
+    num_simulations = 25
+    num_shots = 500
 
     raw_std_errs = []
     for _ in range(num_simulations):
@@ -1469,7 +1469,7 @@ def test_uncalibrated_asymmetric_readout_nontrivial_1q_state(forest):
     # pick some random (but sufficiently large) asymmetric readout errors
     p00, p11 = np.random.uniform(0.7, 0.99, size=2)
     p.define_noisy_readout(0, p00=p00, p11=p11)
-    runs = 50
+    runs = 25
     expt_list = [expt]
     tomo_expt = TomographyExperiment(settings=expt_list * runs, program=p)
     # calculate expected expectation value
@@ -1481,7 +1481,7 @@ def test_uncalibrated_asymmetric_readout_nontrivial_1q_state(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=1000,
+                                                  tomo_expt, n_shots=500,
                                                   symmetrize_readout=None,
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
@@ -1498,7 +1498,7 @@ def test_uncalibrated_symmetric_readout_nontrivial_1q_state(forest):
     # pick some random (but sufficiently large) asymmetric readout errors
     p00, p11 = np.random.uniform(0.7, 0.99, size=2)
     p.define_noisy_readout(0, p00=p00, p11=p11)
-    runs = 50
+    runs = 25
     expt_list = [expt]
     tomo_expt = TomographyExperiment(settings=expt_list * runs, program=p)
     # calculate expected expectation value
@@ -1511,7 +1511,7 @@ def test_uncalibrated_symmetric_readout_nontrivial_1q_state(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=1000,
+                                                  tomo_expt, n_shots=500,
                                                   symmetrize_readout='exhaustive',
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
@@ -1528,7 +1528,7 @@ def test_calibrated_symmetric_readout_nontrivial_1q_state(forest):
     # pick some random (but sufficiently large) asymmetric readout errors
     p00, p11 = np.random.uniform(0.7, 0.99, size=2)
     p.define_noisy_readout(0, p00=p00, p11=p11)
-    runs = 50
+    runs = 25
     expt_list = [expt]
     tomo_expt = TomographyExperiment(settings=expt_list * runs, program=p)
     # calculate expected expectation value
@@ -1539,7 +1539,7 @@ def test_calibrated_symmetric_readout_nontrivial_1q_state(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=1000,
+                                                  tomo_expt, n_shots=500,
                                                   symmetrize_readout='exhaustive',
                                                   calibrate_readout='plus-eig')):
         expect_arr[idx] = res.expectation
@@ -1561,8 +1561,8 @@ def test_measure_2q_observable_raw_statistics(forest):
     p.define_noisy_readout(1, p00=q00, p11=q11)
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
-    num_simulations = 100
-    num_shots = 1000
+    num_simulations = 25
+    num_shots = 500
 
     raw_expectations = []
     raw_std_errs = []
@@ -1606,8 +1606,8 @@ def test_raw_statistics_2q_nontrivial_nonentangled_state(forest):
     p.define_noisy_readout(1, p00=q00, p11=q11)
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
-    num_simulations = 100
-    num_shots = 1000
+    num_simulations = 25
+    num_shots = 500
 
     raw_expectations = []
     raw_std_errs = []
@@ -1674,8 +1674,8 @@ def test_raw_statistics_2q_nontrivial_entangled_state(forest):
     p.define_noisy_readout(1, p00=q00, p11=q11)
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
-    num_simulations = 100
-    num_shots = 1000
+    num_simulations = 25
+    num_shots = 500
 
     raw_expectations = []
     raw_std_errs = []
@@ -1731,8 +1731,8 @@ def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
     p.define_noisy_readout(1, p00=q00, p11=q11)
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
-    num_simulations = 100
-    num_shots = 10000
+    num_simulations = 25
+    num_shots = 500
 
     expectations = []
     std_errs = []
@@ -1782,11 +1782,11 @@ def test_bit_flip_state_fidelity(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=[expt], program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1814,11 +1814,11 @@ def test_dephasing_state_fidelity(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=[expt], program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1848,11 +1848,11 @@ def test_depolarizing_state_fidelity(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=[expt], program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1876,11 +1876,11 @@ def test_unitary_state_fidelity(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=[expt], program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1910,11 +1910,11 @@ def test_bit_flip_state_fidelity_readout_error(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=[expt], program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1943,11 +1943,11 @@ def test_dephasing_state_fidelity_readout_error(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=[expt], program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1978,11 +1978,11 @@ def test_depolarizing_state_fidelity_readout_error(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=[expt], program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -2007,11 +2007,11 @@ def test_unitary_state_fidelity_readout_error(forest):
     # prepare TomographyExperiment
     process_exp = TomographyExperiment(settings=[expt], program=p)
     # list to store experiment results
-    num_expts = 100
+    num_expts = 25
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=500):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -195,7 +195,7 @@ def test_measure_observables(forest):
     assert len(gsuite) == 3 * 3  # can get all the terms with I for free in this case
 
     qc = get_qc('2q-qvm')
-    for res in measure_observables(qc, gsuite, n_shots=1000):
+    for res in measure_observables(qc, gsuite, n_shots=2000):
         if res.setting.out_operator in [sI(), sZ(0), sZ(1), sZ(0) * sZ(1)]:
             assert np.abs(res.expectation) > 0.9
         else:
@@ -265,7 +265,7 @@ def test_no_complex_coeffs(forest):
     qc = get_qc('2q-qvm')
     suite = TomographyExperiment([ExperimentSetting(sI(), 1.j * sY(0))], program=Program(X(0)))
     with pytest.raises(ValueError):
-        res = list(measure_observables(qc, suite, n_shots=1000))
+        res = list(measure_observables(qc, suite, n_shots=2000))
 
 
 def test_max_weight_operator_1():
@@ -536,7 +536,7 @@ def test_stats_from_measurements():
     bs_results = np.array([[0, 1] * 10])
     d_qub_idx = {0: 0, 1: 1}
     setting = ExperimentSetting(TensorProductState(), sZ(0) * sX(1))
-    n_shots = 1000
+    n_shots = 2000
 
     obs_mean, obs_var = _stats_from_measurements(bs_results, d_qub_idx, setting, n_shots)
     assert obs_mean == -1.0
@@ -581,7 +581,7 @@ def test_measure_observables_uncalibrated_asymmetric_readout(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=1000,
+                                                  tomo_expt, n_shots=2000,
                                                   symmetrize_readout=None,
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
@@ -608,7 +608,7 @@ def test_measure_observables_uncalibrated_symmetric_readout(forest):
     uncalibr_e = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=1000,
+                                                  tomo_expt, n_shots=2000,
                                                   calibrate_readout=None)):
         uncalibr_e[idx] = res.expectation
 
@@ -631,7 +631,7 @@ def test_measure_observables_calibrated_symmetric_readout(forest):
 
     expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=2000))
         expectations.append([res.expectation for res in expt_results])
     expectations = np.array(expectations)
     results = np.mean(expectations, axis=0)
@@ -655,7 +655,7 @@ def test_measure_observables_result_zero_symmetrization_calibration(forest):
     expectations = []
     raw_expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=2000))
         expectations.append([res.expectation for res in expt_results])
         raw_expectations.append([res.raw_expectation for res in expt_results])
     expectations = np.array(expectations)
@@ -681,7 +681,7 @@ def test_measure_observables_result_zero_no_noisy_readout(forest):
 
     expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=2000,
                                                 symmetrize_readout=None,
                                                 calibrate_readout=None))
         expectations.append([res.expectation for res in expt_results])
@@ -707,7 +707,7 @@ def test_measure_observables_result_zero_no_symm_calibr(forest):
     expectations = []
     expected_result = (p00 * 0.5 + (1 - p11) * 0.5) - ((1 - p00) * 0.5 + p11 * 0.5)
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000,
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=2000,
                                                 symmetrize_readout=None,
                                                 calibrate_readout=None))
         expectations.append([res.expectation for res in expt_results])
@@ -733,7 +733,7 @@ def test_measure_observables_2q_readout_error_one_measured(forest):
 
     for idx, res in enumerate(measure_observables(qc,
                                                   tomo_experiment,
-                                                  n_shots=1000)):
+                                                  n_shots=2000)):
         raw_e[idx] = res.raw_expectation
         obs_e[idx] = res.expectation
         cal_e[idx] = res.calibration_expectation
@@ -746,7 +746,7 @@ def test_measure_observables_2q_readout_error_one_measured(forest):
 def test_exhaustive_symmetrization_1q(forest):
     qc = get_qc('9q-qvm')
     qubs = [5]
-    n_shots = 1000
+    n_shots = 2000
     p = Program()
     p00, p11 = 0.90, 0.80
     p.define_noisy_readout(5, p00, p11)
@@ -761,7 +761,7 @@ def test_exhaustive_symmetrization_1q(forest):
 def test_exhaustive_symmetrization_2q(forest):
     qc = get_qc('9q-qvm')
     qubs = [5, 7]
-    n_shots = 1000
+    n_shots = 2000
     p = Program()
     p5_00, p5_11 = 0.90, 0.80
     p7_00, p7_11 = 0.99, 0.77
@@ -782,6 +782,8 @@ def test_exhaustive_symmetrization_2q(forest):
     assert np.isclose(frac7_0, expected_frac7_0, 2e-2)
 
 
+# TODO: gh-897
+@pytest.mark.skip
 def test_measure_observables_inherit_noise_errors(forest):
     qc = get_qc('3q-qvm')
     # specify simplest experiments
@@ -837,7 +839,7 @@ def test_expectations_sic0(forest):
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+        for res in measure_observables(qc, tomo_expt, n_shots=2000):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -858,7 +860,7 @@ def test_expectations_sic1(forest):
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+        for res in measure_observables(qc, tomo_expt, n_shots=2000):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -879,7 +881,7 @@ def test_expectations_sic2(forest):
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+        for res in measure_observables(qc, tomo_expt, n_shots=2000):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -902,7 +904,7 @@ def test_expectations_sic3(forest):
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+        for res in measure_observables(qc, tomo_expt, n_shots=2000):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -975,7 +977,7 @@ def test_measure_observables_grouped_expts(forest):
     results_unavged = []
     for _ in range(num_simulations):
         measured_results = []
-        for res in measure_observables(qc, tomo_expt, n_shots=1000):
+        for res in measure_observables(qc, tomo_expt, n_shots=2000):
             measured_results.append(res.expectation)
         results_unavged.append(measured_results)
 
@@ -1018,7 +1020,7 @@ def test_bit_flip_channel_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1056,7 +1058,7 @@ def test_dephasing_channel_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1096,7 +1098,7 @@ def test_depolarizing_channel_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1130,7 +1132,7 @@ def test_unitary_channel_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1171,7 +1173,7 @@ def test_bit_flip_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1211,7 +1213,7 @@ def test_dephasing_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1253,7 +1255,7 @@ def test_depolarizing_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1289,7 +1291,7 @@ def test_unitary_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1346,7 +1348,7 @@ def test_2q_unitary_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1371,7 +1373,7 @@ def test_measure_1q_observable_raw_expectation(forest):
 
     raw_expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=2000))
         raw_expectations.append([res.raw_expectation for res in expt_results])
     raw_expectations = np.array(raw_expectations)
     result = np.mean(raw_expectations, axis=0)
@@ -1393,7 +1395,7 @@ def test_measure_1q_observable_raw_variance(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 1000
+    num_shots = 2000
 
     raw_std_errs = []
     for _ in range(num_simulations):
@@ -1422,7 +1424,7 @@ def test_measure_1q_observable_calibration_expectation(forest):
 
     calibration_expectations = []
     for _ in range(num_simulations):
-        expt_results = list(measure_observables(qc, tomo_expt, n_shots=1000))
+        expt_results = list(measure_observables(qc, tomo_expt, n_shots=2000))
         calibration_expectations.append([res.calibration_expectation for res in expt_results])
     calibration_expectations = np.array(calibration_expectations)
     result = np.mean(calibration_expectations, axis=0)
@@ -1444,7 +1446,7 @@ def test_measure_1q_observable_calibration_variance(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 1000
+    num_shots = 2000
 
     raw_std_errs = []
     for _ in range(num_simulations):
@@ -1481,7 +1483,7 @@ def test_uncalibrated_asymmetric_readout_nontrivial_1q_state(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=1000,
+                                                  tomo_expt, n_shots=2000,
                                                   symmetrize_readout=None,
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
@@ -1511,7 +1513,7 @@ def test_uncalibrated_symmetric_readout_nontrivial_1q_state(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=1000,
+                                                  tomo_expt, n_shots=2000,
                                                   symmetrize_readout='exhaustive',
                                                   calibrate_readout=None)):
         expect_arr[idx] = res.expectation
@@ -1539,7 +1541,7 @@ def test_calibrated_symmetric_readout_nontrivial_1q_state(forest):
     expect_arr = np.zeros(runs * len(expt_list))
 
     for idx, res in enumerate(measure_observables(qc,
-                                                  tomo_expt, n_shots=1000,
+                                                  tomo_expt, n_shots=2000,
                                                   symmetrize_readout='exhaustive',
                                                   calibrate_readout='plus-eig')):
         expect_arr[idx] = res.expectation
@@ -1562,7 +1564,7 @@ def test_measure_2q_observable_raw_statistics(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 1000
+    num_shots = 2000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1607,7 +1609,7 @@ def test_raw_statistics_2q_nontrivial_nonentangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 1000
+    num_shots = 2000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1675,7 +1677,7 @@ def test_raw_statistics_2q_nontrivial_entangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 1000
+    num_shots = 2000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1732,7 +1734,7 @@ def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 1000
+    num_shots = 2000
 
     expectations = []
     std_errs = []
@@ -1786,7 +1788,7 @@ def test_bit_flip_state_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1818,7 +1820,7 @@ def test_dephasing_state_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1852,7 +1854,7 @@ def test_depolarizing_state_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1880,7 +1882,7 @@ def test_unitary_state_fidelity(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1914,7 +1916,7 @@ def test_bit_flip_state_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1947,7 +1949,7 @@ def test_dephasing_state_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1982,7 +1984,7 @@ def test_depolarizing_state_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -2011,7 +2013,7 @@ def test_unitary_state_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=1000):
+        for res in measure_observables(qc, process_exp, n_shots=2000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 


### PR DESCRIPTION
#870 and #896 are the main offenders. This PR also cuts down the running time of the operator estimation unit tests by about a factor of 3, so that they dont add 16 minutes to the build. However, there is chance they could fail now due to undersampling (I did my best to test, but it remains to be seen if my testing was thorough enough). In parallel, I have enabled the qvm- and quilc-related tests in Semaphore (the operator estimation tests fall in this bucket). I need to address #898 before they will start working in GitLab CI.