### PR TITLE
Fix sphinx warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W # treat warnings as errors
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,10 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+clean:
+	rm -rf "$(BUILDDIR)" "$(SOURCEDIR)/apidocs/autogen"
+
+.PHONY: clean help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/source/apidocs/wavefunction.rst
+++ b/docs/source/apidocs/wavefunction.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Wavefunction Methods
 ====================
 

--- a/docs/source/apidocs/wavefunction.rst
+++ b/docs/source/apidocs/wavefunction.rst
@@ -5,6 +5,7 @@ Wavefunction Methods
 
 .. currentmodule:: pyquil.api
 .. autoclass:: pyquil.api.WavefunctionSimulator
+    :noindex:
 
     .. rubric:: Methods
     .. autosummary::
@@ -18,7 +19,6 @@ Wavefunction Methods
 
 
 .. currentmodule:: pyquil.wavefunction
-
 .. autoclass:: pyquil.wavefunction.Wavefunction
 
     .. rubric:: Attributes and Methods

--- a/docs/source/apidocs/wavefunction.rst
+++ b/docs/source/apidocs/wavefunction.rst
@@ -24,7 +24,6 @@ Wavefunction Methods
         :toctree: autogen
         :template: autosumm.rst
 
-        ~Wavefunction.amplitudes
         ~Wavefunction.probabilities
         ~Wavefunction.pretty_print
         ~Wavefunction.pretty_print_probabilities

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -124,7 +124,7 @@ Declaring Memory
 ~~~~~~~~~~~~~~~~
 
 Classical memory regions must be explicitly requested and named by a Quil program using the ``DECLARE`` directive.
-Details about the Quil directive can be found in :ref:`declare`.
+Details about can be found in the :ref:`migration guide <quil_2_declare>` or in :py:func:`pyquil.quil.Program.declare`.
 
 In pyQuil, we declare memory with the ``.declare`` method on a ``Program``. Let's inspect the function signature
 
@@ -286,7 +286,7 @@ Parametric compilation allows one to compile the program ansatz just once. Makin
 memory regions, we can load values to the parametric gates at execution time, after compilation.
 Taking the compiler out of the execution loop for programs like this offers a huge performance
 improvement compared to compiling the program each time a parameter update is required.
-(Some more details about this and an example are found :ref:`here <parametric>`.)
+(Some more details about this and an example are found :doc:`here <migration3-declare>`.)
 
 The first step is to build our parametric program, which functions like a template for all the precise programs we will
 run. Below we create a simple example program to illustrate, which puts the qubit onto the equator of the Bloch Sphere and then

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -21,7 +21,7 @@ Interacting with the Compiler
 After :ref:`downloading the SDK <sdkinstall>`, the Quil Compiler, ``quilc`` is available on your local machine.
 You can initialize a local ``quilc`` server by typing ``quilc -S`` into your terminal. You should see the following message.
 
-.. code:: python
+.. code:: text
 
     $ quilc -S
     +-----------------+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -357,7 +357,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'https://docs.python.org/3/': None}
 
 mathjax_config = {
     'TeX': {

--- a/docs/source/migration.ipynb
+++ b/docs/source/migration.ipynb
@@ -264,7 +264,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### The old way\n",
+    "### The old way\n",
     "When running many programs it was often possible to reduce runtime by batching jobs and exploiting the async queue. The following example does not work in pyQuil 2 but gives a sketch about how this would have worked.\n",
     "\n",
     "```python\n",
@@ -281,7 +281,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### The not-quite-new way\n",
+    "### The not-quite-new way\n",
     "\n",
     "Since this is such an important use case, there have been many changes to support running many programs as quickly as possible. We demonstrate an equivalent, synchronous version of the example given above. **To idiomatically run this set of jobs, there are additional features you should use that are not covered in this document**. Please continue reading the documentation, especially the page covering [parametric programs](migration3-declare.ipynb)."
    ]
@@ -303,7 +303,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### The result"
+    "### The result"
    ]
   },
   {

--- a/docs/source/migration2-qc.ipynb
+++ b/docs/source/migration2-qc.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "source": [
     "## Debugging with `WavefunctionSimulator`\n",
-    "We can check that this program gives us the desired wavefunction by using [WavefunctionSimulator.wavefunction()](apidocs/autogen/pyquil.api.WavefunctionSimulator.wavefunction.html#pyquil.api.WavefunctionSimulator.wavefunction)"
+    "We can check that this program gives us the desired wavefunction by using [WavefunctionSimulator.wavefunction()](apidocs/autogen/pyquil.api.WavefunctionSimulator.wavefunction.rst#pyquil.api.WavefunctionSimulator.wavefunction)"
    ]
   },
   {
@@ -118,7 +118,7 @@
    "source": [
     "## `get_qc`\n",
     "\n",
-    "We'll construct a `QuantumComputer` via the helper method [get_qc](apidocs/quantum_computer.html#pyquil.get_qc). You may be tempted to use the `QuantumComputer` constructor directly. Please refer to the [advanced documentation](#%E2%80%9CWhat-is-a-QuantumComputer?%E2%80%9D-Advanced-Edition) to see how to do that. Our program uses 3 qubits, so we'll ask for a 3-qubit QVM."
+    "We'll construct a `QuantumComputer` via the helper method [get_qc](apidocs/quantum_computer.rst#pyquil.get_qc). You may be tempted to use the `QuantumComputer` constructor directly. Please refer to the [advanced documentation](#%E2%80%9CWhat-is-a-QuantumComputer?%E2%80%9D-Advanced-Edition) to see how to do that. Our program uses 3 qubits, so we'll ask for a 3-qubit QVM."
    ]
   },
   {

--- a/docs/source/migration4.rst
+++ b/docs/source/migration4.rst
@@ -22,10 +22,13 @@ In terms of compatibility with Quil 1.0, this primarily changes how ``MEASURE`` 
 classical address targets must be modified to fit the new framework. In terms of new functionality, this allows angle
 values to be read in from classical memory.
 
-Quil 2 also introduces easier ways to manipulate gates by using gate modifiers. Two gate modifiers are supported currently,
-`DAGGER` and `CONTROLLED`.
+``DAGGER`` and ``CONTROLLED`` modifiers
+--------------------------------------------
 
-`DAGGER` can be written before a gate to refer to its inverse. For instance::
+Quil 2 also introduces easier ways to manipulate gates by using gate modifiers. Two gate modifiers are supported currently,
+``DAGGER`` and ``CONTROLLED``.
+
+``DAGGER`` can be written before a gate to refer to its inverse. For instance::
 
     DAGGER RX(pi/3) 0
 
@@ -33,7 +36,7 @@ would have the same effect as::
 
     RX(-pi/3) 0
 
-`DAGGER` can be applied to any gate, but also circuits defined with `DEFCIRCUIT`. This allows for easy reversal of unitary circuits::
+``DAGGER`` can be applied to any gate, but also circuits defined with ``DEFCIRCUIT``. This allows for easy reversal of unitary circuits::
 
     DEFCIRCUIT BELL:
         H 0
@@ -44,6 +47,10 @@ would have the same effect as::
     # disentangle, bringing us back to identity
     DAGGER BELL
 
+.. _quil_2_declare:
+
+``DECLARE``
+------------
 
 Classical memory regions must be explicitly requested and named by a Quil program using ``DECLARE`` directive. A generic
 ``DECLARE`` directive has the following syntax:

--- a/docs/source/qvm.rst
+++ b/docs/source/qvm.rst
@@ -236,7 +236,7 @@ Instantiation
 -------------
 
 A decent amount of information needs to be provided to initialize the ``compiler``, ``device``, and ``qam`` attributes,
-much of which is already in your :ref:`config files <_advanced_usage>` (or provided reasonable defaults when running locally).
+much of which is already in your :ref:`config files <advanced_usage>` (or provided reasonable defaults when running locally).
 Typically, you will want a :py:class:`~pyquil.api.QuantumComputer` which either:
 
   - pertains to a real, available QPU device

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -237,7 +237,7 @@ Now that our local endpoints are up and running, we can start running pyQuil pro
 We will run a simple program on the Quantum Virtual Machine (QVM).
 
 The program we will create prepares a fully entangled state between two qubits, called a Bell State. This state is in an equal
-superposition between |00⟩ and |11⟩, meaning that it is equally likely that a measurement will result in measuring
+superposition between :math:`\ket{00}` and :math:`\ket{11}`, meaning that it is equally likely that a measurement will result in measuring
 both qubits in the ground state or both qubits in the excited state. For more details about the physics behind these
 concepts, see :ref:`intro`.
 

--- a/docs/source/wavefunction_simulator.rst
+++ b/docs/source/wavefunction_simulator.rst
@@ -58,6 +58,8 @@ amplitudes directly or look at a dictionary of associated outcome probabilities.
 It is important to remember that this ``wavefunction`` method is a useful debugging tool for small quantum systems, and
 cannot be feasibly obtained on a quantum processor.
 
+.. _basis_ordering:
+
 Multi-Qubit Basis Enumeration
 -----------------------------
 

--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -348,8 +348,8 @@ def CPHASE(angle, control, target):
     This gate applies to two qubit arguments to produce the variant of the controlled phase
     instruction that affects the state 11.
 
-    Compare with the :py:func:`CPHASExx` variants. This variant is the most common and does
-    not have a suffix, although you can think of it as ``CPHASE11`.
+    Compare with the ``CPHASExx`` variants. This variant is the most common and does
+    not have a suffix, although you can think of it as ``CPHASE11``.
 
     :param angle: The input phase angle to apply when both qubits are in the ``|1>`` state.
     :param control: Qubit 1.

--- a/pyquil/noise.py
+++ b/pyquil/noise.py
@@ -233,8 +233,8 @@ def pauli_kraus_map(probabilities):
     Generate the Kraus operators corresponding to a pauli channel.
 
     :params list|floats probabilities: The 4^num_qubits list of probabilities specifying the desired pauli channel.
-    There should be either 4 or 16 probabilities specified in the order I, X, Y, Z for 1 qubit
-    or II, IX, IY, IZ, XI, XX, XY, etc for 2 qubits.
+        There should be either 4 or 16 probabilities specified in the order I, X, Y, Z for 1 qubit
+        or II, IX, IY, IZ, XI, XX, XY, etc for 2 qubits.
 
             For example::
 

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -657,14 +657,14 @@ def group_experiments(experiments: TomographyExperiment,
     product term-by-term.
 
     For example, X(1) * Z(0) would be diagonal in the 'natural' tensor product basis
-    {(|0> +/- |1>)/Sqrt[2]} * {|0>, |1>}, whereas Z(1) * X(0) would be diagonal
-    in the 'natural' tpb {|0>, |1>} * {(|0> +/- |1>)/Sqrt[2]}. The two operators
+    ``{(|0> +/- |1>)/Sqrt[2]} * {|0>, |1>}``, whereas Z(1) * X(0) would be diagonal
+    in the 'natural' tpb ``{|0>, |1>} * {(|0> +/- |1>)/Sqrt[2]}``. The two operators
     commute but are not diagonal in each others 'natural' tpb (in fact, they are
     anti-diagonal in each others 'natural' tpb). This function tests whether two
     operators given as PauliTerms are both diagonal in each others 'natural' tpb.
 
     Note that for the given example of X(1) * Z(0) and Z(1) * X(0), we can construct
-    the following basis which simultaneously diagonalizes both operators:
+    the following basis which simultaneously diagonalizes both operators::
 
       -- |0>' = |0> (|+>) + |1> (|->)
       -- |1>' = |0> (|+>) - |1> (|->)
@@ -823,7 +823,7 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
         settings is run with arguments ``f(i, len(tomo_experiment)`` such that the progress
         is ``i / len(tomo_experiment)``.
     :param active_reset: Whether to actively reset qubits instead of waiting several
-        times the coherence length for qubits to decay to |0> naturally. Setting this
+        times the coherence length for qubits to decay to ``|0>`` naturally. Setting this
         to True is much faster but there is a ~1% error per qubit in the reset operation.
         Thermal noise from "traditional" reset is not routinely characterized but is of the same
         order.

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -650,8 +650,7 @@ def group_experiments(experiments: TomographyExperiment,
     Group experiments that are diagonal in a shared tensor product basis (TPB) to minimize number
     of QPU runs.
 
-    Background
-    ----------
+    .. rubric:: Background
 
     Given some PauliTerm operator, the 'natural' tensor product basis to
     diagonalize this term is the one which diagonalizes each Pauli operator in the
@@ -677,8 +676,7 @@ def group_experiments(experiments: TomographyExperiment,
     of the basis vectors are entangled states.
 
 
-    Methods
-    -------
+    .. rubric:: Methods
 
     The "greedy" method will keep a running set of 'buckets' into which grouped ExperimentSettings
     will be placed. Each new ExperimentSetting considered is assigned to the first applicable

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -200,7 +200,7 @@ class Program(object):
             The matrix elements along each axis are ordered by bitstring. For two qubits the order
             is ``00, 01, 10, 11``, where the the bits **are ordered in reverse** by the qubit index,
             i.e., for qubits 0 and 1 the bitstring ``01`` indicates that qubit 0 is in the state 1.
-            See also :ref:`the related documentation section in the QVM Overview <basis-ordering>`.
+            See also :ref:`the related documentation section in the WavefunctionSimulator Overview <basis_ordering>`.
 
         :param string name: The name of the gate.
         :param list params: Parameters to send to the gate.
@@ -219,7 +219,7 @@ class Program(object):
             The matrix elements along each axis are ordered by bitstring. For two qubits the order
             is ``00, 01, 10, 11``, where the the bits **are ordered in reverse** by the qubit index,
             i.e., for qubits 0 and 1 the bitstring ``01`` indicates that qubit 0 is in the state 1.
-            See also :ref:`the related documentation section in the QVM Overview <basis-ordering>`.
+            See also :ref:`the related documentation section in the WavefunctionSimulator Overview <basis_ordering>`.
 
 
         :param string name: The name of the gate.
@@ -239,7 +239,7 @@ class Program(object):
             The matrix elements along each axis are ordered by bitstring. For two qubits the order
             is ``00, 01, 10, 11``, where the the bits **are ordered in reverse** by the qubit index,
             i.e., for qubits 0 and 1 the bitstring ``01`` indicates that qubit 0 is in the state 1.
-            See also :ref:`the related documentation section in the QVM Overview <basis-ordering>`.
+            See also :ref:`the related documentation section in the WavefunctionSimulator Overview <basis_ordering>`.
 
 
         :param str name: The name of the gate.

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -37,7 +37,7 @@ class Wavefunction(object):
         The elements of the wavefunction are ordered by bitstring. E.g., for two qubits the order
         is ``00, 01, 10, 11``, where the the bits **are ordered in reverse** by the qubit index,
         i.e., for qubits 0 and 1 the bitstring ``01`` indicates that qubit 0 is in the state 1.
-        See also :ref:`the related documentation section in the QVM Overview <basis-ordering>`.
+        See also :ref:`the related documentation section in the WavefunctionSimulator Overview <basis_ordering>`.
     """
 
     def __init__(self, amplitude_vector):


### PR DESCRIPTION
Description
-----------

Fix a bunch of warnings when building the sphinx docs. See individual commit messages for the full list of warnings addressed by this PR.

EDIT: #927 is now merged.
~~Note on merge dependencies:~~

~~After these changes, only one warning remains, which will be fixed when/if #927 is merged. Because this PR includes a tentative change to make sphnix-build treat warnings as errors, this PR should only be merged after #927 (unless we drop the warnings-as-errors change from this PR).~~

Fixes #583

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
