### PR TITLE
Use Optional typing for some measure_observables params

### DIFF
--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -812,8 +812,8 @@ class ExperimentResult:
 
 def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperiment,
                         n_shots: int = 10000, progress_callback=None, active_reset=False,
-                        symmetrize_readout: str = 'exhaustive',
-                        calibrate_readout: str = 'plus-eig',
+                        symmetrize_readout: Optional[str] = 'exhaustive',
+                        calibrate_readout: Optional[str] = 'plus-eig',
                         readout_symmetrize: Optional[str] = None):
     """
     Measure all the observables in a TomographyExperiment.


### PR DESCRIPTION
`symmetrize_readout` and `calibrate_readout` are both optional arguments to `measure_observables` that can be `None` and have a very specific meaning when they do so. This change makes it clear that those inputs can be `type(None)` (previously, in python 2.x, `NoneType`) in principle.