### PR TITLE
Opt-in to protoquil from compiler

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -18,6 +18,11 @@ Improvements and Changes:
 - Updated the examples README. Removed an outdated notebook. Updated remaining notebooks to use
   ``MemoryReference``, and fix any parts that were broken (gh-820).
 
+- The ``AbstractCompiler.quil_to_native_quil()`` function now accepts a ``protoquil`` keyword which
+  tells the compiler to restrict both input and output to protoquil (i.e. Quil code executable on a
+  QPU). Additionally, the compiler will return a metadata dictionary that contains statistics about
+  the compiled program, e.g. its estimated QPU runtime. See the compiler docs for more information.
+
 Bugfixes:
 
 - ``unitary_tools.lifted_gate()`` was not properly handling modifiers such as ``DAGGER`` and ``CONTROLLED``.

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -21,7 +21,8 @@ Improvements and Changes:
 - The ``AbstractCompiler.quil_to_native_quil()`` function now accepts a ``protoquil`` keyword which
   tells the compiler to restrict both input and output to protoquil (i.e. Quil code executable on a
   QPU). Additionally, the compiler will return a metadata dictionary that contains statistics about
-  the compiled program, e.g. its estimated QPU runtime. See the compiler docs for more information.
+  the compiled program, e.g. its estimated QPU runtime. See the compiler docs for more information
+  (gh-940).
 
 Bugfixes:
 

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -78,11 +78,14 @@ The compiler connection is also available directly via the property ``qc.compile
 precise class of this object changes based on context (e.g., ``QPUCompiler``,
 ``QVMCompiler``), but it always conforms to the interface laid out by ``pyquil.api._qac``:
 
-* ``compiler.quil_to_native_quil(program)``: This method converts a Quil program into native Quil,
-  according to the ISA that the compiler is initialized with.  The input parameter is specified as a
-  :py:class:`~pyquil.quil.Program` object, and the output is given as a new ``Program`` object, equipped with a
-  ``.metadata`` property that gives extraneous information about the compilation output (e.g., gate
-  depth, as well as many others).  This call blocks until Quil compilation finishes.
+* ``compiler.quil_to_native_quil(program, protoquil)``: This method converts a Quil program into
+  native Quil, according to the ISA that the compiler is initialized with.  The input parameter is
+  specified as a :py:class:`~pyquil.quil.Program` object. The optional ``protoquil`` keyword
+  argument instructs the compiler to restrict both its input and output to protoquil (Quil code that
+  can be executed on a QPU). If the server is started with the ``-P`` option, or you specify
+  ``protoquil=True`` the returned ``Program`` object will be equipped with a ``.metadata`` property
+  that gives extraneous information about the compilation output (e.g., gate depth, as well as many
+  others).  This call blocks until Quil compilation finishes.
 * ``compiler.native_quil_to_executable(nq_program)``: This method converts a native Quil program, which
   is promised to consist only of native gates for a given ISA, into an executable suitable for
   submission to one of a QVM or a QPU.  This call blocks until the executable is generated.
@@ -100,9 +103,11 @@ the previous example snippet is identical to the following:
     qc = get_qc("9q-square-qvm")
 
     p = Program(H(0), CNOT(0,1), CNOT(1,2))
-    np = qc.compiler.quil_to_native_quil(p)
-    ep = qc.compiler.native_quil_to_executable(np)
 
+    np = qc.compiler.quil_to_native_quil(p, protoquil=True)
+    print(np.metadata)
+
+    ep = qc.compiler.native_quil_to_executable(np)
     print(ep.program) # here ep is of type PyquilExecutableResponse, which is not always inspectable
 
 
@@ -119,6 +124,14 @@ The QPU is not able to execute all possible Quil programs.  At present, a Quil p
   a pair of qubits participating in a qubit-qubit interaction.
 * This is then followed by a block of ``MEASURE`` instructions.
 
+To instruct the compiler to produce Quil code that can be executed on a QPU, you can use the
+``protoquil`` keyword in a call to `compiler.quil_to_native_quil(program, protoquil=True)` or
+`qc.compile(program, protoquil=True)`.
+
+.. note::
+
+   If your compiler server is started with the protoquil option ``-P`` (as is the case for your QMI
+   compiler) then specifying ``protoquil=False`` will have no effect.
 
 .. _pragma:
 

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -131,7 +131,8 @@ To instruct the compiler to produce Quil code that can be executed on a QPU, you
 .. note::
 
    If your compiler server is started with the protoquil option ``-P`` (as is the case for your QMI
-   compiler) then specifying ``protoquil=False`` will have no effect.
+   compiler) then specifying ``protoquil=False`` will override the server and force disable
+   protoquil. Specifying ``protoquil=None`` defers to the server.
 
 .. _pragma:
 

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -227,9 +227,7 @@ terminal.
 That's it! You're all set up to run pyQuil locally. Your programs will make requests to these server endpoints to compile your Quil
 programs to native Quil, and to simulate those programs on the QVM.
 
-**NOTE**: We are transitioning from using an HTTP ``quilc`` server to an RPCQ one.
-In the near term, ``-S`` will spawn an HTTP server at port 6000 and an RPCQ server
-at port 5555 (accessible via ``tcp://localhost:5555``).
+**NOTE**: Prior to quilc version 1.10 there existed two methods for communicating with the quilc server: over HTTP by creating the server with the ``-S`` flag, or over RPCQ by creating the server with the ``-R`` flag. The HTTP server mode was deprecated in early 2019, and removed in mid 2019. The ``-S`` and ``-R`` flags now both start the RPCQ server.
 
 Run Your First Program
 ----------------------

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -226,10 +226,10 @@ class QPUCompiler(AbstractCompiler):
         return {'quilc': quilc_version_info}
 
     @_record_call
-    def quil_to_native_quil(self, program: Program, protoquil=False) -> Program:
+    def quil_to_native_quil(self, program: Program, protoquil=None) -> Program:
         self._connect_quilc()
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
-        response = self.quilc_client.call('quil_to_native_quil', request, protoquil=False).asdict()  # type: Dict
+        response = self.quilc_client.call('quil_to_native_quil', request, protoquil=protoquil).asdict()  # type: Dict
         nq_program = parse_program(response['quil'])
         nq_program.native_quil_metadata = response['metadata']
         nq_program.num_shots = program.num_shots
@@ -310,7 +310,7 @@ class QVMCompiler(AbstractCompiler):
         return self.client.call('get_version_info', rpc_timeout=1)
 
     @_record_call
-    def quil_to_native_quil(self, program: Program, protoquil=False) -> Program:
+    def quil_to_native_quil(self, program: Program, protoquil=None) -> Program:
         self.connect()
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
         response = self.client.call('quil_to_native_quil', request, protoquil=protoquil).asdict()  # type: Dict

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -226,7 +226,7 @@ class QPUCompiler(AbstractCompiler):
         return {'quilc': quilc_version_info}
 
     @_record_call
-    def quil_to_native_quil(self, program: Program, protoquil=None) -> Program:
+    def quil_to_native_quil(self, program: Program, *, protoquil=None) -> Program:
         self._connect_quilc()
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
         response = self.quilc_client.call('quil_to_native_quil', request, protoquil=protoquil).asdict()  # type: Dict
@@ -310,7 +310,7 @@ class QVMCompiler(AbstractCompiler):
         return self.client.call('get_version_info', rpc_timeout=1)
 
     @_record_call
-    def quil_to_native_quil(self, program: Program, protoquil=None) -> Program:
+    def quil_to_native_quil(self, program: Program, *, protoquil=None) -> Program:
         self.connect()
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
         response = self.client.call('quil_to_native_quil', request, protoquil=protoquil).asdict()  # type: Dict

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -226,10 +226,10 @@ class QPUCompiler(AbstractCompiler):
         return {'quilc': quilc_version_info}
 
     @_record_call
-    def quil_to_native_quil(self, program: Program) -> Program:
+    def quil_to_native_quil(self, program: Program, protoquil=False) -> Program:
         self._connect_quilc()
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
-        response = self.quilc_client.call('quil_to_native_quil', request).asdict()  # type: Dict
+        response = self.quilc_client.call('quil_to_native_quil', request, protoquil=False).asdict()  # type: Dict
         nq_program = parse_program(response['quil'])
         nq_program.native_quil_metadata = response['metadata']
         nq_program.num_shots = program.num_shots
@@ -310,10 +310,10 @@ class QVMCompiler(AbstractCompiler):
         return self.client.call('get_version_info', rpc_timeout=1)
 
     @_record_call
-    def quil_to_native_quil(self, program: Program) -> Program:
+    def quil_to_native_quil(self, program: Program, protoquil=False) -> Program:
         self.connect()
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
-        response = self.client.call('quil_to_native_quil', request).asdict()  # type: Dict
+        response = self.client.call('quil_to_native_quil', request, protoquil=protoquil).asdict()  # type: Dict
         nq_program = parse_program(response['quil'])
         nq_program.native_quil_metadata = response['metadata']
         nq_program.num_shots = program.num_shots

--- a/pyquil/api/_qac.py
+++ b/pyquil/api/_qac.py
@@ -33,7 +33,7 @@ class AbstractCompiler(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def quil_to_native_quil(self, program: Program) -> Program:
+    def quil_to_native_quil(self, program: Program, protoquil=False) -> Program:
         """
         Compile an arbitrary quil program according to the ISA of target_device.
 

--- a/pyquil/api/_qac.py
+++ b/pyquil/api/_qac.py
@@ -33,11 +33,12 @@ class AbstractCompiler(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def quil_to_native_quil(self, program: Program, protoquil=False) -> Program:
+    def quil_to_native_quil(self, program: Program, protoquil=None) -> Program:
         """
         Compile an arbitrary quil program according to the ISA of target_device.
 
         :param program: Arbitrary quil to compile
+        :param protoquil: Whether to restrict to protoquil (``None`` means defer to server)
         :return: Native quil and compiler metadata
         """
 

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -233,7 +233,8 @@ class QuantumComputer:
     @_record_call
     def compile(self, program: Program,
                 to_native_gates: bool = True,
-                optimize: bool = True) -> Union[BinaryExecutableResponse, PyQuilExecutableResponse]:
+                optimize: bool = True,
+                protoquil: bool = False) -> Union[BinaryExecutableResponse, PyQuilExecutableResponse]:
         """
         A high-level interface to program compilation.
 
@@ -245,7 +246,9 @@ class QuantumComputer:
 
         :param program: A Program
         :param to_native_gates: Whether to compile non-native gates to native gates.
-        :param optimize: Whether to optimize programs to reduce the number of operations.
+        :param optimize: Whether to optimize the program to reduce the number of operations.
+        :param protoquil: Whether to restrict the input program to and the compiled program
+            to protoquil (executable on QPU).
         :return: An executable binary suitable for passing to :py:func:`QuantumComputer.run`.
         """
         flags = [to_native_gates, optimize]
@@ -253,7 +256,7 @@ class QuantumComputer:
         quilc = all(flags)
 
         if quilc:
-            nq_program = self.compiler.quil_to_native_quil(program)
+            nq_program = self.compiler.quil_to_native_quil(program, protoquil=protoquil)
         else:
             nq_program = program
         binary = self.compiler.native_quil_to_executable(nq_program)

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -234,7 +234,7 @@ class QuantumComputer:
     def compile(self, program: Program,
                 to_native_gates: bool = True,
                 optimize: bool = True,
-                protoquil: bool = False) -> Union[BinaryExecutableResponse, PyQuilExecutableResponse]:
+                protoquil: bool = None) -> Union[BinaryExecutableResponse, PyQuilExecutableResponse]:
         """
         A high-level interface to program compilation.
 
@@ -248,7 +248,7 @@ class QuantumComputer:
         :param to_native_gates: Whether to compile non-native gates to native gates.
         :param optimize: Whether to optimize the program to reduce the number of operations.
         :param protoquil: Whether to restrict the input program to and the compiled program
-            to protoquil (executable on QPU).
+            to protoquil (executable on QPU). A value of ``None`` means defer to server.
         :return: An executable binary suitable for passing to :py:func:`QuantumComputer.run`.
         """
         flags = [to_native_gates, optimize]

--- a/pyquil/tests/utils.py
+++ b/pyquil/tests/utils.py
@@ -13,7 +13,7 @@ class DummyCompiler(AbstractCompiler):
     def get_version_info(self):
         return {}
 
-    def quil_to_native_quil(self, program: Program):
+    def quil_to_native_quil(self, program: Program, protoquil=False):
         return program
 
     def native_quil_to_executable(self, nq_program: Program):

--- a/pyquil/tests/utils.py
+++ b/pyquil/tests/utils.py
@@ -13,7 +13,7 @@ class DummyCompiler(AbstractCompiler):
     def get_version_info(self):
         return {}
 
-    def quil_to_native_quil(self, program: Program, protoquil=False):
+    def quil_to_native_quil(self, program: Program, protoquil=None):
         return program
 
     def native_quil_to_executable(self, nq_program: Program):


### PR DESCRIPTION
This makes, in a backwards-compatible fashion:

  * Adds `protoquil` keyword argument to `QuantumComputer.compile()`. When this is set to `True` the compiler will employ it's protoquil restrictions on input/output.

Prior to this PR the compiler was configured at launch-time to produce protoquil (via the `-P` option). This could not be changed while the server was running. That option remains in the compiler, but now there is the above endpoint that enables the protoquil option as-and-when
the user desires it.

This shouldn't be merged before https://github.com/rigetti/quilc/pull/289.

TODO:
- [x] Make sure there are no other `compile` functions that need extending to take the `protoquil` kwarg