### PR TITLE
Support for dagger when converting gate to matrix.

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v2.9.1 (XX, YY, 2019)
+---------------------
+
+Bugfixes:
+
+- ``unitary_tools.lifted_gate(gate.dagger(), ...)`` was not returning the dagger of the original ``gate`` matrix.
+
 v2.9 (June 25, 2019)
 --------------------
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -1,12 +1,12 @@
 Changelog
 =========
 
-v2.9.1 (XX, YY, 2019)
----------------------
+v2.10 (in development)
+----------------------
 
 Bugfixes:
 
-- ``unitary_tools.lifted_gate()`` was not properly handling modifiers such as 'DAGGER' and 'CONTROLLED'
+- ``unitary_tools.lifted_gate()`` was not properly handling modifiers such as `DAGGER` and `CONTROLLED`
 
 v2.9 (June 25, 2019)
 --------------------

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -6,7 +6,7 @@ v2.9.1 (XX, YY, 2019)
 
 Bugfixes:
 
-- ``unitary_tools.lifted_gate(gate.dagger(), ...)`` was not returning the dagger of the original ``gate`` matrix.
+- ``unitary_tools.lifted_gate()`` was not properly handling modifiers such as 'DAGGER' and 'CONTROLLED'
 
 v2.9 (June 25, 2019)
 --------------------

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -6,7 +6,7 @@ v2.10 (in development)
 
 Bugfixes:
 
-- ``unitary_tools.lifted_gate()`` was not properly handling modifiers such as `DAGGER` and `CONTROLLED`
+- ``unitary_tools.lifted_gate()`` was not properly handling modifiers such as ``DAGGER`` and ``CONTROLLED``
 
 v2.9 (June 25, 2019)
 --------------------

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -6,7 +6,7 @@ v2.10 (in development)
 
 Bugfixes:
 
-- ``unitary_tools.lifted_gate()`` was not properly handling modifiers such as ``DAGGER`` and ``CONTROLLED``
+- ``unitary_tools.lifted_gate()`` was not properly handling modifiers such as ``DAGGER`` and ``CONTROLLED``.
 
 v2.9.1 (June 28, 2019)
 ----------------------

--- a/pyquil/tests/test_unitary_tools.py
+++ b/pyquil/tests/test_unitary_tools.py
@@ -292,10 +292,6 @@ def test_lifted_gate_single_qubit():
     true_unitary = np.kron(np.eye(2 ** 0), np.kron(mat.RX(0.5), np.eye(2 ** 4)))
     assert np.allclose(test_unitary, true_unitary)
 
-    test_unitary = lifted_gate(RZ(np.pi / 4, 0).dagger(), 1)
-    true_unitary = mat.RZ(-np.pi / 4)
-    assert np.allclose(test_unitary, true_unitary)
-
 
 def test_lifted_gate_two_qubit():
     test_unitary = lifted_gate(CNOT(0, 1), 4)
@@ -308,6 +304,37 @@ def test_lifted_gate_two_qubit():
 
     test_unitary = lifted_gate(CNOT(1, 3), 4)
     true_unitary = lifted_gate_matrix(mat.CNOT, [1, 3], 4)
+    assert np.allclose(test_unitary, true_unitary)
+
+
+def test_lifted_gate_modified():
+    test_unitary = lifted_gate(RZ(np.pi / 4, 0).dagger(), 1)
+    true_unitary = mat.RZ(-np.pi / 4)
+    assert np.allclose(test_unitary, true_unitary)
+
+    test_unitary = lifted_gate(X(0).dagger().controlled(1), 2)
+    true_unitary = lifted_gate(CNOT(1, 0), 2)
+    other_true = mat.CNOT
+    assert np.allclose(test_unitary, true_unitary)
+    assert np.allclose(other_true, true_unitary)
+
+    test_unitary = lifted_gate(X(1).dagger().controlled(0).dagger().dagger(), 2)
+    true_unitary = lifted_gate(CNOT(0, 1), 2)
+    assert np.allclose(test_unitary, true_unitary)
+
+    test_unitary = lifted_gate(X(0).dagger().controlled(1).dagger().dagger().controlled(2), 3)
+    true_unitary = lifted_gate(CCNOT(1, 2, 0), 3)
+    other_true = mat.CCNOT
+    assert np.allclose(test_unitary, true_unitary)
+    assert np.allclose(other_true, true_unitary)
+
+    test_unitary = lifted_gate(RY(np.pi / 4, 0).dagger().controlled(2).dagger().dagger(), 3)
+    ry_part = lifted_gate(RY(-np.pi / 4, 0), 1)
+    zero = np.eye(2)
+    zero[1, 1] = 0
+    one = np.eye(2)
+    one[0, 0] = 0
+    true_unitary = np.kron(zero, np.eye(4)) + np.kron(one, np.kron(np.eye(2), ry_part))
     assert np.allclose(test_unitary, true_unitary)
 
 

--- a/pyquil/tests/test_unitary_tools.py
+++ b/pyquil/tests/test_unitary_tools.py
@@ -292,7 +292,7 @@ def test_lifted_gate_single_qubit():
     true_unitary = np.kron(np.eye(2 ** 0), np.kron(mat.RX(0.5), np.eye(2 ** 4)))
     assert np.allclose(test_unitary, true_unitary)
 
-    test_unitary = lifted_gate(RZ(np.pi/4, 0).dagger(), 1)
+    test_unitary = lifted_gate(RZ(np.pi / 4, 0).dagger(), 1)
     true_unitary = mat.RZ(-np.pi/4)
     assert np.allclose(test_unitary, true_unitary)
 

--- a/pyquil/tests/test_unitary_tools.py
+++ b/pyquil/tests/test_unitary_tools.py
@@ -292,6 +292,10 @@ def test_lifted_gate_single_qubit():
     true_unitary = np.kron(np.eye(2 ** 0), np.kron(mat.RX(0.5), np.eye(2 ** 4)))
     assert np.allclose(test_unitary, true_unitary)
 
+    test_unitary = lifted_gate(RZ(np.pi/4, 0).dagger(), 1)
+    true_unitary = mat.RZ(-np.pi/4)
+    assert np.allclose(test_unitary, true_unitary)
+
 
 def test_lifted_gate_two_qubit():
     test_unitary = lifted_gate(CNOT(0, 1), 4)

--- a/pyquil/tests/test_unitary_tools.py
+++ b/pyquil/tests/test_unitary_tools.py
@@ -293,7 +293,7 @@ def test_lifted_gate_single_qubit():
     assert np.allclose(test_unitary, true_unitary)
 
     test_unitary = lifted_gate(RZ(np.pi / 4, 0).dagger(), 1)
-    true_unitary = mat.RZ(-np.pi/4)
+    true_unitary = mat.RZ(-np.pi / 4)
     assert np.allclose(test_unitary, true_unitary)
 
 

--- a/pyquil/unitary_tools.py
+++ b/pyquil/unitary_tools.py
@@ -276,7 +276,7 @@ def lifted_gate(gate: Gate, n_qubits: int):
     else:
         matrix = QUANTUM_GATES[gate.name]
 
-    for mod in gate.modifiers:
+    for mod in reversed(gate.modifiers):
         if mod == 'DAGGER':
             matrix = matrix.conj().T
         if mod == 'CONTROLLED':

--- a/pyquil/unitary_tools.py
+++ b/pyquil/unitary_tools.py
@@ -276,8 +276,16 @@ def lifted_gate(gate: Gate, n_qubits: int):
     else:
         matrix = QUANTUM_GATES[gate.name]
 
-    if 'DAGGER' in gate.modifiers:
-        matrix = matrix.conj().T
+    for mod in gate.modifiers:
+        if mod == 'DAGGER':
+            matrix = matrix.conj().T
+        if mod == 'CONTROLLED':
+            zero = np.eye(2)
+            zero[1, 1] = 0
+            one = np.eye(2)
+            one[0, 0] = 0
+
+            matrix = np.kron(zero, np.eye(*matrix.shape)) + np.kron(one, matrix)
 
     return lifted_gate_matrix(matrix=matrix,
                               qubit_inds=[q.index for q in gate.qubits],

--- a/pyquil/unitary_tools.py
+++ b/pyquil/unitary_tools.py
@@ -276,6 +276,9 @@ def lifted_gate(gate: Gate, n_qubits: int):
     else:
         matrix = QUANTUM_GATES[gate.name]
 
+    if 'DAGGER' in gate.modifiers:
+        matrix = matrix.conj().T
+
     return lifted_gate_matrix(matrix=matrix,
                               qubit_inds=[q.index for q in gate.qubits],
                               n_qubits=n_qubits)


### PR DESCRIPTION
Description
-----------

In `unitary_tools.py` we provide functionality for converting a pyquil `Gate` into a matrix. Gates which had been modified with a `dagger()` call were not being converted properly to the daggered matrix. 

closes #932

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The changelog (`docs/source/changes.rst`) has a description of this change.
