### PR TITLE
Fix missing modifiers in dagger()

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -576,23 +576,29 @@ class Program(object):
                 daggered.defgate(gate.name + suffix, gate.matrix.T.conj())
 
         for gate in reversed(self._instructions):
+            reversed_gate = None
+            qubits = [unpack_qubit(q) for q in gate.qubits]
             if gate.name in QUANTUM_GATES:
                 if gate.name == "S":
-                    daggered.inst(QUANTUM_GATES["PHASE"](-pi / 2, *gate.qubits))
+                    reversed_gate = Gate("PHASE", -pi / 2, qubits)
                 elif gate.name == "T":
-                    daggered.inst(QUANTUM_GATES["RZ"](pi / 4, *gate.qubits))
+                    reversed_gate = Gate("RZ", pi / 4, qubits)
                 elif gate.name == "ISWAP":
-                    daggered.inst(QUANTUM_GATES["PSWAP"](pi / 2, *gate.qubits))
+                    reversed_gate = Gate("PSWAP", pi / 2, qubits)
                 else:
                     negated_params = list(map(lambda x: -1 * x, gate.params))
-                    daggered.inst(QUANTUM_GATES[gate.name](*(negated_params + gate.qubits)))
+                    reversed_gate = Gate(gate.name, negated_params, qubits)
+                reversed_gate.modifiers = gate.modifiers
+                daggered.inst(reversed_gate)
             else:
                 if inv_dict is None or gate.name not in inv_dict:
                     gate_inv_name = gate.name + suffix
                 else:
                     gate_inv_name = inv_dict[gate.name]
 
-                daggered.inst(Gate(gate_inv_name, gate.params, gate.qubits))
+                reversed_gate = Gate(gate_inv_name, gate.params, qubits)
+                reversed_gate.modifiers = gate.modifiers
+                daggered.inst(reversed_gate)
 
         return daggered
 

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -580,11 +580,11 @@ class Program(object):
             qubits = [unpack_qubit(q) for q in gate.qubits]
             if gate.name in QUANTUM_GATES:
                 if gate.name == "S":
-                    reversed_gate = Gate("PHASE", -pi / 2, qubits)
+                    reversed_gate = Gate("PHASE", [-pi / 2], qubits)
                 elif gate.name == "T":
-                    reversed_gate = Gate("RZ", pi / 4, qubits)
+                    reversed_gate = Gate("RZ", [pi / 4], qubits)
                 elif gate.name == "ISWAP":
-                    reversed_gate = Gate("PSWAP", pi / 2, qubits)
+                    reversed_gate = Gate("PSWAP", [pi / 2], qubits)
                 else:
                     negated_params = list(map(lambda x: -1 * x, gate.params))
                     reversed_gate = Gate(gate.name, negated_params, qubits)

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -365,6 +365,7 @@ def test_dagger():
                                'CONTROLLED Y 0 1\n' \
                                'CONTROLLED X 0 1\n'
 
+
 def test_construction_syntax():
     p = Program().inst(X(0), Y(1), Z(0)).measure(0, 1)
     assert p.out() == ('DECLARE ro BIT[2]\n'

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -343,6 +343,27 @@ def test_dagger():
     p = Program(GPARAM(pi)(1, 2))
     assert p.dagger().out() == 'GPARAM-INV(pi) 1 2\n'
 
+    # ensure that modifiers are preserved https://github.com/rigetti/pyquil/pull/914
+    p = Program()
+    control = 0
+    target = 1
+    cnot_control = 2
+    p += X(target).controlled(control)
+    p += Y(target).controlled(control)
+    p += Z(target).controlled(control)
+    p += H(target).controlled(control)
+    p += S(target).controlled(control)
+    p += T(target).controlled(control)
+    p += PHASE(pi, target).controlled(control)
+    p += CNOT(cnot_control, target).controlled(control)
+    assert p.dagger().out() == 'CONTROLLED CNOT 0 2 1\n' \
+                               'CONTROLLED PHASE(-pi) 0 1\n' \
+                               'CONTROLLED RZ(pi/4) 0 1\n' \
+                               'CONTROLLED PHASE(-pi/2) 0 1\n' \
+                               'CONTROLLED H 0 1\n' \
+                               'CONTROLLED Z 0 1\n' \
+                               'CONTROLLED Y 0 1\n' \
+                               'CONTROLLED X 0 1\n'
 
 def test_construction_syntax():
     p = Program().inst(X(0), Y(1), Z(0)).measure(0, 1)


### PR DESCRIPTION
Hi all,

We ran into a problem where taking the adjoint of a controlled gate using the dagger() function would drop the CONTROLLED modifiers on the new inverted gate. This was a similar problem to #905, and based on the fix in #907, we figured out what needed to be changed in order to preserve the modifiers. This PR is a simple fix to the dagger() function that does exactly that.

We tested it on our implementation of Shor's algorithm and can confirm that it works there, but please review it and let me know if you see it breaking anything we didn't manage to test.