### PR TITLE
Add QubitPlaceholder support to RESET, add ResetQubit support to address_qubits()

### DIFF
--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -443,18 +443,19 @@ manipulated by a CPU in a hybrid classical/quantum algorithm.
 """
 
 
-def RESET(qubit=None):
+def RESET(qubit_index=None):
     """
-    Reset all qubits or just a specific qubit at qubit_index.
+    Reset all qubits or just one specific qubit.
 
-    :param Optional[qubit] qubit: The qubit to reset.
+    :param Optional[qubit_index] qubit: The qubit to reset. This can be a qubit's index, a Qubit,
+        or a QubitPlaceholder.
         If None, reset all qubits.
     :returns: A Reset or ResetQubit Quil AST expression corresponding to a global or targeted
         reset, respectively.
     :rtype: Union[Reset, ResetQubit]
     """
-    if qubit is not None:
-        return ResetQubit(unpack_qubit(qubit))
+    if qubit_index is not None:
+        return ResetQubit(unpack_qubit(qubit_index))
     else:
         return Reset()
 

--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -447,8 +447,8 @@ def RESET(qubit_index=None):
     """
     Reset all qubits or just one specific qubit.
 
-    :param Optional[qubit_index] qubit: The qubit to reset. This can be a qubit's index, a Qubit,
-        or a QubitPlaceholder.
+    :param Optional[Union[integer_types, Qubit, QubitPlaceholder]] qubit_index: The qubit to reset.
+        This can be a qubit's index, a Qubit, or a QubitPlaceholder.
         If None, reset all qubits.
     :returns: A Reset or ResetQubit Quil AST expression corresponding to a global or targeted
         reset, respectively.

--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -443,18 +443,18 @@ manipulated by a CPU in a hybrid classical/quantum algorithm.
 """
 
 
-def RESET(qubit_index=None):
+def RESET(qubit=None):
     """
     Reset all qubits or just a specific qubit at qubit_index.
 
-    :param Optional[int] qubit_index: The address of the qubit to reset.
+    :param Optional[qubit] qubit: The qubit to reset.
         If None, reset all qubits.
     :returns: A Reset or ResetQubit Quil AST expression corresponding to a global or targeted
         reset, respectively.
     :rtype: Union[Reset, ResetQubit]
     """
-    if qubit_index is not None:
-        return ResetQubit(Qubit(qubit_index))
+    if qubit is not None:
+        return ResetQubit(unpack_qubit(qubit))
     else:
         return Reset()
 

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -786,12 +786,14 @@ def address_qubits(program, qubit_mapping=None):
 
     result = []
     for instr in program:
-        # Remap qubits on Gate and Measurement instructions
+        # Remap qubits on Gate, Measurement, and ResetQubit instructions
         if isinstance(instr, Gate):
             remapped_qubits = [qubit_mapping[q] for q in instr.qubits]
             result.append(Gate(instr.name, instr.params, remapped_qubits))
         elif isinstance(instr, Measurement):
             result.append(Measurement(qubit_mapping[instr.qubit], instr.classical_reg))
+        elif isinstance(instr, ResetQubit):
+            result.append(ResetQubit(qubit_mapping[instr.qubit]))
         elif isinstance(instr, Pragma):
             new_args = []
             for arg in instr.args:

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -975,6 +975,15 @@ def test_reset():
     p.reset()
     assert p.out() == "RESET 0\nRESET\n"
 
+    program = Program()
+    qubit = QubitPlaceholder()
+    program += X(qubit) # address_qubits() won't work unless there's a gate besides
+                        # RESET on a QubitPlaceholder, this is just here to make
+                        # addressing work
+    program += RESET(qubit)
+    program = address_qubits(program)
+    assert program.out() == "X 0\nRESET 0\n"
+
 
 def test_copy():
     prog1 = Program(

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -977,9 +977,11 @@ def test_reset():
 
     program = Program()
     qubit = QubitPlaceholder()
-    program += X(qubit) # address_qubits() won't work unless there's a gate besides
-                        # RESET on a QubitPlaceholder, this is just here to make
-                        # addressing work
+    # address_qubits() won't work unless there's a gate besides
+    # RESET on a QubitPlaceholder, this is just here to make
+    # addressing work
+    program += X(qubit) 
+
     program += RESET(qubit)
     program = address_qubits(program)
     assert program.out() == "X 0\nRESET 0\n"

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -980,7 +980,7 @@ def test_reset():
     # address_qubits() won't work unless there's a gate besides
     # RESET on a QubitPlaceholder, this is just here to make
     # addressing work
-    program += X(qubit) 
+    program += X(qubit)
 
     program += RESET(qubit)
     program = address_qubits(program)


### PR DESCRIPTION
This PR adds support for QubitPlaceholders (and Qubits in general) to the RESET instruction, which used to exclusively take a qubit index. Since QubitPlaceholders don't have indices during program construction, the RESET function wouldn't work with them.

This could be worked around by calling ResetQubit() to explicitly create a RESET instruction with the QubitPlaceholder as the target, but address_qubits() ignored ResetQubit instructions so they wouldn't be mapped to the assigned qubit indices. This PR fixes that too.