### PR TITLE
Opt-in to protoquil from compiler

### DIFF
--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -289,6 +289,16 @@ class QVMCompiler(AbstractCompiler):
         return nq_program
 
     @_record_call
+    def quil_to_protoquil(self, program: Program) -> Program:
+        request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
+        response = self.client.call('quil_to_protoquil', request).asdict()  # type: Dict
+        nq_program = parse_program(response['quil'])
+        nq_program.native_quil_metadata = response['metadata']
+        nq_program.num_shots = program.num_shots
+        return nq_program
+
+
+    @_record_call
     def native_quil_to_executable(self, nq_program: Program) -> PyQuilExecutableResponse:
         return PyQuilExecutableResponse(
             program=nq_program.out(),

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -203,9 +203,9 @@ class QPUCompiler(AbstractCompiler):
         return {'quilc': quilc_version_info}
 
     @_record_call
-    def quil_to_native_quil(self, program: Program) -> Program:
+    def quil_to_native_quil(self, program: Program, protoquil=False) -> Program:
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
-        response = self.quilc_client.call('quil_to_native_quil', request).asdict()  # type: Dict
+        response = self.quilc_client.call('quil_to_native_quil', request, protoquil=False).asdict()  # type: Dict
         nq_program = parse_program(response['quil'])
         nq_program.native_quil_metadata = response['metadata']
         nq_program.num_shots = program.num_shots
@@ -280,23 +280,13 @@ class QVMCompiler(AbstractCompiler):
         return self.client.call('get_version_info')
 
     @_record_call
-    def quil_to_native_quil(self, program: Program) -> Program:
+    def quil_to_native_quil(self, program: Program, protoquil = False) -> Program:
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
-        response = self.client.call('quil_to_native_quil', request).asdict()  # type: Dict
+        response = self.client.call('quil_to_native_quil', request, protoquil=protoquil).asdict()  # type: Dict
         nq_program = parse_program(response['quil'])
         nq_program.native_quil_metadata = response['metadata']
         nq_program.num_shots = program.num_shots
         return nq_program
-
-    @_record_call
-    def quil_to_protoquil(self, program: Program) -> Program:
-        request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
-        response = self.client.call('quil_to_protoquil', request).asdict()  # type: Dict
-        nq_program = parse_program(response['quil'])
-        nq_program.native_quil_metadata = response['metadata']
-        nq_program.num_shots = program.num_shots
-        return nq_program
-
 
     @_record_call
     def native_quil_to_executable(self, nq_program: Program) -> PyQuilExecutableResponse:

--- a/pyquil/api/_qac.py
+++ b/pyquil/api/_qac.py
@@ -33,7 +33,7 @@ class AbstractCompiler(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def quil_to_native_quil(self, program: Program) -> Program:
+    def quil_to_native_quil(self, program: Program, protoquil=False) -> Program:
         """
         Compile an arbitrary quil program according to the ISA of target_device.
 

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -233,7 +233,8 @@ class QuantumComputer:
     @_record_call
     def compile(self, program: Program,
                 to_native_gates: bool = True,
-                optimize: bool = True) -> Union[BinaryExecutableResponse, PyQuilExecutableResponse]:
+                optimize: bool = True,
+                protoquil: bool = False) -> Union[BinaryExecutableResponse, PyQuilExecutableResponse]:
         """
         A high-level interface to program compilation.
 
@@ -245,7 +246,8 @@ class QuantumComputer:
 
         :param program: A Program
         :param to_native_gates: Whether to compile non-native gates to native gates.
-        :param optimize: Whether to optimize programs to reduce the number of operations.
+        :param optimize: Whether to optimize the program to reduce the number of operations.
+        :param protoquil: Whether to compile the program to protoquil (executable on QPU).
         :return: An executable binary suitable for passing to :py:func:`QuantumComputer.run`.
         """
         flags = [to_native_gates, optimize]
@@ -253,7 +255,7 @@ class QuantumComputer:
         quilc = all(flags)
 
         if quilc:
-            nq_program = self.compiler.quil_to_native_quil(program)
+            nq_program = self.compiler.quil_to_protoquil(program) if protoquil else self.compiler.quil_to_native_quil(program)
         else:
             nq_program = program
         binary = self.compiler.native_quil_to_executable(nq_program)

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -255,7 +255,7 @@ class QuantumComputer:
         quilc = all(flags)
 
         if quilc:
-            nq_program = self.compiler.quil_to_protoquil(program) if protoquil else self.compiler.quil_to_native_quil(program)
+            nq_program = self.compiler.quil_to_native_quil(program, protoquil=protoquil)
         else:
             nq_program = program
         binary = self.compiler.native_quil_to_executable(nq_program)

--- a/pyquil/tests/utils.py
+++ b/pyquil/tests/utils.py
@@ -13,7 +13,7 @@ class DummyCompiler(AbstractCompiler):
     def get_version_info(self):
         return {}
 
-    def quil_to_native_quil(self, program: Program):
+    def quil_to_native_quil(self, program: Program, protoquil=False):
         return program
 
     def native_quil_to_executable(self, nq_program: Program):


### PR DESCRIPTION
This makes, in a backwards-compatible fashion, two changes:

  * A method `QVMCompiler.quil_to_protoquil()` which is almost
    identical to `QVMCompiler.quil_to_native_quil()` except that it
    calls the `quil_to_protoquil` endpoint. It does what it says on
    the tin -- compiles to protoquil, and also populates the metadata
    property of the compiled program.

  * Adds `protoquil` keyword argument to
    `QuantumComputer.compile()`. This enables users to use the above
    protoquil compilation endpoint, and in a backwards-compatible
    fashion.

Prior to this PR the compiler was configured at launch-time to produce
protoquil (via the `-P` option). This could not be changed while the
server was running. That option remains in the compiler, but now there
is the above endpoint that enables the protoquil option as-and-when
the user desires it.

I'm leaving this as a draft for now. It's not time sensitive, just something
I think will be useful, but also maybe not. Who knows.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] The changelog (`docs/source/changes.rst`) has a description of this change.
