### PR TITLE
Rerun flaky unit tests once more when they fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Changelog
 
 ### Improvements and Changes
 
+-   Test suite attempts to retry specific tests that fail often. Tests are
+    retried only a single time (@notmgsk, gh-951).
+
 ### Bugfixes
 
 -   The `MemoryReference` warnings from have been removed from the unit

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -19,6 +19,9 @@ Announcements
 Improvements and Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Test suite attempts to retry any tests that fail. Tests are retried
+  only a single time (@notmgsk, gh-951).
+
 Bugfixes
 ~~~~~~~~
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -19,8 +19,6 @@ Announcements
 Improvements and Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Test suite attempts to retry any tests that fail. Tests are retried
-  only a single time (@notmgsk, gh-951).
 
 Bugfixes
 ~~~~~~~~

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -774,6 +774,7 @@ def test_measure_observables_2q_readout_error_one_measured(forest, use_seed):
     assert np.isclose(np.mean(cal_e), 0.849, atol=2e-2)
 
 
+@pytest.mark.flaky(reruns=1)
 def test_exhaustive_symmetrization_1q(forest):
     qc = get_qc('9q-qvm')
     qubs = [5]

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -1869,6 +1869,7 @@ def test_raw_statistics_2q_nontrivial_entangled_state(forest, use_seed):
     np.testing.assert_allclose(result_std_err, simulated_std_err, atol=2e-2)
 
 
+@pytest.mark.flaky(reruns=1)
 def test_corrected_statistics_2q_nontrivial_nonentangled_state(forest, use_seed):
     ''' Testing that we can successfully correct for observed statistics
         in the presence of readout errors, even for 2q nontrivial but

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ rpcq >= 2.7.2
 # test deps
 pytest
 pytest-timeout
+pytest-rerunfailures
 requests-mock
 flake8
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ recreate=
 deps=
     -rrequirements.txt
 commands=
-    py.test -v pyquil/tests
+    py.test --reruns 2 -v pyquil/tests
 
 [testenv:docs]
 whitelist_externals = make

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ recreate=
 deps=
     -rrequirements.txt
 commands=
-    py.test --reruns 2 -v pyquil/tests
+    py.test -v pyquil/tests
 
 [testenv:docs]
 whitelist_externals = make


### PR DESCRIPTION
Description
-----------

We have a number of tests that have a small but non-zero chance of failing. This commit makes pytest retry any test that fails (and retry only a single time). Reduces the likelihood that a stray numerical instability causes the whole test run to fail.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The changelog (`docs/source/changes.rst`) has a description of this change.
