### PR TITLE
Fix inlinemath rendering in intro.rst + other small doc typos

### DIFF
--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -194,14 +194,14 @@ loop by following these steps:
 
 1. Declare a register called ``flag_register`` to use as a boolean test for looping.
 
-2. Initialize this register to ``1`` program so our while loop will execute. This is often called the
+2. Initialize this register to ``1``, so our while loop will execute. This is often called the
    *loop preamble* or *loop initialization*.
 
 3. Write the body of the loop in its own :py:class:`~pyquil.quil.Program`. This will be a
-   program that applies an :math:`X` gate followed by a :math:`H` gate on our
+   program that applies an :math:`X` gate followed by an :math:`H` gate on our
    qubit.
 
-4. Using the :py:func:`~pyquil.quil.Program.while_do` method to add control flow.
+4. Use the :py:func:`~pyquil.quil.Program.while_do` method to add control flow.
 
 .. code:: python
 
@@ -336,7 +336,7 @@ exponential of the Pauli term, i.e., :math:`\exp[-i\beta\sigma]`.  This is
 accomplished by constructing a parameterized Quil program that is evaluated
 when passed values for the coefficients of the angle :math:`\beta`.
 
-Related to exponentiating Pauli sums we provide utility functions for finding
+Related to exponentiating Pauli sums, we provide utility functions for finding
 the commuting subgroups of a Pauli sum and approximating the exponential with the
 Suzuki-Trotter approximation through fourth order.
 

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -9,7 +9,7 @@ Expectations for Program Contents
 The QPUs have much more limited natural gate sets than the standard gate set offered by pyQuil: on Rigetti QPUs, the
 gate operators are constrained to lie in ``RZ(θ)``, ``RX(k*π/2)``, and ``CZ``; and the
 gates are required to act on physically available hardware (for single-qubit gates, this means
-acting only on live qubits, and for qubit-pair gates, this means acting on neighboring qubits). However, as a programmer, it is often (though not always) desirable to to be able to write programs which don't take these details into account. These generally leads to more portable code if one isn't tied to a specific set of gates or QPU architecture.
+acting only on live qubits, and for qubit-pair gates, this means acting on neighboring qubits). However, as a programmer, it is often (though not always) desirable to to be able to write programs which don't take these details into account. This generally leads to more portable code if one isn't tied to a specific set of gates or QPU architecture.
 To ameliorate these limitations, the Rigetti software toolkit contains an optimizing compiler that
 translates arbitrary Quil to native Quil and native Quil to executables suitable for Rigetti
 hardware.
@@ -36,7 +36,8 @@ You can initialize a local ``quilc`` server by typing ``quilc -S`` into your ter
     ... - Launching quilc.
     ... - Spawning server at (tcp://*:5555) .
 
-To get a description of ``quilc``, and options and examples of its command line use, see :ref:`quilc_man`.
+To get a description of ``quilc`` and its options and examples of command line use, see the quilc `README
+<https://github.com/rigetti/quilc>`_ or type ``man quilc`` in your terminal.
 
 
 A ``QuantumComputer`` object supplied by the function ``pyquil.api.get_qc()`` comes equipped with a

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -368,7 +368,7 @@ mathjax_config = {
             'ket': ["\\left| #1 \\right\\rangle", 1],
             'bra': ["\\left\\langle #1 \\right|", 1],
             'braket': ["\\left\\langle #1 | #2 \\right\\rangle", 2],
-            'vec': ["\\text{vec}\\left(#1\\right)", 1],
+            'vect': ["\\text{vec}\\left(#1\\right)", 1],
             'tr': ["\\text{Tr}\\left(#1\\right)", 1]
         }
     }

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -38,16 +38,16 @@ Probabilistic Bits as Vector Spaces
 
 From an operational perspective, a bit is described by the results of
 measurements performed on it. Let the possible results of measuring a bit (0
-or 1) be represented by orthonormal basis vectors \\(\\vec{0}\\) and
-\\(\\vec{1}\\). We will call these vectors **outcomes**. These outcomes
+or 1) be represented by orthonormal basis vectors :math:`\vec{0}` and
+:math:`\vec{1}`. We will call these vectors **outcomes**. These outcomes
 span a two-dimensional vector space that represents a probabilistic bit.
 A probabilistic bit can be represented as a vector
 
 .. math::  \vec{v} = a\,\vec{0} + b\,\vec{1},
 
-where \\(a\\) represents the probability of the bit being 0 and \\(b\\)
+where :math:`a` represents the probability of the bit being 0 and :math:`b`
 represents the probability of the bit being 1. This clearly also
-requires that \\(a+b=1\\). In this picture the **system** (the
+requires that :math:`a+b=1`. In this picture the **system** (the
 probabilistic bit) is a two-dimensional real vector space and a
 **state** of a system is a particular vector in that vector space.
 
@@ -80,9 +80,9 @@ Given some state vector, like the one plotted above, we can find the
 probabilities associated with each outcome by projecting the vector onto
 the basis outcomes. This gives us the following rule:
 
-.. math::  \operatorname{Pr}(0) = \vec{v}^T.\vec{0} = a \\ \operatorname{Pr}(1) = \vec{v}^T.\vec{1} = b,
+.. math::  \operatorname{Pr}(0) = \vec{v}^T \cdot \vec{0} = a \\ \operatorname{Pr}(1) = \vec{v}^T \cdot \vec{1} = b,
 
-where Pr(0) and Pr(1) are the probabilities of the 0 and 1 outcomes
+where :math:`\operatorname{Pr}(0)` and :math:`\operatorname{Pr}(1)` are the probabilities of the 0 and 1 outcomes
 respectively.
 
 Dirac Notation
@@ -96,7 +96,7 @@ of the great theoretical physicist Paul Dirac, allows us to define
 
 Thus, we can rewrite our "measurement rule" in this notation as
 
-.. math::  Pr(0) = \langle v \vert 0 \rangle = a \\ Pr(1) = \langle v\vert 1 \rangle = b
+.. math::  \operatorname{Pr}(0) = \langle v \vert 0 \rangle = a \\ \operatorname{Pr}(1) = \langle v\vert 1 \rangle = b
 
 We will use this notation throughout the rest of this introduction.
 
@@ -113,9 +113,9 @@ programmers). Their states can be represented as
     |\,u\rangle = \frac{1}{2}|\,0_u\rangle + \frac{1}{2}|\,1_u\rangle \\
    |\,v\rangle = \frac{1}{2}|\,0_v\rangle + \frac{1}{2}|\,1_v\rangle,
 
-where \\(1\_u\\) represents the outcome 1 on coin \\(u\\). The
-**combined system** of the two coins has four possible outcomes \\(\\{
-0\_u0\_v,\\;0\_u1\_v,\\;1\_u0\_v,\\;1\_u1\_v \\}\\) that are the basis
+where :math:`1_u` represents the outcome 1 on coin :math:`u`. The
+**combined system** of the two coins has four possible outcomes :math:`\{
+0_u0_v,\;0_u1_v,\;1_u0_v,\;1_u1_v\}` that are the basis
 states of a larger four-dimensional vector space. The rule for
 constructing a **combined state** is to take the tensor product of
 individual states, e.g.
@@ -125,7 +125,7 @@ individual states, e.g.
 Then, the combined space is simply the space spanned by the tensor products
 of all pairs of basis vectors of the two smaller spaces.
 
-Similarly, the combined state for \\(n\\) such probabilistic bits is a vector of size \\(2^n\\) and is given by \\(\\bigotimes\_{i=0}^{n-1}\|\\,v\_i\\rangle\\). We will talk more about these larger spaces in the quantum case, but it is important to note that not all composite states can be written as tensor products of sub-states (e.g. consider the state \\(\\frac{1}{2}|\\,0\_u0\_v\\rangle + \\frac{1}{2}|\\,1\_u1\_v\\rangle\\)). The most general composite state of \\(n\\) probabilistic bits can be written as \\(\\sum\_{j=0}^{2^n - 1} a\_{j} (\\bigotimes\_{i=0}^{n-1}\|\\,b\_{ij}\\rangle\\)) where each \\(b\_{ij} \\in \\{0, 1\\}\\) and \\(a_j \\in \\mathbb{R}\\), i.e. as a linear combination (with real coefficients) of tensor products of basis states. Note that this still gives us \\(2^n\\) possible states.
+Similarly, the combined state for :math:`n` such probabilistic bits is a vector of size :math:`2^n` and is given by :math:`\bigotimes_{i=0}^{n-1}|\,v_i\rangle`. We will talk more about these larger spaces in the quantum case, but it is important to note that not all composite states can be written as tensor products of sub-states (e.g. consider the state :math:`\frac{1}{2}|\,0_u0_v\rangle + \frac{1}{2}|\,1_u1_v\rangle`). The most general composite state of :math:`n` probabilistic bits can be written as :math:`\sum_{j=0}^{2^n - 1} a_{j} (\bigotimes_{i=0}^{n-1}|\,b_{ij}\rangle` where each :math:`b_{ij} \in \{0, 1\}` and :math:`a_j \in \mathbb{R}`, i.e. as a linear combination (with real coefficients) of tensor products of basis states. Note that this still gives us :math:`2^n` possible states.
 
 Qubits
 ^^^^^^
@@ -136,8 +136,8 @@ it is measured. Similar to the previous section, a qubit can also be
 represented in a vector space, but with complex coefficients instead of
 real ones. A qubit **system** is a two-dimensional complex vector space,
 and the **state** of a qubit is a complex vector in that space. Again we
-will define a basis of outcomes \\(\\{\|\\,0\\rangle,
-\|\\,1\\rangle\\}\\) and let a generic qubit state be written as
+will define a basis of outcomes :math:`\{|\,0\rangle,
+|\,1\rangle\}` and let a generic qubit state be written as
 
 .. math:: \alpha |\,0\rangle + \beta |\,1\rangle.
 
@@ -147,7 +147,7 @@ rewrite the rule for outcomes in the following manner:
 
 .. math::  \operatorname{Pr}(0) = |\langle v\,|\,0 \rangle|^2 = |\alpha|^2 \\ \operatorname{Pr}(1) = |\langle v\,|\,1 \rangle|^2 = |\beta|^2,
 
-and as long as \\(\|\\alpha\|^2 + \|\\beta\|^2 = 1\\) we are able to
+and as long as :math:`|\alpha|^2 + |\beta|^2 = 1` we are able to
 recover acceptable probabilities for outcomes based on our new complex
 vector.
 
@@ -159,14 +159,13 @@ outcome of 0 is represented by:
 
 .. image:: images/bloch_1.png
 
-Notice that the two axes in the horizontal plane have been labeled \\(x\\)
-and \\(y\\), implying that \\(z\\) is the vertical axis (not labeled). Physicists
-use the convention that a qubit's \\(\\{\|\\,0\\rangle,
-\|\\,1\\rangle\\}\\) states are the
+Notice that the two axes in the horizontal plane have been labeled :math:`x`
+and :math:`y`, implying that :math:`z` is the vertical axis (not labeled). Physicists
+use the convention that a qubit's :math:`\{|\,0\rangle, |\,1\rangle\}` states are the
 positive and negative unit vectors along the z axis, respectively. These
 axes will be useful later in this document.
 
-Multiple qubits are represented in precisely the same way, by taking linear combinations (with complex coefficients, now) of tensor products of basis states. Thus \\(n\\) qubits have \\(2^n\\) possible states.
+Multiple qubits are represented in precisely the same way, by taking linear combinations (with complex coefficients, now) of tensor products of basis states. Thus :math:`n` qubits have :math:`2^n` possible states.
 
 An Important Distinction
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -418,8 +417,8 @@ called the Pauli operators:
 The Pauli matrices have a visual interpretation: they perform 180-degree rotations of
 qubit state vectors on the Bloch sphere. They operate about their respective axes
 as shown in the Bloch sphere depicted above. For example, the ``X`` gate performs a 180-degree
-rotation **about** the \\(x\\) axis. This explains the results of our code above: for a state vector
-initially in the +\\(z\\) direction, both ``X`` and ``Y`` gates will rotate it to -\\(z\\),
+rotation **about** the :math:`x` axis. This explains the results of our code above: for a state vector
+initially in the :math:`+z` direction, both ``X`` and ``Y`` gates will rotate it to :math:`-z`,
 and the ``Z`` gate will leave it unchanged.
 
 However, notice that while the ``X`` and ``Y`` gates produce the same outcome probabilities, they
@@ -512,8 +511,8 @@ Let's take a look at how we could use a ``CNOT`` gate in pyQuil.
 The ``CNOT`` gate does what its name implies: the state of the second qubit is flipped
 (negated) if and only if the state of the first qubit is 1 (true).
 
-Another two-qubit gate example is the ``SWAP`` gate, which swaps the \\( \|01\\rangle \\)
-and \\(\|10\\rangle \\) states:
+Another two-qubit gate example is the ``SWAP`` gate, which swaps the :math:`|01\rangle`
+and :math:`|10\rangle` states:
 
 .. math::
 
@@ -553,7 +552,7 @@ The Quantum Abstract Machine
 
 We now have enough background to introduce the programming model
 that underlies Quil. This is a hybrid quantum-classical model in which
-\\(N\\) qubits interact with \\(M\\) classical bits:
+:math:`N` qubits interact with :math:`M` classical bits:
 
 .. image:: images/qam.png
 
@@ -681,11 +680,10 @@ The following pyQuil code shows how we can use the Hadamard gate:
     {'0': 0.49999999999999989, '1': 0.49999999999999989}
 
 
-A qubit in this state will be measured half of the time in the \\( \|0\\rangle \\) state,
-and half of the time in the \\( \|1\\rangle \\) state. In a sense, this qubit truly is a
-random variable representing a
-coin. In fact, there are many wavefunctions that will give this same operational
-outcome. There is a continuous family of states of the form
+A qubit in this state will be measured half of the time in the :math:`|0\rangle` state,
+and half of the time in the :math:`|1\rangle` state. In a sense, this qubit truly is a
+random variable representing a coin. In fact, there are many wavefunctions that will give
+this same operational outcome. There is a continuous family of states of the form
 
 .. math::
 
@@ -741,9 +739,9 @@ pyQuil allows us to look at the wavefunction **after** a measurement as well:
 
 We can clearly see that measurement has an effect on the quantum state
 independent of what is stored classically. We begin in a state that has
-a 50-50 probability of being \\( \|0\\rangle \\) or \\( \|1\\rangle \\).
-After measurement, the state changes into being entirely in \\( \|0\\rangle \\)
-or entirely in \\( \|1\\rangle \\) according to which outcome was
+a 50-50 probability of being :math:`|0\rangle` or :math:`|1\rangle`.
+After measurement, the state changes into being entirely in :math:`|0\rangle`
+or entirely in :math:`|1\rangle` according to which outcome was
 obtained. This is the phenomenon referred to as the **collapse** of the wavefunction.
 Mathematically, the wavefunction is being projected onto the vector of
 the obtained outcome and subsequently rescaled to unit norm.
@@ -776,7 +774,7 @@ the obtained outcome and subsequently rescaled to unit norm.
 
 The above program prepares **entanglement** because, even though there are
 random outcomes, after every measurement both qubits are in the same state. They
-are either both \\( \|0\\rangle \\) or both \\( \|1\\rangle \\). This special kind of
+are either both :math:`|0\rangle` or both :math:`|1\rangle`. This special kind of
 correlation is part of what makes quantum mechanics so unique and powerful.
 
 

--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -884,7 +884,7 @@ where
    p(x') & = \sum_{x\in\mathcal{O}} p(x'|x) p(x)  \\
    & = \tr{\sum_{x\in \mathcal{O}} p(x'|x) \Pi_x \rho \Pi_x} \\
    & = \tr{\rho \sum_{x\in \mathcal{O}} p(x'|x)\Pi_x} \\
-   & = \tr{\rho E_x'}.
+   & = \tr{\rho E_{x'}}.
    \end{aligned}
 
 where we have exploited the cyclical property of the trace
@@ -900,7 +900,7 @@ that must sum to 1:
 
 .. math::
 
-   \sum_{x'\in\mathcal{O}'} E_x' = \sum_{x\in\mathcal{O}}\underbrace{\left[\sum_{x'\in\mathcal{O}'} p(x'|x)\right]}_{1}\Pi_x = \sum_{x\in\mathcal{O}}\Pi_x = 1.
+   \sum_{x'\in\mathcal{O}'} E_{x'} = \sum_{x\in\mathcal{O}}\underbrace{\left[\sum_{x'\in\mathcal{O}'} p(x'|x)\right]}_{1}\Pi_x = \sum_{x\in\mathcal{O}}\Pi_x = 1.
 
 The above result is a type of generalized **Bayes' theorem** that is
 extremely useful for this type of (slightly) generalized measurement and

--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -57,7 +57,7 @@ Quantum Gate Errors
 ~~~~~~~~~~~~~~~~~~~
 
 For a quantum gate given by its unitary operator :math:`U`, a "quantum gate error" describes the scenario in which the
-actually induces transformation deviates from :math:`\ket{\psi} \mapsto U\ket{\psi}`. There are two basic types of
+actually induced transformation deviates from :math:`\ket{\psi} \mapsto U\ket{\psi}`. There are two basic types of
 quantum gate errors:
 
 1. **coherent errors** are those that preserve the purity of the input
@@ -192,14 +192,14 @@ equation <https://en.wikipedia.org/wiki/Lindblad_equation>`__.
 Noisy Gates on the Rigetti QVM
 ------------------------------
 
-As of today, users of our Forest SDK can annotate their QUIL programs by
+As of today, users of our Forest SDK can annotate their Quil programs by
 certain pragma statements that inform the QVM that a particular gate on
 specific target qubits should be replaced by an imperfect realization
 given by a Kraus map.
 
 The QVM propagates **pure states** --- so how does it simulate noisy gates?
 It does so by yielding the correct outcomes **in the average over many
-executions of the QUIL program**: When the noisy version of a gate
+executions of the Quil program**: When the noisy version of a gate
 should be applied the QVM makes a random choice which Kraus operator is
 applied to the current state with a probability that ensures that the
 average over many executions is equivalent to the Kraus map. In
@@ -259,14 +259,14 @@ Getting Started
    matrices to obtain a very accurate noise model for a particular QPU.
 2. Define your Kraus operators as a list of numpy arrays
    ``kraus_ops = [K1, K2, ..., Km]``.
-3. For your QUIL program ``p``, call:
+3. For your Quil program ``p``, call:
 
    ::
 
        p.define_noisy_gate("MY_NOISY_GATE", [q1, q2], kraus_ops)
 
    where you should replace ``MY_NOISY_GATE`` with the gate of interest
-   and ``q1, q2`` the indices of the qubits.
+   and ``q1, q2`` with the indices of the qubits.
 
 **Scroll down for some examples!**
 
@@ -443,7 +443,7 @@ outcomes:
 
 The Kraus operators for this are given by
 
-.. raw:: latex
+.. math::
 
    \begin{align}
    K'_1(p,q) = K_1(p)\otimes K_1(q) \\
@@ -661,7 +661,7 @@ will want to use a compiler to do this step for you.
 Scan Over Noise Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-We perform a scan over three levels of noise each at 20 theta points.
+We perform a scan over three levels of noise, each at 20 theta points.
 
 Specifically, we investigate T1 values of 1, 3, and 10 us. By default,
 T2 = T1 / 2, 1 qubit gates take 50 ns, and 2 qubit gates take 150 ns.
@@ -784,9 +784,9 @@ The most general type of measurement performed on a single qubit at a
 single time can be characterized by some set :math:`\mathcal{O}` of
 measurement outcomes, e.g., in the simplest case
 :math:`\mathcal{O} = \{0, 1\}`, and some unnormalized quantum channels
-(see notebook on gate noise models) that encapsulate 1. the probability
-of that outcome 2. how the qubit state is affected conditional on the
-measurement outcome.
+(see notebook on gate noise models) that encapsulate: 1. the probability
+of that outcome, and 2. how the qubit state is affected conditional on
+the measurement outcome.
 
 Here the *outcome* is understood as classical information that has been
 extracted from the quantum system.
@@ -813,10 +813,10 @@ set of projectors any two members satisfy
 
 and for a *complete* set we additionally demand that
 :math:`\sum_{x\in\mathcal{O}} \Pi_x = 1`. Following our introduction to
-gate noise, we write quantum states as density matrices as this is more
+gate noise, we write quantum states as density matrices, as this is more
 general and in closer correspondence with classical probability theory.
 
-With these the probability of outcome :math:`x` is given by
+With these, the probability of outcome :math:`x` is given by
 :math:`p(x) = \tr{\Pi_x \rho \Pi_x} = \tr{\Pi_x^2 \rho} = \tr{\Pi_x \rho}`
 and the post measurement state is
 
@@ -827,8 +827,9 @@ and the post measurement state is
 which is the projection postulate applied to mixed states.
 
 If we were a sloppy quantum programmer and accidentally erased the
-measurement outcome then our best guess for the post measurement state
-would be given by something that looks an awful lot like a Kraus map:
+measurement outcome, then our best guess for the post measurement
+state would be given by something that looks an awful lot like a Kraus
+map:
 
 .. math::
 
@@ -905,9 +906,9 @@ that must sum to 1:
 The above result is a type of generalized **Bayes' theorem** that is
 extremely useful for this type of (slightly) generalized measurement and
 the family of operators :math:`\{E_{x'}| x' \in \mathcal{O}'\}` whose
-expectations give the probabilities is called a **positive operator
+expectations given the probabilities is called a **positive operator
 valued measure** (POVM). These operators are not generally orthogonal
-nor valid projection operators but they naturally arise in this
+nor valid projection operators, but they naturally arise in this
 scenario. This is not yet the most general type of measurement, but it
 will get us pretty far.
 
@@ -934,12 +935,12 @@ Working with Readout Noise
 --------------------------
 
 1. Come up with a good guess for your readout noise parameters
-   :math:`p(0|0)` and :math:`p(1|1)`, the off-diagonals then follow from
+   :math:`p(0|0)` and :math:`p(1|1)`; the off-diagonals then follow from
    the normalization of :math:`P_{x'|x}`. If your assignment fidelity
    :math:`F` is given, and you assume that the classical bit flip noise
    is roughly symmetric, then a good approximation is to set
    :math:`p(0|0)=p(1|1)=F`.
-2. For your QUIL program ``p``, and a qubit index ``q`` call:
+2. For your Quil program ``p`` and a qubit index ``q`` call:
 
    ::
 

--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -1162,7 +1162,7 @@ Uncorrupted probability for :math:`\left|000\right\rangle` and :math:`\left|111\
 As expected the outcomes ``000`` and ``111`` each have roughly
 probability :math:`1/2`.
 
-Corrupted probability for :math:`\left|011\right\rangle` and :math:`\left|100\right\rangle`
+Corrupted probability for :math:`\left|000\right\rangle` and :math:`\left|111\right\rangle`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: python
@@ -1177,7 +1177,7 @@ Corrupted probability for :math:`\left|011\right\rangle` and :math:`\left|100\ri
 The noise-corrupted outcome probabilities deviate significantly from
 their ideal values!
 
-Corrected probability for :math:`\left|011\right\rangle` and :math:`\left|100\right\rangle`
+Corrected probability for :math:`\left|000\right\rangle` and :math:`\left|111\right\rangle`
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: python

--- a/docs/source/qvm.rst
+++ b/docs/source/qvm.rst
@@ -20,7 +20,7 @@ Within pyQuil, there is a :py:class:`~pyquil.api.QVM` object and a :py:class:`~p
 the exposed APIs of the QVM and QPU servers, respectively.
 
 On this page, we'll learn a bit about the :ref:`QVM <qvm_use>` and :ref:`QPU <qpu>`. Then we will
-show you how to use them from pyQuil with a :ref:`quantum_computer`.
+show you how to use them from pyQuil with a :ref:`QuantumComputer <quantum_computer>` object.
 
 For information on constructing quantum programs, please refer back to :ref:`basics`.
 
@@ -419,8 +419,8 @@ Simulating the QPU using the QVM
 The :py:class:`~pyquil.api.QAM` methods are intended to be used in the same way, whether a QVM or QPU is being targeted.
 Everywhere on this page,
 you can swap out the type of the QAM (QVM <=> QPU) and you will still
-get reasonable results back. As long as the topology of the devices are the same, programs compiled and ran on the QVM
-will be able to run on the QPU and visa-versa. Since :py:class:`~pyquil.api.QuantumComputer` is built on the ``QAM``
+get reasonable results back. As long as the topologies of the devices are the same, programs compiled and run on the QVM
+will be able to run on the QPU and vice versa. Since :py:class:`~pyquil.api.QuantumComputer` is built on the ``QAM``
 abstract class, its methods will also work for both QAM implementations.
 
 This makes the QVM a powerful tool for testing quantum programs before executing them on the QPU.

--- a/examples/ReadoutNoise.ipynb
+++ b/examples/ReadoutNoise.ipynb
@@ -500,7 +500,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Corrupted probability for $\\left|011\\right\\rangle$ and $\\left|100\\right\\rangle$"
+    "### Corrupted probability for $\\left|000\\right\\rangle$ and $\\left|111\\right\\rangle$"
    ]
   },
   {
@@ -537,7 +537,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Corrected probability for $\\left|011\\right\\rangle$ and $\\left|100\\right\\rangle$"
+    "### Corrected probability for $\\left|000\\right\\rangle$ and $\\left|111\\right\\rangle$"
    ]
   },
   {


### PR DESCRIPTION
Description
-----------

Fixes for small typos and the like that I encountered while reading over the docs.

Here is a screenshot of http://docs.rigetti.com/en/stable/intro.html showing broken inlinemath rendering.

<img alt="inline math before" src="https://drive.google.com/uc?id=1xQSYo5aXZtFcfhxVsq2ZbzahTTL_sQ5d">

https://drive.google.com/open?id=1xQSYo5aXZtFcfhxVsq2ZbzahTTL_sQ5d

I am not sure why this is broken, since the MathJax config includes `"inlineMath": [["$", "$"], ["\\(", "\\)"]]`. I think maybe the `\\(`s in the rst source file need an extra escape. In any case, `intro.rst` was the only file still using latex-style `\\(..\\)` delimiters, so I just switched everything over to `:math:` style. Screenshot of same section after these changes:

<img alt="inline math after" src="https://drive.google.com/uc?id=1rUdnlmmR24Fq4qJ48zVygehqvCrFqaM0">

https://drive.google.com/open?id=1rUdnlmmR24Fq4qJ48zVygehqvCrFqaM0