### PR TITLE
 Bump version to 2.7.2 for a patch release

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v2.7.2 (May 3, 2019)
+--------------------
+
+Bugfixes:
+
+- An additional backwards-incompatible change from gh-870 snuck through 2.7.1, and is
+  addressed in this patch release.
+
 v2.7.1 (April 30, 2019)
 -----------------------
 
@@ -9,7 +17,6 @@ Bugfixes:
 - The changes to operator estimation (gh-870, gh-896) were not made in a backwards-compatible
   fashion, and therefore this patch release aims to remedy that. Going forward, there will be
   much more stringent requirements around backwards compatibility and deprecation.
-
 
 v2.7 (April 29, 2019)
 ---------------------

--- a/pyquil/__init__.py
+++ b/pyquil/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 
 from pyquil.quil import Program
 from pyquil.api import list_quantum_computers, get_qc

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -6,9 +6,8 @@ import re
 import sys
 import warnings
 from json import JSONEncoder
-from math import pi
 from operator import mul
-from typing import List, Union, Iterable, Dict, Tuple
+from typing import List, Union, Iterable, Tuple, Optional
 
 import networkx as nx
 import numpy as np
@@ -17,9 +16,7 @@ from functools import reduce
 from pyquil import Program
 from pyquil.api import QuantumComputer
 from pyquil.gates import *
-from pyquil.paulis import (PauliSum, PauliTerm, commuting_sets, sI,
-                           term_with_coeff, is_identity)
-from pyquil.quilbase import (Measurement, Pragma, Gate)
+from pyquil.paulis import PauliTerm, sI, is_identity
 from math import pi
 
 if sys.version_info < (3, 7):
@@ -816,7 +813,8 @@ class ExperimentResult:
 def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperiment,
                         n_shots: int = 10000, progress_callback=None, active_reset=False,
                         symmetrize_readout: str = 'exhaustive',
-                        calibrate_readout: str = 'plus-eig'):
+                        calibrate_readout: str = 'plus-eig',
+                        readout_symmetrize: Optional[str] = None):
     """
     Measure all the observables in a TomographyExperiment.
 
@@ -845,6 +843,11 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
         eigenstate, which can be specified by setting this variable to 'plus-eig' (default value).
         The preceding symmetrization and this step together yield a more accurate estimation of the observable. Set to `None` if no calibration is desired.
     """
+    if readout_symmetrize is not None:
+        warnings.warn("'readout_symmetrize' has been renamed to 'symmetrize_readout'",
+                      DeprecationWarning)
+        symmetrize_readout = readout_symmetrize
+
     # calibration readout only works with symmetrization turned on
     if calibrate_readout is not None and symmetrize_readout is None:
         raise ValueError("Readout calibration only works with readout symmetrization turned on")

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from json import JSONEncoder
 from operator import mul
-from typing import List, Union, Iterable, Tuple, Optional
+from typing import List, Union, Iterable, Tuple, Optional, Dict
 
 import networkx as nx
 import numpy as np

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -733,7 +733,7 @@ def test_measure_observables_2q_readout_error_one_measured(forest):
 
     for idx, res in enumerate(measure_observables(qc,
                                                   tomo_experiment,
-                                                  n_shots=4000)):
+                                                  n_shots=5000)):
         raw_e[idx] = res.raw_expectation
         obs_e[idx] = res.expectation
         cal_e[idx] = res.calibration_expectation
@@ -761,7 +761,7 @@ def test_exhaustive_symmetrization_1q(forest):
 def test_exhaustive_symmetrization_2q(forest):
     qc = get_qc('9q-qvm')
     qubs = [5, 7]
-    n_shots = 4000
+    n_shots = 5000
     p = Program()
     p5_00, p5_11 = 0.90, 0.80
     p7_00, p7_11 = 0.99, 0.77
@@ -1348,7 +1348,7 @@ def test_2q_unitary_channel_fidelity_readout_error(forest):
     expts = []
     for _ in range(num_expts):
         expt_results = []
-        for res in measure_observables(qc, process_exp, n_shots=4000):
+        for res in measure_observables(qc, process_exp, n_shots=5000):
             expt_results.append(res.expectation)
         expts.append(expt_results)
 
@@ -1564,7 +1564,7 @@ def test_measure_2q_observable_raw_statistics(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 4000
+    num_shots = 5000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1609,7 +1609,7 @@ def test_raw_statistics_2q_nontrivial_nonentangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 4000
+    num_shots = 5000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1677,7 +1677,7 @@ def test_raw_statistics_2q_nontrivial_entangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 4000
+    num_shots = 5000
 
     raw_expectations = []
     raw_std_errs = []
@@ -1734,7 +1734,7 @@ def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest):
     tomo_expt = TomographyExperiment(settings=[expt], program=p)
 
     num_simulations = 25
-    num_shots = 4000
+    num_shots = 5000
 
     expectations = []
     std_errs = []


### PR DESCRIPTION
The `readout_symmetrize` change in #870 snuck past the 2.7.1 patch (#899).