### PR TITLE
Raise RPCQ requirement to 2.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ six
 networkx >= 2.0.0
 
 # rigetti packages
-rpcq >= 2.5.0
+rpcq >= 2.5.1
 
 # test deps
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ six
 networkx >= 2.0.0
 
 # rigetti packages
-rpcq >= 2.2.1
+rpcq >= 2.5.0
 
 # test deps
 pytest

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'requests',
         'six',
         'networkx>=2.0.0',
-        'rpcq>=2.5.0',
+        'rpcq>=2.5.1',
 
         # dependency of contextvars, which we vendor
         'immutables==0.6',

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'requests',
         'six',
         'networkx>=2.0.0',
-        'rpcq>=2.2.1',
+        'rpcq>=2.5.0',
 
         # dependency of contextvars, which we vendor
         'immutables==0.6',


### PR DESCRIPTION
A backwards incompatible change was made to RPCQ for this
release. pyQuil >=2.7.0 will not work with RPCQ <2.5.0

Please add reviewers if they may need to know about this.