### PR TITLE
Allow bare gate/circuit application

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -7,6 +7,7 @@ v2.10 (in development)
 Bugfixes:
 
 - ``unitary_tools.lifted_gate()`` was not properly handling modifiers such as ``DAGGER`` and ``CONTROLLED``.
+- The parser can now handle circuit instructions with zero input qubits (gh-958).
 
 v2.9.1 (June 28, 2019)
 ----------------------

--- a/pyquil/_parser/PyQuilListener.py
+++ b/pyquil/_parser/PyQuilListener.py
@@ -163,7 +163,10 @@ class PyQuilListener(QuilListener):
             else:
                 gate = QUANTUM_GATES[gate_name](*target_qubits)
         else:
-            gate = Gate(gate_name, params, target_qubits)
+            if qubits:
+                gate = Gate(gate_name, params, target_qubits)
+            else:
+                gate = RawInstr(gate_name)
 
         for modifier in modifiers:
             if modifier == "CONTROLLED":

--- a/pyquil/_parser/Quil.g4
+++ b/pyquil/_parser/Quil.g4
@@ -33,7 +33,7 @@ instr               : gate
 
 // C. Static and Parametric Gates
 
-gate                : modifier* name ( LPAREN param ( COMMA param )* RPAREN )? qubit+ ;
+gate                : modifier* name ( LPAREN param ( COMMA param )* RPAREN )? qubit* ;
 
 name                : IDENTIFIER ;
 qubit               : INT ;

--- a/pyquil/_parser/gen3/QuilParser.py
+++ b/pyquil/_parser/gen3/QuilParser.py
@@ -8,7 +8,7 @@ import sys
 def serializedATN():
     with StringIO() as buf:
         buf.write("\3\u608b\ua72a\u8133\ub9ed\u417c\u3be7\u7786\u5964\3M")
-        buf.write("\u01ef\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7")
+        buf.write("\u01f0\4\2\t\2\4\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7")
         buf.write("\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t\13\4\f\t\f\4\r\t\r\4\16")
         buf.write("\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22\4\23\t\23")
         buf.write("\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31")
@@ -22,221 +22,222 @@ def serializedATN():
         buf.write("\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4\3\4")
         buf.write("\3\4\3\4\5\4\u009a\n\4\3\5\7\5\u009d\n\5\f\5\16\5\u00a0")
         buf.write("\13\5\3\5\3\5\3\5\3\5\3\5\7\5\u00a7\n\5\f\5\16\5\u00aa")
-        buf.write("\13\5\3\5\3\5\5\5\u00ae\n\5\3\5\6\5\u00b1\n\5\r\5\16\5")
-        buf.write("\u00b2\3\6\3\6\3\7\3\7\3\b\3\b\3\t\3\t\3\n\3\n\3\n\3\n")
-        buf.write("\3\n\3\n\7\n\u00c3\n\n\f\n\16\n\u00c6\13\n\3\n\3\n\3\n")
-        buf.write("\3\n\5\n\u00cc\n\n\3\n\3\n\3\n\3\n\3\13\3\13\3\13\3\f")
-        buf.write("\3\f\3\r\3\r\3\r\7\r\u00da\n\r\f\r\16\r\u00dd\13\r\3\r")
-        buf.write("\3\r\3\16\3\16\3\16\3\16\7\16\u00e5\n\16\f\16\16\16\u00e8")
-        buf.write("\13\16\3\17\3\17\3\17\3\17\3\17\3\17\7\17\u00f0\n\17\f")
-        buf.write("\17\16\17\u00f3\13\17\3\17\3\17\5\17\u00f7\n\17\3\17\7")
-        buf.write("\17\u00fa\n\17\f\17\16\17\u00fd\13\17\3\17\3\17\3\17\3")
-        buf.write("\17\3\20\3\20\3\21\3\21\5\21\u0107\n\21\3\22\3\22\3\22")
-        buf.write("\3\22\3\22\7\22\u010e\n\22\f\22\16\22\u0111\13\22\3\22")
-        buf.write("\3\22\5\22\u0115\n\22\3\22\6\22\u0118\n\22\r\22\16\22")
-        buf.write("\u0119\3\23\3\23\3\23\5\23\u011f\n\23\3\24\3\24\5\24\u0123")
-        buf.write("\n\24\3\25\3\25\3\25\3\25\5\25\u0129\n\25\3\26\3\26\3")
-        buf.write("\26\3\26\7\26\u012f\n\26\f\26\16\26\u0132\13\26\3\26\3")
-        buf.write("\26\3\26\3\27\3\27\3\27\5\27\u013a\n\27\3\30\3\30\5\30")
-        buf.write("\u013e\n\30\3\30\3\30\3\30\5\30\u0143\n\30\3\31\3\31\3")
-        buf.write("\31\3\32\3\32\3\32\3\33\3\33\3\34\3\34\3\34\3\35\3\35")
-        buf.write("\3\35\3\35\3\36\3\36\3\36\3\36\3\37\3\37\5\37\u015a\n")
-        buf.write("\37\3 \3 \3!\3!\3!\3!\3!\3!\5!\u0164\n!\3!\3!\3!\7!\u0169")
-        buf.write("\n!\f!\16!\u016c\13!\5!\u016e\n!\3\"\3\"\3\"\3\"\3#\3")
-        buf.write("#\3#\3$\3$\3$\3$\3$\5$\u017c\n$\3%\3%\3%\3%\5%\u0182\n")
-        buf.write("%\3&\3&\3&\3&\5&\u0188\n&\3\'\3\'\3\'\3\'\5\'\u018e\n")
-        buf.write("\'\3(\3(\3(\3(\3)\3)\3)\3)\3*\3*\3*\3*\3*\3+\3+\3+\3+")
-        buf.write("\3+\5+\u01a2\n+\3,\3,\3,\3,\3,\5,\u01a9\n,\3-\3-\3.\3")
-        buf.write(".\3.\3/\3/\3/\7/\u01b3\n/\f/\16/\u01b6\13/\3/\5/\u01b9")
-        buf.write("\n/\3\60\3\60\3\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61")
-        buf.write("\3\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61\5\61\u01cd\n")
-        buf.write("\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61\7\61")
-        buf.write("\u01d8\n\61\f\61\16\61\u01db\13\61\3\62\3\62\3\63\3\63")
-        buf.write("\3\64\5\64\u01e2\n\64\3\64\3\64\3\64\3\64\5\64\u01e8\n")
-        buf.write("\64\3\65\3\65\3\65\3\66\3\66\3\66\2\3`\67\2\4\6\b\n\f")
-        buf.write("\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62\64\668:<>@")
-        buf.write("BDFHJLNPRTVXZ\\^`bdfhj\2\r\3\289\3\2\24\25\3\2\26\31\3")
-        buf.write("\2\32\35\3\2\36!\3\2%)\3\2:;\3\2\65\66\3\2\63\64\3\2.")
-        buf.write("\62\3\2;<\2\u0204\2m\3\2\2\2\4\u0085\3\2\2\2\6\u0099\3")
-        buf.write("\2\2\2\b\u009e\3\2\2\2\n\u00b4\3\2\2\2\f\u00b6\3\2\2\2")
-        buf.write("\16\u00b8\3\2\2\2\20\u00ba\3\2\2\2\22\u00bc\3\2\2\2\24")
-        buf.write("\u00d1\3\2\2\2\26\u00d4\3\2\2\2\30\u00db\3\2\2\2\32\u00e0")
-        buf.write("\3\2\2\2\34\u00e9\3\2\2\2\36\u0102\3\2\2\2 \u0106\3\2")
-        buf.write("\2\2\"\u0108\3\2\2\2$\u011b\3\2\2\2&\u0120\3\2\2\2(\u0128")
-        buf.write("\3\2\2\2*\u0130\3\2\2\2,\u0136\3\2\2\2.\u0142\3\2\2\2")
-        buf.write("\60\u0144\3\2\2\2\62\u0147\3\2\2\2\64\u014a\3\2\2\2\66")
-        buf.write("\u014c\3\2\2\28\u014f\3\2\2\2:\u0153\3\2\2\2<\u0157\3")
-        buf.write("\2\2\2>\u015b\3\2\2\2@\u015d\3\2\2\2B\u016f\3\2\2\2D\u0173")
-        buf.write("\3\2\2\2F\u017b\3\2\2\2H\u017d\3\2\2\2J\u0183\3\2\2\2")
-        buf.write("L\u0189\3\2\2\2N\u018f\3\2\2\2P\u0193\3\2\2\2R\u0197\3")
-        buf.write("\2\2\2T\u019c\3\2\2\2V\u01a3\3\2\2\2X\u01aa\3\2\2\2Z\u01ac")
-        buf.write("\3\2\2\2\\\u01af\3\2\2\2^\u01ba\3\2\2\2`\u01cc\3\2\2\2")
-        buf.write("b\u01dc\3\2\2\2d\u01de\3\2\2\2f\u01e1\3\2\2\2h\u01e9\3")
-        buf.write("\2\2\2j\u01ec\3\2\2\2ln\5\4\3\2ml\3\2\2\2mn\3\2\2\2nw")
-        buf.write("\3\2\2\2oq\7J\2\2po\3\2\2\2qr\3\2\2\2rp\3\2\2\2rs\3\2")
-        buf.write("\2\2st\3\2\2\2tv\5\4\3\2up\3\2\2\2vy\3\2\2\2wu\3\2\2\2")
-        buf.write("wx\3\2\2\2x}\3\2\2\2yw\3\2\2\2z|\7J\2\2{z\3\2\2\2|\177")
-        buf.write("\3\2\2\2}{\3\2\2\2}~\3\2\2\2~\u0080\3\2\2\2\177}\3\2\2")
-        buf.write("\2\u0080\u0081\7\2\2\3\u0081\3\3\2\2\2\u0082\u0086\5\22")
-        buf.write("\n\2\u0083\u0086\5\34\17\2\u0084\u0086\5\6\4\2\u0085\u0082")
-        buf.write("\3\2\2\2\u0085\u0083\3\2\2\2\u0085\u0084\3\2\2\2\u0086")
-        buf.write("\5\3\2\2\2\u0087\u009a\5\b\5\2\u0088\u009a\5,\27\2\u0089")
-        buf.write("\u009a\5\60\31\2\u008a\u009a\5\64\33\2\u008b\u009a\5\66")
-        buf.write("\34\2\u008c\u009a\58\35\2\u008d\u009a\5:\36\2\u008e\u009a")
-        buf.write("\5<\37\2\u008f\u009a\5> \2\u0090\u009a\5D#\2\u0091\u009a")
-        buf.write("\5F$\2\u0092\u009a\5V,\2\u0093\u009a\5R*\2\u0094\u009a")
-        buf.write("\5T+\2\u0095\u009a\5X-\2\u0096\u009a\5Z.\2\u0097\u009a")
-        buf.write("\5\\/\2\u0098\u009a\5@!\2\u0099\u0087\3\2\2\2\u0099\u0088")
-        buf.write("\3\2\2\2\u0099\u0089\3\2\2\2\u0099\u008a\3\2\2\2\u0099")
-        buf.write("\u008b\3\2\2\2\u0099\u008c\3\2\2\2\u0099\u008d\3\2\2\2")
-        buf.write("\u0099\u008e\3\2\2\2\u0099\u008f\3\2\2\2\u0099\u0090\3")
-        buf.write("\2\2\2\u0099\u0091\3\2\2\2\u0099\u0092\3\2\2\2\u0099\u0093")
-        buf.write("\3\2\2\2\u0099\u0094\3\2\2\2\u0099\u0095\3\2\2\2\u0099")
-        buf.write("\u0096\3\2\2\2\u0099\u0097\3\2\2\2\u0099\u0098\3\2\2\2")
-        buf.write("\u009a\7\3\2\2\2\u009b\u009d\5\20\t\2\u009c\u009b\3\2")
-        buf.write("\2\2\u009d\u00a0\3\2\2\2\u009e\u009c\3\2\2\2\u009e\u009f")
-        buf.write("\3\2\2\2\u009f\u00a1\3\2\2\2\u00a0\u009e\3\2\2\2\u00a1")
-        buf.write("\u00ad\5\n\6\2\u00a2\u00a3\7@\2\2\u00a3\u00a8\5\16\b\2")
-        buf.write("\u00a4\u00a5\7?\2\2\u00a5\u00a7\5\16\b\2\u00a6\u00a4\3")
-        buf.write("\2\2\2\u00a7\u00aa\3\2\2\2\u00a8\u00a6\3\2\2\2\u00a8\u00a9")
-        buf.write("\3\2\2\2\u00a9\u00ab\3\2\2\2\u00aa\u00a8\3\2\2\2\u00ab")
-        buf.write("\u00ac\7A\2\2\u00ac\u00ae\3\2\2\2\u00ad\u00a2\3\2\2\2")
-        buf.write("\u00ad\u00ae\3\2\2\2\u00ae\u00b0\3\2\2\2\u00af\u00b1\5")
-        buf.write("\f\7\2\u00b0\u00af\3\2\2\2\u00b1\u00b2\3\2\2\2\u00b2\u00b0")
-        buf.write("\3\2\2\2\u00b2\u00b3\3\2\2\2\u00b3\t\3\2\2\2\u00b4\u00b5")
-        buf.write("\7:\2\2\u00b5\13\3\2\2\2\u00b6\u00b7\7;\2\2\u00b7\r\3")
-        buf.write("\2\2\2\u00b8\u00b9\5`\61\2\u00b9\17\3\2\2\2\u00ba\u00bb")
-        buf.write("\t\2\2\2\u00bb\21\3\2\2\2\u00bc\u00bd\7\3\2\2\u00bd\u00cb")
-        buf.write("\5\n\6\2\u00be\u00bf\7@\2\2\u00bf\u00c4\5\24\13\2\u00c0")
-        buf.write("\u00c1\7?\2\2\u00c1\u00c3\5\24\13\2\u00c2\u00c0\3\2\2")
-        buf.write("\2\u00c3\u00c6\3\2\2\2\u00c4\u00c2\3\2\2\2\u00c4\u00c5")
-        buf.write("\3\2\2\2\u00c5\u00c7\3\2\2\2\u00c6\u00c4\3\2\2\2\u00c7")
-        buf.write("\u00c8\7A\2\2\u00c8\u00cc\3\2\2\2\u00c9\u00ca\7\23\2\2")
-        buf.write("\u00ca\u00cc\5\26\f\2\u00cb\u00be\3\2\2\2\u00cb\u00c9")
-        buf.write("\3\2\2\2\u00cb\u00cc\3\2\2\2\u00cc\u00cd\3\2\2\2\u00cd")
-        buf.write("\u00ce\7D\2\2\u00ce\u00cf\7J\2\2\u00cf\u00d0\5\30\r\2")
-        buf.write("\u00d0\23\3\2\2\2\u00d1\u00d2\7E\2\2\u00d2\u00d3\7:\2")
-        buf.write("\2\u00d3\25\3\2\2\2\u00d4\u00d5\t\3\2\2\u00d5\27\3\2\2")
-        buf.write("\2\u00d6\u00d7\5\32\16\2\u00d7\u00d8\7J\2\2\u00d8\u00da")
-        buf.write("\3\2\2\2\u00d9\u00d6\3\2\2\2\u00da\u00dd\3\2\2\2\u00db")
-        buf.write("\u00d9\3\2\2\2\u00db\u00dc\3\2\2\2\u00dc\u00de\3\2\2\2")
-        buf.write("\u00dd\u00db\3\2\2\2\u00de\u00df\5\32\16\2\u00df\31\3")
-        buf.write("\2\2\2\u00e0\u00e1\7I\2\2\u00e1\u00e6\5`\61\2\u00e2\u00e3")
-        buf.write("\7?\2\2\u00e3\u00e5\5`\61\2\u00e4\u00e2\3\2\2\2\u00e5")
-        buf.write("\u00e8\3\2\2\2\u00e6\u00e4\3\2\2\2\u00e6\u00e7\3\2\2\2")
-        buf.write("\u00e7\33\3\2\2\2\u00e8\u00e6\3\2\2\2\u00e9\u00ea\7\4")
-        buf.write("\2\2\u00ea\u00f6\5\n\6\2\u00eb\u00ec\7@\2\2\u00ec\u00f1")
-        buf.write("\5\24\13\2\u00ed\u00ee\7?\2\2\u00ee\u00f0\5\24\13\2\u00ef")
-        buf.write("\u00ed\3\2\2\2\u00f0\u00f3\3\2\2\2\u00f1\u00ef\3\2\2\2")
-        buf.write("\u00f1\u00f2\3\2\2\2\u00f2\u00f4\3\2\2\2\u00f3\u00f1\3")
-        buf.write("\2\2\2\u00f4\u00f5\7A\2\2\u00f5\u00f7\3\2\2\2\u00f6\u00eb")
-        buf.write("\3\2\2\2\u00f6\u00f7\3\2\2\2\u00f7\u00fb\3\2\2\2\u00f8")
-        buf.write("\u00fa\5\36\20\2\u00f9\u00f8\3\2\2\2\u00fa\u00fd\3\2\2")
-        buf.write("\2\u00fb\u00f9\3\2\2\2\u00fb\u00fc\3\2\2\2\u00fc\u00fe")
-        buf.write("\3\2\2\2\u00fd\u00fb\3\2\2\2\u00fe\u00ff\7D\2\2\u00ff")
-        buf.write("\u0100\7J\2\2\u0100\u0101\5*\26\2\u0101\35\3\2\2\2\u0102")
-        buf.write("\u0103\7:\2\2\u0103\37\3\2\2\2\u0104\u0107\5\f\7\2\u0105")
-        buf.write("\u0107\5\36\20\2\u0106\u0104\3\2\2\2\u0106\u0105\3\2\2")
-        buf.write("\2\u0107!\3\2\2\2\u0108\u0114\5\n\6\2\u0109\u010a\7@\2")
-        buf.write("\2\u010a\u010f\5\16\b\2\u010b\u010c\7?\2\2\u010c\u010e")
-        buf.write("\5\16\b\2\u010d\u010b\3\2\2\2\u010e\u0111\3\2\2\2\u010f")
-        buf.write("\u010d\3\2\2\2\u010f\u0110\3\2\2\2\u0110\u0112\3\2\2\2")
-        buf.write("\u0111\u010f\3\2\2\2\u0112\u0113\7A\2\2\u0113\u0115\3")
-        buf.write("\2\2\2\u0114\u0109\3\2\2\2\u0114\u0115\3\2\2\2\u0115\u0117")
-        buf.write("\3\2\2\2\u0116\u0118\5 \21\2\u0117\u0116\3\2\2\2\u0118")
-        buf.write("\u0119\3\2\2\2\u0119\u0117\3\2\2\2\u0119\u011a\3\2\2\2")
-        buf.write("\u011a#\3\2\2\2\u011b\u011c\7\5\2\2\u011c\u011e\5 \21")
-        buf.write("\2\u011d\u011f\5.\30\2\u011e\u011d\3\2\2\2\u011e\u011f")
-        buf.write("\3\2\2\2\u011f%\3\2\2\2\u0120\u0122\7\13\2\2\u0121\u0123")
-        buf.write("\5 \21\2\u0122\u0121\3\2\2\2\u0122\u0123\3\2\2\2\u0123")
-        buf.write("\'\3\2\2\2\u0124\u0129\5\"\22\2\u0125\u0129\5$\23\2\u0126")
-        buf.write("\u0129\5&\24\2\u0127\u0129\5\6\4\2\u0128\u0124\3\2\2\2")
-        buf.write("\u0128\u0125\3\2\2\2\u0128\u0126\3\2\2\2\u0128\u0127\3")
-        buf.write("\2\2\2\u0129)\3\2\2\2\u012a\u012b\7I\2\2\u012b\u012c\5")
-        buf.write("(\25\2\u012c\u012d\7J\2\2\u012d\u012f\3\2\2\2\u012e\u012a")
-        buf.write("\3\2\2\2\u012f\u0132\3\2\2\2\u0130\u012e\3\2\2\2\u0130")
-        buf.write("\u0131\3\2\2\2\u0131\u0133\3\2\2\2\u0132\u0130\3\2\2\2")
-        buf.write("\u0133\u0134\7I\2\2\u0134\u0135\5(\25\2\u0135+\3\2\2\2")
-        buf.write("\u0136\u0137\7\5\2\2\u0137\u0139\5\f\7\2\u0138\u013a\5")
-        buf.write(".\30\2\u0139\u0138\3\2\2\2\u0139\u013a\3\2\2\2\u013a-")
-        buf.write("\3\2\2\2\u013b\u0143\7:\2\2\u013c\u013e\7:\2\2\u013d\u013c")
-        buf.write("\3\2\2\2\u013d\u013e\3\2\2\2\u013e\u013f\3\2\2\2\u013f")
-        buf.write("\u0140\7B\2\2\u0140\u0141\7;\2\2\u0141\u0143\7C\2\2\u0142")
-        buf.write("\u013b\3\2\2\2\u0142\u013d\3\2\2\2\u0143/\3\2\2\2\u0144")
-        buf.write("\u0145\7\6\2\2\u0145\u0146\5\62\32\2\u0146\61\3\2\2\2")
-        buf.write("\u0147\u0148\7F\2\2\u0148\u0149\7:\2\2\u0149\63\3\2\2")
-        buf.write("\2\u014a\u014b\7\7\2\2\u014b\65\3\2\2\2\u014c\u014d\7")
-        buf.write("\b\2\2\u014d\u014e\5\62\32\2\u014e\67\3\2\2\2\u014f\u0150")
-        buf.write("\7\t\2\2\u0150\u0151\5\62\32\2\u0151\u0152\5.\30\2\u0152")
-        buf.write("9\3\2\2\2\u0153\u0154\7\n\2\2\u0154\u0155\5\62\32\2\u0155")
-        buf.write("\u0156\5.\30\2\u0156;\3\2\2\2\u0157\u0159\7\13\2\2\u0158")
-        buf.write("\u015a\5\f\7\2\u0159\u0158\3\2\2\2\u0159\u015a\3\2\2\2")
-        buf.write("\u015a=\3\2\2\2\u015b\u015c\7\f\2\2\u015c?\3\2\2\2\u015d")
-        buf.write("\u015e\7\20\2\2\u015e\u015f\7:\2\2\u015f\u0163\7:\2\2")
-        buf.write("\u0160\u0161\7B\2\2\u0161\u0162\7;\2\2\u0162\u0164\7C")
-        buf.write("\2\2\u0163\u0160\3\2\2\2\u0163\u0164\3\2\2\2\u0164\u016d")
-        buf.write("\3\2\2\2\u0165\u0166\7\21\2\2\u0166\u016a\7:\2\2\u0167")
-        buf.write("\u0169\5B\"\2\u0168\u0167\3\2\2\2\u0169\u016c\3\2\2\2")
-        buf.write("\u016a\u0168\3\2\2\2\u016a\u016b\3\2\2\2\u016b\u016e\3")
-        buf.write("\2\2\2\u016c\u016a\3\2\2\2\u016d\u0165\3\2\2\2\u016d\u016e")
-        buf.write("\3\2\2\2\u016eA\3\2\2\2\u016f\u0170\7\22\2\2\u0170\u0171")
-        buf.write("\7;\2\2\u0171\u0172\7:\2\2\u0172C\3\2\2\2\u0173\u0174")
-        buf.write("\t\4\2\2\u0174\u0175\5.\30\2\u0175E\3\2\2\2\u0176\u017c")
-        buf.write("\5H%\2\u0177\u017c\5J&\2\u0178\u017c\5L\'\2\u0179\u017c")
-        buf.write("\5N(\2\u017a\u017c\5P)\2\u017b\u0176\3\2\2\2\u017b\u0177")
-        buf.write("\3\2\2\2\u017b\u0178\3\2\2\2\u017b\u0179\3\2\2\2\u017b")
-        buf.write("\u017a\3\2\2\2\u017cG\3\2\2\2\u017d\u017e\t\5\2\2\u017e")
-        buf.write("\u0181\5.\30\2\u017f\u0182\5.\30\2\u0180\u0182\7;\2\2")
-        buf.write("\u0181\u017f\3\2\2\2\u0181\u0180\3\2\2\2\u0182I\3\2\2")
-        buf.write("\2\u0183\u0184\t\6\2\2\u0184\u0187\5.\30\2\u0185\u0188")
-        buf.write("\5.\30\2\u0186\u0188\5f\64\2\u0187\u0185\3\2\2\2\u0187")
-        buf.write("\u0186\3\2\2\2\u0188K\3\2\2\2\u0189\u018a\7\"\2\2\u018a")
-        buf.write("\u018d\5.\30\2\u018b\u018e\5.\30\2\u018c\u018e\5f\64\2")
-        buf.write("\u018d\u018b\3\2\2\2\u018d\u018c\3\2\2\2\u018eM\3\2\2")
-        buf.write("\2\u018f\u0190\7#\2\2\u0190\u0191\5.\30\2\u0191\u0192")
-        buf.write("\5.\30\2\u0192O\3\2\2\2\u0193\u0194\7$\2\2\u0194\u0195")
-        buf.write("\5.\30\2\u0195\u0196\5.\30\2\u0196Q\3\2\2\2\u0197\u0198")
-        buf.write("\7*\2\2\u0198\u0199\5.\30\2\u0199\u019a\7:\2\2\u019a\u019b")
-        buf.write("\5.\30\2\u019bS\3\2\2\2\u019c\u019d\7+\2\2\u019d\u019e")
-        buf.write("\7:\2\2\u019e\u01a1\5.\30\2\u019f\u01a2\5.\30\2\u01a0")
-        buf.write("\u01a2\5f\64\2\u01a1\u019f\3\2\2\2\u01a1\u01a0\3\2\2\2")
-        buf.write("\u01a2U\3\2\2\2\u01a3\u01a4\t\7\2\2\u01a4\u01a5\5.\30")
-        buf.write("\2\u01a5\u01a8\5.\30\2\u01a6\u01a9\5.\30\2\u01a7\u01a9")
-        buf.write("\5f\64\2\u01a8\u01a6\3\2\2\2\u01a8\u01a7\3\2\2\2\u01a9")
-        buf.write("W\3\2\2\2\u01aa\u01ab\7\r\2\2\u01abY\3\2\2\2\u01ac\u01ad")
-        buf.write("\7\16\2\2\u01ad\u01ae\7=\2\2\u01ae[\3\2\2\2\u01af\u01b0")
-        buf.write("\7\17\2\2\u01b0\u01b4\7:\2\2\u01b1\u01b3\5^\60\2\u01b2")
-        buf.write("\u01b1\3\2\2\2\u01b3\u01b6\3\2\2\2\u01b4\u01b2\3\2\2\2")
-        buf.write("\u01b4\u01b5\3\2\2\2\u01b5\u01b8\3\2\2\2\u01b6\u01b4\3")
-        buf.write("\2\2\2\u01b7\u01b9\7=\2\2\u01b8\u01b7\3\2\2\2\u01b8\u01b9")
-        buf.write("\3\2\2\2\u01b9]\3\2\2\2\u01ba\u01bb\t\b\2\2\u01bb_\3\2")
-        buf.write("\2\2\u01bc\u01bd\b\61\1\2\u01bd\u01be\7@\2\2\u01be\u01bf")
-        buf.write("\5`\61\2\u01bf\u01c0\7A\2\2\u01c0\u01cd\3\2\2\2\u01c1")
-        buf.write("\u01c2\5d\63\2\u01c2\u01c3\5`\61\n\u01c3\u01cd\3\2\2\2")
-        buf.write("\u01c4\u01c5\5b\62\2\u01c5\u01c6\7@\2\2\u01c6\u01c7\5")
-        buf.write("`\61\2\u01c7\u01c8\7A\2\2\u01c8\u01cd\3\2\2\2\u01c9\u01cd")
-        buf.write("\5f\64\2\u01ca\u01cd\5\24\13\2\u01cb\u01cd\5.\30\2\u01cc")
-        buf.write("\u01bc\3\2\2\2\u01cc\u01c1\3\2\2\2\u01cc\u01c4\3\2\2\2")
-        buf.write("\u01cc\u01c9\3\2\2\2\u01cc\u01ca\3\2\2\2\u01cc\u01cb\3")
-        buf.write("\2\2\2\u01cd\u01d9\3\2\2\2\u01ce\u01cf\f\t\2\2\u01cf\u01d0")
-        buf.write("\7\67\2\2\u01d0\u01d8\5`\61\t\u01d1\u01d2\f\b\2\2\u01d2")
-        buf.write("\u01d3\t\t\2\2\u01d3\u01d8\5`\61\t\u01d4\u01d5\f\7\2\2")
-        buf.write("\u01d5\u01d6\t\n\2\2\u01d6\u01d8\5`\61\b\u01d7\u01ce\3")
-        buf.write("\2\2\2\u01d7\u01d1\3\2\2\2\u01d7\u01d4\3\2\2\2\u01d8\u01db")
-        buf.write("\3\2\2\2\u01d9\u01d7\3\2\2\2\u01d9\u01da\3\2\2\2\u01da")
-        buf.write("a\3\2\2\2\u01db\u01d9\3\2\2\2\u01dc\u01dd\t\13\2\2\u01dd")
-        buf.write("c\3\2\2\2\u01de\u01df\t\n\2\2\u01dfe\3\2\2\2\u01e0\u01e2")
-        buf.write("\7\64\2\2\u01e1\u01e0\3\2\2\2\u01e1\u01e2\3\2\2\2\u01e2")
-        buf.write("\u01e7\3\2\2\2\u01e3\u01e8\5j\66\2\u01e4\u01e8\5h\65\2")
-        buf.write("\u01e5\u01e8\7-\2\2\u01e6\u01e8\7,\2\2\u01e7\u01e3\3\2")
-        buf.write("\2\2\u01e7\u01e4\3\2\2\2\u01e7\u01e5\3\2\2\2\u01e7\u01e6")
-        buf.write("\3\2\2\2\u01e8g\3\2\2\2\u01e9\u01ea\5j\66\2\u01ea\u01eb")
-        buf.write("\7-\2\2\u01ebi\3\2\2\2\u01ec\u01ed\t\f\2\2\u01edk\3\2")
-        buf.write("\2\2/mrw}\u0085\u0099\u009e\u00a8\u00ad\u00b2\u00c4\u00cb")
-        buf.write("\u00db\u00e6\u00f1\u00f6\u00fb\u0106\u010f\u0114\u0119")
-        buf.write("\u011e\u0122\u0128\u0130\u0139\u013d\u0142\u0159\u0163")
-        buf.write("\u016a\u016d\u017b\u0181\u0187\u018d\u01a1\u01a8\u01b4")
-        buf.write("\u01b8\u01cc\u01d7\u01d9\u01e1\u01e7")
+        buf.write("\13\5\3\5\3\5\5\5\u00ae\n\5\3\5\7\5\u00b1\n\5\f\5\16\5")
+        buf.write("\u00b4\13\5\3\6\3\6\3\7\3\7\3\b\3\b\3\t\3\t\3\n\3\n\3")
+        buf.write("\n\3\n\3\n\3\n\7\n\u00c4\n\n\f\n\16\n\u00c7\13\n\3\n\3")
+        buf.write("\n\3\n\3\n\5\n\u00cd\n\n\3\n\3\n\3\n\3\n\3\13\3\13\3\13")
+        buf.write("\3\f\3\f\3\r\3\r\3\r\7\r\u00db\n\r\f\r\16\r\u00de\13\r")
+        buf.write("\3\r\3\r\3\16\3\16\3\16\3\16\7\16\u00e6\n\16\f\16\16\16")
+        buf.write("\u00e9\13\16\3\17\3\17\3\17\3\17\3\17\3\17\7\17\u00f1")
+        buf.write("\n\17\f\17\16\17\u00f4\13\17\3\17\3\17\5\17\u00f8\n\17")
+        buf.write("\3\17\7\17\u00fb\n\17\f\17\16\17\u00fe\13\17\3\17\3\17")
+        buf.write("\3\17\3\17\3\20\3\20\3\21\3\21\5\21\u0108\n\21\3\22\3")
+        buf.write("\22\3\22\3\22\3\22\7\22\u010f\n\22\f\22\16\22\u0112\13")
+        buf.write("\22\3\22\3\22\5\22\u0116\n\22\3\22\6\22\u0119\n\22\r\22")
+        buf.write("\16\22\u011a\3\23\3\23\3\23\5\23\u0120\n\23\3\24\3\24")
+        buf.write("\5\24\u0124\n\24\3\25\3\25\3\25\3\25\5\25\u012a\n\25\3")
+        buf.write("\26\3\26\3\26\3\26\7\26\u0130\n\26\f\26\16\26\u0133\13")
+        buf.write("\26\3\26\3\26\3\26\3\27\3\27\3\27\5\27\u013b\n\27\3\30")
+        buf.write("\3\30\5\30\u013f\n\30\3\30\3\30\3\30\5\30\u0144\n\30\3")
+        buf.write("\31\3\31\3\31\3\32\3\32\3\32\3\33\3\33\3\34\3\34\3\34")
+        buf.write("\3\35\3\35\3\35\3\35\3\36\3\36\3\36\3\36\3\37\3\37\5\37")
+        buf.write("\u015b\n\37\3 \3 \3!\3!\3!\3!\3!\3!\5!\u0165\n!\3!\3!")
+        buf.write("\3!\7!\u016a\n!\f!\16!\u016d\13!\5!\u016f\n!\3\"\3\"\3")
+        buf.write("\"\3\"\3#\3#\3#\3$\3$\3$\3$\3$\5$\u017d\n$\3%\3%\3%\3")
+        buf.write("%\5%\u0183\n%\3&\3&\3&\3&\5&\u0189\n&\3\'\3\'\3\'\3\'")
+        buf.write("\5\'\u018f\n\'\3(\3(\3(\3(\3)\3)\3)\3)\3*\3*\3*\3*\3*")
+        buf.write("\3+\3+\3+\3+\3+\5+\u01a3\n+\3,\3,\3,\3,\3,\5,\u01aa\n")
+        buf.write(",\3-\3-\3.\3.\3.\3/\3/\3/\7/\u01b4\n/\f/\16/\u01b7\13")
+        buf.write("/\3/\5/\u01ba\n/\3\60\3\60\3\61\3\61\3\61\3\61\3\61\3")
+        buf.write("\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61")
+        buf.write("\5\61\u01ce\n\61\3\61\3\61\3\61\3\61\3\61\3\61\3\61\3")
+        buf.write("\61\3\61\7\61\u01d9\n\61\f\61\16\61\u01dc\13\61\3\62\3")
+        buf.write("\62\3\63\3\63\3\64\5\64\u01e3\n\64\3\64\3\64\3\64\3\64")
+        buf.write("\5\64\u01e9\n\64\3\65\3\65\3\65\3\66\3\66\3\66\2\3`\67")
+        buf.write("\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62")
+        buf.write("\64\668:<>@BDFHJLNPRTVXZ\\^`bdfhj\2\r\3\289\3\2\24\25")
+        buf.write("\3\2\26\31\3\2\32\35\3\2\36!\3\2%)\3\2:;\3\2\65\66\3\2")
+        buf.write("\63\64\3\2.\62\3\2;<\2\u0205\2m\3\2\2\2\4\u0085\3\2\2")
+        buf.write("\2\6\u0099\3\2\2\2\b\u009e\3\2\2\2\n\u00b5\3\2\2\2\f\u00b7")
+        buf.write("\3\2\2\2\16\u00b9\3\2\2\2\20\u00bb\3\2\2\2\22\u00bd\3")
+        buf.write("\2\2\2\24\u00d2\3\2\2\2\26\u00d5\3\2\2\2\30\u00dc\3\2")
+        buf.write("\2\2\32\u00e1\3\2\2\2\34\u00ea\3\2\2\2\36\u0103\3\2\2")
+        buf.write("\2 \u0107\3\2\2\2\"\u0109\3\2\2\2$\u011c\3\2\2\2&\u0121")
+        buf.write("\3\2\2\2(\u0129\3\2\2\2*\u0131\3\2\2\2,\u0137\3\2\2\2")
+        buf.write(".\u0143\3\2\2\2\60\u0145\3\2\2\2\62\u0148\3\2\2\2\64\u014b")
+        buf.write("\3\2\2\2\66\u014d\3\2\2\28\u0150\3\2\2\2:\u0154\3\2\2")
+        buf.write("\2<\u0158\3\2\2\2>\u015c\3\2\2\2@\u015e\3\2\2\2B\u0170")
+        buf.write("\3\2\2\2D\u0174\3\2\2\2F\u017c\3\2\2\2H\u017e\3\2\2\2")
+        buf.write("J\u0184\3\2\2\2L\u018a\3\2\2\2N\u0190\3\2\2\2P\u0194\3")
+        buf.write("\2\2\2R\u0198\3\2\2\2T\u019d\3\2\2\2V\u01a4\3\2\2\2X\u01ab")
+        buf.write("\3\2\2\2Z\u01ad\3\2\2\2\\\u01b0\3\2\2\2^\u01bb\3\2\2\2")
+        buf.write("`\u01cd\3\2\2\2b\u01dd\3\2\2\2d\u01df\3\2\2\2f\u01e2\3")
+        buf.write("\2\2\2h\u01ea\3\2\2\2j\u01ed\3\2\2\2ln\5\4\3\2ml\3\2\2")
+        buf.write("\2mn\3\2\2\2nw\3\2\2\2oq\7J\2\2po\3\2\2\2qr\3\2\2\2rp")
+        buf.write("\3\2\2\2rs\3\2\2\2st\3\2\2\2tv\5\4\3\2up\3\2\2\2vy\3\2")
+        buf.write("\2\2wu\3\2\2\2wx\3\2\2\2x}\3\2\2\2yw\3\2\2\2z|\7J\2\2")
+        buf.write("{z\3\2\2\2|\177\3\2\2\2}{\3\2\2\2}~\3\2\2\2~\u0080\3\2")
+        buf.write("\2\2\177}\3\2\2\2\u0080\u0081\7\2\2\3\u0081\3\3\2\2\2")
+        buf.write("\u0082\u0086\5\22\n\2\u0083\u0086\5\34\17\2\u0084\u0086")
+        buf.write("\5\6\4\2\u0085\u0082\3\2\2\2\u0085\u0083\3\2\2\2\u0085")
+        buf.write("\u0084\3\2\2\2\u0086\5\3\2\2\2\u0087\u009a\5\b\5\2\u0088")
+        buf.write("\u009a\5,\27\2\u0089\u009a\5\60\31\2\u008a\u009a\5\64")
+        buf.write("\33\2\u008b\u009a\5\66\34\2\u008c\u009a\58\35\2\u008d")
+        buf.write("\u009a\5:\36\2\u008e\u009a\5<\37\2\u008f\u009a\5> \2\u0090")
+        buf.write("\u009a\5D#\2\u0091\u009a\5F$\2\u0092\u009a\5V,\2\u0093")
+        buf.write("\u009a\5R*\2\u0094\u009a\5T+\2\u0095\u009a\5X-\2\u0096")
+        buf.write("\u009a\5Z.\2\u0097\u009a\5\\/\2\u0098\u009a\5@!\2\u0099")
+        buf.write("\u0087\3\2\2\2\u0099\u0088\3\2\2\2\u0099\u0089\3\2\2\2")
+        buf.write("\u0099\u008a\3\2\2\2\u0099\u008b\3\2\2\2\u0099\u008c\3")
+        buf.write("\2\2\2\u0099\u008d\3\2\2\2\u0099\u008e\3\2\2\2\u0099\u008f")
+        buf.write("\3\2\2\2\u0099\u0090\3\2\2\2\u0099\u0091\3\2\2\2\u0099")
+        buf.write("\u0092\3\2\2\2\u0099\u0093\3\2\2\2\u0099\u0094\3\2\2\2")
+        buf.write("\u0099\u0095\3\2\2\2\u0099\u0096\3\2\2\2\u0099\u0097\3")
+        buf.write("\2\2\2\u0099\u0098\3\2\2\2\u009a\7\3\2\2\2\u009b\u009d")
+        buf.write("\5\20\t\2\u009c\u009b\3\2\2\2\u009d\u00a0\3\2\2\2\u009e")
+        buf.write("\u009c\3\2\2\2\u009e\u009f\3\2\2\2\u009f\u00a1\3\2\2\2")
+        buf.write("\u00a0\u009e\3\2\2\2\u00a1\u00ad\5\n\6\2\u00a2\u00a3\7")
+        buf.write("@\2\2\u00a3\u00a8\5\16\b\2\u00a4\u00a5\7?\2\2\u00a5\u00a7")
+        buf.write("\5\16\b\2\u00a6\u00a4\3\2\2\2\u00a7\u00aa\3\2\2\2\u00a8")
+        buf.write("\u00a6\3\2\2\2\u00a8\u00a9\3\2\2\2\u00a9\u00ab\3\2\2\2")
+        buf.write("\u00aa\u00a8\3\2\2\2\u00ab\u00ac\7A\2\2\u00ac\u00ae\3")
+        buf.write("\2\2\2\u00ad\u00a2\3\2\2\2\u00ad\u00ae\3\2\2\2\u00ae\u00b2")
+        buf.write("\3\2\2\2\u00af\u00b1\5\f\7\2\u00b0\u00af\3\2\2\2\u00b1")
+        buf.write("\u00b4\3\2\2\2\u00b2\u00b0\3\2\2\2\u00b2\u00b3\3\2\2\2")
+        buf.write("\u00b3\t\3\2\2\2\u00b4\u00b2\3\2\2\2\u00b5\u00b6\7:\2")
+        buf.write("\2\u00b6\13\3\2\2\2\u00b7\u00b8\7;\2\2\u00b8\r\3\2\2\2")
+        buf.write("\u00b9\u00ba\5`\61\2\u00ba\17\3\2\2\2\u00bb\u00bc\t\2")
+        buf.write("\2\2\u00bc\21\3\2\2\2\u00bd\u00be\7\3\2\2\u00be\u00cc")
+        buf.write("\5\n\6\2\u00bf\u00c0\7@\2\2\u00c0\u00c5\5\24\13\2\u00c1")
+        buf.write("\u00c2\7?\2\2\u00c2\u00c4\5\24\13\2\u00c3\u00c1\3\2\2")
+        buf.write("\2\u00c4\u00c7\3\2\2\2\u00c5\u00c3\3\2\2\2\u00c5\u00c6")
+        buf.write("\3\2\2\2\u00c6\u00c8\3\2\2\2\u00c7\u00c5\3\2\2\2\u00c8")
+        buf.write("\u00c9\7A\2\2\u00c9\u00cd\3\2\2\2\u00ca\u00cb\7\23\2\2")
+        buf.write("\u00cb\u00cd\5\26\f\2\u00cc\u00bf\3\2\2\2\u00cc\u00ca")
+        buf.write("\3\2\2\2\u00cc\u00cd\3\2\2\2\u00cd\u00ce\3\2\2\2\u00ce")
+        buf.write("\u00cf\7D\2\2\u00cf\u00d0\7J\2\2\u00d0\u00d1\5\30\r\2")
+        buf.write("\u00d1\23\3\2\2\2\u00d2\u00d3\7E\2\2\u00d3\u00d4\7:\2")
+        buf.write("\2\u00d4\25\3\2\2\2\u00d5\u00d6\t\3\2\2\u00d6\27\3\2\2")
+        buf.write("\2\u00d7\u00d8\5\32\16\2\u00d8\u00d9\7J\2\2\u00d9\u00db")
+        buf.write("\3\2\2\2\u00da\u00d7\3\2\2\2\u00db\u00de\3\2\2\2\u00dc")
+        buf.write("\u00da\3\2\2\2\u00dc\u00dd\3\2\2\2\u00dd\u00df\3\2\2\2")
+        buf.write("\u00de\u00dc\3\2\2\2\u00df\u00e0\5\32\16\2\u00e0\31\3")
+        buf.write("\2\2\2\u00e1\u00e2\7I\2\2\u00e2\u00e7\5`\61\2\u00e3\u00e4")
+        buf.write("\7?\2\2\u00e4\u00e6\5`\61\2\u00e5\u00e3\3\2\2\2\u00e6")
+        buf.write("\u00e9\3\2\2\2\u00e7\u00e5\3\2\2\2\u00e7\u00e8\3\2\2\2")
+        buf.write("\u00e8\33\3\2\2\2\u00e9\u00e7\3\2\2\2\u00ea\u00eb\7\4")
+        buf.write("\2\2\u00eb\u00f7\5\n\6\2\u00ec\u00ed\7@\2\2\u00ed\u00f2")
+        buf.write("\5\24\13\2\u00ee\u00ef\7?\2\2\u00ef\u00f1\5\24\13\2\u00f0")
+        buf.write("\u00ee\3\2\2\2\u00f1\u00f4\3\2\2\2\u00f2\u00f0\3\2\2\2")
+        buf.write("\u00f2\u00f3\3\2\2\2\u00f3\u00f5\3\2\2\2\u00f4\u00f2\3")
+        buf.write("\2\2\2\u00f5\u00f6\7A\2\2\u00f6\u00f8\3\2\2\2\u00f7\u00ec")
+        buf.write("\3\2\2\2\u00f7\u00f8\3\2\2\2\u00f8\u00fc\3\2\2\2\u00f9")
+        buf.write("\u00fb\5\36\20\2\u00fa\u00f9\3\2\2\2\u00fb\u00fe\3\2\2")
+        buf.write("\2\u00fc\u00fa\3\2\2\2\u00fc\u00fd\3\2\2\2\u00fd\u00ff")
+        buf.write("\3\2\2\2\u00fe\u00fc\3\2\2\2\u00ff\u0100\7D\2\2\u0100")
+        buf.write("\u0101\7J\2\2\u0101\u0102\5*\26\2\u0102\35\3\2\2\2\u0103")
+        buf.write("\u0104\7:\2\2\u0104\37\3\2\2\2\u0105\u0108\5\f\7\2\u0106")
+        buf.write("\u0108\5\36\20\2\u0107\u0105\3\2\2\2\u0107\u0106\3\2\2")
+        buf.write("\2\u0108!\3\2\2\2\u0109\u0115\5\n\6\2\u010a\u010b\7@\2")
+        buf.write("\2\u010b\u0110\5\16\b\2\u010c\u010d\7?\2\2\u010d\u010f")
+        buf.write("\5\16\b\2\u010e\u010c\3\2\2\2\u010f\u0112\3\2\2\2\u0110")
+        buf.write("\u010e\3\2\2\2\u0110\u0111\3\2\2\2\u0111\u0113\3\2\2\2")
+        buf.write("\u0112\u0110\3\2\2\2\u0113\u0114\7A\2\2\u0114\u0116\3")
+        buf.write("\2\2\2\u0115\u010a\3\2\2\2\u0115\u0116\3\2\2\2\u0116\u0118")
+        buf.write("\3\2\2\2\u0117\u0119\5 \21\2\u0118\u0117\3\2\2\2\u0119")
+        buf.write("\u011a\3\2\2\2\u011a\u0118\3\2\2\2\u011a\u011b\3\2\2\2")
+        buf.write("\u011b#\3\2\2\2\u011c\u011d\7\5\2\2\u011d\u011f\5 \21")
+        buf.write("\2\u011e\u0120\5.\30\2\u011f\u011e\3\2\2\2\u011f\u0120")
+        buf.write("\3\2\2\2\u0120%\3\2\2\2\u0121\u0123\7\13\2\2\u0122\u0124")
+        buf.write("\5 \21\2\u0123\u0122\3\2\2\2\u0123\u0124\3\2\2\2\u0124")
+        buf.write("\'\3\2\2\2\u0125\u012a\5\"\22\2\u0126\u012a\5$\23\2\u0127")
+        buf.write("\u012a\5&\24\2\u0128\u012a\5\6\4\2\u0129\u0125\3\2\2\2")
+        buf.write("\u0129\u0126\3\2\2\2\u0129\u0127\3\2\2\2\u0129\u0128\3")
+        buf.write("\2\2\2\u012a)\3\2\2\2\u012b\u012c\7I\2\2\u012c\u012d\5")
+        buf.write("(\25\2\u012d\u012e\7J\2\2\u012e\u0130\3\2\2\2\u012f\u012b")
+        buf.write("\3\2\2\2\u0130\u0133\3\2\2\2\u0131\u012f\3\2\2\2\u0131")
+        buf.write("\u0132\3\2\2\2\u0132\u0134\3\2\2\2\u0133\u0131\3\2\2\2")
+        buf.write("\u0134\u0135\7I\2\2\u0135\u0136\5(\25\2\u0136+\3\2\2\2")
+        buf.write("\u0137\u0138\7\5\2\2\u0138\u013a\5\f\7\2\u0139\u013b\5")
+        buf.write(".\30\2\u013a\u0139\3\2\2\2\u013a\u013b\3\2\2\2\u013b-")
+        buf.write("\3\2\2\2\u013c\u0144\7:\2\2\u013d\u013f\7:\2\2\u013e\u013d")
+        buf.write("\3\2\2\2\u013e\u013f\3\2\2\2\u013f\u0140\3\2\2\2\u0140")
+        buf.write("\u0141\7B\2\2\u0141\u0142\7;\2\2\u0142\u0144\7C\2\2\u0143")
+        buf.write("\u013c\3\2\2\2\u0143\u013e\3\2\2\2\u0144/\3\2\2\2\u0145")
+        buf.write("\u0146\7\6\2\2\u0146\u0147\5\62\32\2\u0147\61\3\2\2\2")
+        buf.write("\u0148\u0149\7F\2\2\u0149\u014a\7:\2\2\u014a\63\3\2\2")
+        buf.write("\2\u014b\u014c\7\7\2\2\u014c\65\3\2\2\2\u014d\u014e\7")
+        buf.write("\b\2\2\u014e\u014f\5\62\32\2\u014f\67\3\2\2\2\u0150\u0151")
+        buf.write("\7\t\2\2\u0151\u0152\5\62\32\2\u0152\u0153\5.\30\2\u0153")
+        buf.write("9\3\2\2\2\u0154\u0155\7\n\2\2\u0155\u0156\5\62\32\2\u0156")
+        buf.write("\u0157\5.\30\2\u0157;\3\2\2\2\u0158\u015a\7\13\2\2\u0159")
+        buf.write("\u015b\5\f\7\2\u015a\u0159\3\2\2\2\u015a\u015b\3\2\2\2")
+        buf.write("\u015b=\3\2\2\2\u015c\u015d\7\f\2\2\u015d?\3\2\2\2\u015e")
+        buf.write("\u015f\7\20\2\2\u015f\u0160\7:\2\2\u0160\u0164\7:\2\2")
+        buf.write("\u0161\u0162\7B\2\2\u0162\u0163\7;\2\2\u0163\u0165\7C")
+        buf.write("\2\2\u0164\u0161\3\2\2\2\u0164\u0165\3\2\2\2\u0165\u016e")
+        buf.write("\3\2\2\2\u0166\u0167\7\21\2\2\u0167\u016b\7:\2\2\u0168")
+        buf.write("\u016a\5B\"\2\u0169\u0168\3\2\2\2\u016a\u016d\3\2\2\2")
+        buf.write("\u016b\u0169\3\2\2\2\u016b\u016c\3\2\2\2\u016c\u016f\3")
+        buf.write("\2\2\2\u016d\u016b\3\2\2\2\u016e\u0166\3\2\2\2\u016e\u016f")
+        buf.write("\3\2\2\2\u016fA\3\2\2\2\u0170\u0171\7\22\2\2\u0171\u0172")
+        buf.write("\7;\2\2\u0172\u0173\7:\2\2\u0173C\3\2\2\2\u0174\u0175")
+        buf.write("\t\4\2\2\u0175\u0176\5.\30\2\u0176E\3\2\2\2\u0177\u017d")
+        buf.write("\5H%\2\u0178\u017d\5J&\2\u0179\u017d\5L\'\2\u017a\u017d")
+        buf.write("\5N(\2\u017b\u017d\5P)\2\u017c\u0177\3\2\2\2\u017c\u0178")
+        buf.write("\3\2\2\2\u017c\u0179\3\2\2\2\u017c\u017a\3\2\2\2\u017c")
+        buf.write("\u017b\3\2\2\2\u017dG\3\2\2\2\u017e\u017f\t\5\2\2\u017f")
+        buf.write("\u0182\5.\30\2\u0180\u0183\5.\30\2\u0181\u0183\7;\2\2")
+        buf.write("\u0182\u0180\3\2\2\2\u0182\u0181\3\2\2\2\u0183I\3\2\2")
+        buf.write("\2\u0184\u0185\t\6\2\2\u0185\u0188\5.\30\2\u0186\u0189")
+        buf.write("\5.\30\2\u0187\u0189\5f\64\2\u0188\u0186\3\2\2\2\u0188")
+        buf.write("\u0187\3\2\2\2\u0189K\3\2\2\2\u018a\u018b\7\"\2\2\u018b")
+        buf.write("\u018e\5.\30\2\u018c\u018f\5.\30\2\u018d\u018f\5f\64\2")
+        buf.write("\u018e\u018c\3\2\2\2\u018e\u018d\3\2\2\2\u018fM\3\2\2")
+        buf.write("\2\u0190\u0191\7#\2\2\u0191\u0192\5.\30\2\u0192\u0193")
+        buf.write("\5.\30\2\u0193O\3\2\2\2\u0194\u0195\7$\2\2\u0195\u0196")
+        buf.write("\5.\30\2\u0196\u0197\5.\30\2\u0197Q\3\2\2\2\u0198\u0199")
+        buf.write("\7*\2\2\u0199\u019a\5.\30\2\u019a\u019b\7:\2\2\u019b\u019c")
+        buf.write("\5.\30\2\u019cS\3\2\2\2\u019d\u019e\7+\2\2\u019e\u019f")
+        buf.write("\7:\2\2\u019f\u01a2\5.\30\2\u01a0\u01a3\5.\30\2\u01a1")
+        buf.write("\u01a3\5f\64\2\u01a2\u01a0\3\2\2\2\u01a2\u01a1\3\2\2\2")
+        buf.write("\u01a3U\3\2\2\2\u01a4\u01a5\t\7\2\2\u01a5\u01a6\5.\30")
+        buf.write("\2\u01a6\u01a9\5.\30\2\u01a7\u01aa\5.\30\2\u01a8\u01aa")
+        buf.write("\5f\64\2\u01a9\u01a7\3\2\2\2\u01a9\u01a8\3\2\2\2\u01aa")
+        buf.write("W\3\2\2\2\u01ab\u01ac\7\r\2\2\u01acY\3\2\2\2\u01ad\u01ae")
+        buf.write("\7\16\2\2\u01ae\u01af\7=\2\2\u01af[\3\2\2\2\u01b0\u01b1")
+        buf.write("\7\17\2\2\u01b1\u01b5\7:\2\2\u01b2\u01b4\5^\60\2\u01b3")
+        buf.write("\u01b2\3\2\2\2\u01b4\u01b7\3\2\2\2\u01b5\u01b3\3\2\2\2")
+        buf.write("\u01b5\u01b6\3\2\2\2\u01b6\u01b9\3\2\2\2\u01b7\u01b5\3")
+        buf.write("\2\2\2\u01b8\u01ba\7=\2\2\u01b9\u01b8\3\2\2\2\u01b9\u01ba")
+        buf.write("\3\2\2\2\u01ba]\3\2\2\2\u01bb\u01bc\t\b\2\2\u01bc_\3\2")
+        buf.write("\2\2\u01bd\u01be\b\61\1\2\u01be\u01bf\7@\2\2\u01bf\u01c0")
+        buf.write("\5`\61\2\u01c0\u01c1\7A\2\2\u01c1\u01ce\3\2\2\2\u01c2")
+        buf.write("\u01c3\5d\63\2\u01c3\u01c4\5`\61\n\u01c4\u01ce\3\2\2\2")
+        buf.write("\u01c5\u01c6\5b\62\2\u01c6\u01c7\7@\2\2\u01c7\u01c8\5")
+        buf.write("`\61\2\u01c8\u01c9\7A\2\2\u01c9\u01ce\3\2\2\2\u01ca\u01ce")
+        buf.write("\5f\64\2\u01cb\u01ce\5\24\13\2\u01cc\u01ce\5.\30\2\u01cd")
+        buf.write("\u01bd\3\2\2\2\u01cd\u01c2\3\2\2\2\u01cd\u01c5\3\2\2\2")
+        buf.write("\u01cd\u01ca\3\2\2\2\u01cd\u01cb\3\2\2\2\u01cd\u01cc\3")
+        buf.write("\2\2\2\u01ce\u01da\3\2\2\2\u01cf\u01d0\f\t\2\2\u01d0\u01d1")
+        buf.write("\7\67\2\2\u01d1\u01d9\5`\61\t\u01d2\u01d3\f\b\2\2\u01d3")
+        buf.write("\u01d4\t\t\2\2\u01d4\u01d9\5`\61\t\u01d5\u01d6\f\7\2\2")
+        buf.write("\u01d6\u01d7\t\n\2\2\u01d7\u01d9\5`\61\b\u01d8\u01cf\3")
+        buf.write("\2\2\2\u01d8\u01d2\3\2\2\2\u01d8\u01d5\3\2\2\2\u01d9\u01dc")
+        buf.write("\3\2\2\2\u01da\u01d8\3\2\2\2\u01da\u01db\3\2\2\2\u01db")
+        buf.write("a\3\2\2\2\u01dc\u01da\3\2\2\2\u01dd\u01de\t\13\2\2\u01de")
+        buf.write("c\3\2\2\2\u01df\u01e0\t\n\2\2\u01e0e\3\2\2\2\u01e1\u01e3")
+        buf.write("\7\64\2\2\u01e2\u01e1\3\2\2\2\u01e2\u01e3\3\2\2\2\u01e3")
+        buf.write("\u01e8\3\2\2\2\u01e4\u01e9\5j\66\2\u01e5\u01e9\5h\65\2")
+        buf.write("\u01e6\u01e9\7-\2\2\u01e7\u01e9\7,\2\2\u01e8\u01e4\3\2")
+        buf.write("\2\2\u01e8\u01e5\3\2\2\2\u01e8\u01e6\3\2\2\2\u01e8\u01e7")
+        buf.write("\3\2\2\2\u01e9g\3\2\2\2\u01ea\u01eb\5j\66\2\u01eb\u01ec")
+        buf.write("\7-\2\2\u01eci\3\2\2\2\u01ed\u01ee\t\f\2\2\u01eek\3\2")
+        buf.write("\2\2/mrw}\u0085\u0099\u009e\u00a8\u00ad\u00b2\u00c5\u00cc")
+        buf.write("\u00dc\u00e7\u00f2\u00f7\u00fc\u0107\u0110\u0115\u011a")
+        buf.write("\u011f\u0123\u0129\u0131\u013a\u013e\u0143\u015a\u0164")
+        buf.write("\u016b\u016e\u017c\u0182\u0188\u018e\u01a2\u01a9\u01b5")
+        buf.write("\u01b9\u01cd\u01d8\u01da\u01e2\u01e8")
         return buf.getvalue()
 
 
@@ -891,17 +892,15 @@ class QuilParser ( Parser ):
                 self.match(QuilParser.RPAREN)
 
 
-            self.state = 174 
+            self.state = 176
             self._errHandler.sync(self)
             _la = self._input.LA(1)
-            while True:
+            while _la==QuilParser.INT:
                 self.state = 173
                 self.qubit()
-                self.state = 176 
+                self.state = 178
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
-                if not (_la==QuilParser.INT):
-                    break
 
         except RecognitionException as re:
             localctx.exception = re
@@ -940,7 +939,7 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 8, self.RULE_name)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 178
+            self.state = 179
             self.match(QuilParser.IDENTIFIER)
         except RecognitionException as re:
             localctx.exception = re
@@ -979,7 +978,7 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 10, self.RULE_qubit)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 180
+            self.state = 181
             self.match(QuilParser.INT)
         except RecognitionException as re:
             localctx.exception = re
@@ -1019,7 +1018,7 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 12, self.RULE_param)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 182
+            self.state = 183
             self.expression(0)
         except RecognitionException as re:
             localctx.exception = re
@@ -1062,7 +1061,7 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 184
+            self.state = 185
             _la = self._input.LA(1)
             if not(_la==QuilParser.CONTROLLED or _la==QuilParser.DAGGER):
                 self._errHandler.recoverInline(self)
@@ -1147,48 +1146,48 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 186
-            self.match(QuilParser.DEFGATE)
             self.state = 187
+            self.match(QuilParser.DEFGATE)
+            self.state = 188
             self.name()
-            self.state = 201
+            self.state = 202
             self._errHandler.sync(self)
             token = self._input.LA(1)
             if token in [QuilParser.LPAREN]:
-                self.state = 188
-                self.match(QuilParser.LPAREN)
                 self.state = 189
+                self.match(QuilParser.LPAREN)
+                self.state = 190
                 self.variable()
-                self.state = 194
+                self.state = 195
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 while _la==QuilParser.COMMA:
-                    self.state = 190
-                    self.match(QuilParser.COMMA)
                     self.state = 191
+                    self.match(QuilParser.COMMA)
+                    self.state = 192
                     self.variable()
-                    self.state = 196
+                    self.state = 197
                     self._errHandler.sync(self)
                     _la = self._input.LA(1)
 
-                self.state = 197
+                self.state = 198
                 self.match(QuilParser.RPAREN)
                 pass
             elif token in [QuilParser.AS]:
-                self.state = 199
-                self.match(QuilParser.AS)
                 self.state = 200
+                self.match(QuilParser.AS)
+                self.state = 201
                 self.gatetype()
                 pass
             elif token in [QuilParser.COLON]:
                 pass
             else:
                 pass
-            self.state = 203
-            self.match(QuilParser.COLON)
             self.state = 204
-            self.match(QuilParser.NEWLINE)
+            self.match(QuilParser.COLON)
             self.state = 205
+            self.match(QuilParser.NEWLINE)
+            self.state = 206
             self.matrix()
         except RecognitionException as re:
             localctx.exception = re
@@ -1230,9 +1229,9 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 18, self.RULE_variable)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 207
-            self.match(QuilParser.PERCENTAGE)
             self.state = 208
+            self.match(QuilParser.PERCENTAGE)
+            self.state = 209
             self.match(QuilParser.IDENTIFIER)
         except RecognitionException as re:
             localctx.exception = re
@@ -1275,7 +1274,7 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 210
+            self.state = 211
             _la = self._input.LA(1)
             if not(_la==QuilParser.MATRIX or _la==QuilParser.PERMUTATION):
                 self._errHandler.recoverInline(self)
@@ -1329,20 +1328,20 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 22, self.RULE_matrix)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 217
+            self.state = 218
             self._errHandler.sync(self)
             _alt = self._interp.adaptivePredict(self._input,12,self._ctx)
             while _alt!=2 and _alt!=ATN.INVALID_ALT_NUMBER:
                 if _alt==1:
-                    self.state = 212
-                    self.matrixRow()
                     self.state = 213
+                    self.matrixRow()
+                    self.state = 214
                     self.match(QuilParser.NEWLINE) 
-                self.state = 219
+                self.state = 220
                 self._errHandler.sync(self)
                 _alt = self._interp.adaptivePredict(self._input,12,self._ctx)
 
-            self.state = 220
+            self.state = 221
             self.matrixRow()
         except RecognitionException as re:
             localctx.exception = re
@@ -1395,19 +1394,19 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 222
-            self.match(QuilParser.TAB)
             self.state = 223
+            self.match(QuilParser.TAB)
+            self.state = 224
             self.expression(0)
-            self.state = 228
+            self.state = 229
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             while _la==QuilParser.COMMA:
-                self.state = 224
-                self.match(QuilParser.COMMA)
                 self.state = 225
+                self.match(QuilParser.COMMA)
+                self.state = 226
                 self.expression(0)
-                self.state = 230
+                self.state = 231
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
 
@@ -1489,49 +1488,49 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 231
-            self.match(QuilParser.DEFCIRCUIT)
             self.state = 232
+            self.match(QuilParser.DEFCIRCUIT)
+            self.state = 233
             self.name()
-            self.state = 244
+            self.state = 245
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==QuilParser.LPAREN:
-                self.state = 233
-                self.match(QuilParser.LPAREN)
                 self.state = 234
+                self.match(QuilParser.LPAREN)
+                self.state = 235
                 self.variable()
-                self.state = 239
+                self.state = 240
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 while _la==QuilParser.COMMA:
-                    self.state = 235
-                    self.match(QuilParser.COMMA)
                     self.state = 236
+                    self.match(QuilParser.COMMA)
+                    self.state = 237
                     self.variable()
-                    self.state = 241
+                    self.state = 242
                     self._errHandler.sync(self)
                     _la = self._input.LA(1)
 
-                self.state = 242
+                self.state = 243
                 self.match(QuilParser.RPAREN)
 
 
-            self.state = 249
+            self.state = 250
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             while _la==QuilParser.IDENTIFIER:
-                self.state = 246
+                self.state = 247
                 self.qubitVariable()
-                self.state = 251
+                self.state = 252
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
 
-            self.state = 252
-            self.match(QuilParser.COLON)
             self.state = 253
-            self.match(QuilParser.NEWLINE)
+            self.match(QuilParser.COLON)
             self.state = 254
+            self.match(QuilParser.NEWLINE)
+            self.state = 255
             self.circuit()
         except RecognitionException as re:
             localctx.exception = re
@@ -1570,7 +1569,7 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 28, self.RULE_qubitVariable)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 256
+            self.state = 257
             self.match(QuilParser.IDENTIFIER)
         except RecognitionException as re:
             localctx.exception = re
@@ -1613,17 +1612,17 @@ class QuilParser ( Parser ):
         localctx = QuilParser.CircuitQubitContext(self, self._ctx, self.state)
         self.enterRule(localctx, 30, self.RULE_circuitQubit)
         try:
-            self.state = 260
+            self.state = 261
             self._errHandler.sync(self)
             token = self._input.LA(1)
             if token in [QuilParser.INT]:
                 self.enterOuterAlt(localctx, 1)
-                self.state = 258
+                self.state = 259
                 self.qubit()
                 pass
             elif token in [QuilParser.IDENTIFIER]:
                 self.enterOuterAlt(localctx, 2)
-                self.state = 259
+                self.state = 260
                 self.qubitVariable()
                 pass
             else:
@@ -1694,39 +1693,39 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 262
+            self.state = 263
             self.name()
-            self.state = 274
+            self.state = 275
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==QuilParser.LPAREN:
-                self.state = 263
-                self.match(QuilParser.LPAREN)
                 self.state = 264
+                self.match(QuilParser.LPAREN)
+                self.state = 265
                 self.param()
-                self.state = 269
+                self.state = 270
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 while _la==QuilParser.COMMA:
-                    self.state = 265
-                    self.match(QuilParser.COMMA)
                     self.state = 266
+                    self.match(QuilParser.COMMA)
+                    self.state = 267
                     self.param()
-                    self.state = 271
+                    self.state = 272
                     self._errHandler.sync(self)
                     _la = self._input.LA(1)
 
-                self.state = 272
+                self.state = 273
                 self.match(QuilParser.RPAREN)
 
 
-            self.state = 277 
+            self.state = 278 
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             while True:
-                self.state = 276
+                self.state = 277
                 self.circuitQubit()
-                self.state = 279 
+                self.state = 280 
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 if not (_la==QuilParser.IDENTIFIER or _la==QuilParser.INT):
@@ -1778,15 +1777,15 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 281
-            self.match(QuilParser.MEASURE)
             self.state = 282
+            self.match(QuilParser.MEASURE)
+            self.state = 283
             self.circuitQubit()
-            self.state = 284
+            self.state = 285
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==QuilParser.IDENTIFIER or _la==QuilParser.LBRACKET:
-                self.state = 283
+                self.state = 284
                 self.addr()
 
 
@@ -1832,13 +1831,13 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 286
+            self.state = 287
             self.match(QuilParser.RESET)
-            self.state = 288
+            self.state = 289
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==QuilParser.IDENTIFIER or _la==QuilParser.INT:
-                self.state = 287
+                self.state = 288
                 self.circuitQubit()
 
 
@@ -1891,30 +1890,30 @@ class QuilParser ( Parser ):
         localctx = QuilParser.CircuitInstrContext(self, self._ctx, self.state)
         self.enterRule(localctx, 38, self.RULE_circuitInstr)
         try:
-            self.state = 294
+            self.state = 295
             self._errHandler.sync(self)
             la_ = self._interp.adaptivePredict(self._input,23,self._ctx)
             if la_ == 1:
                 self.enterOuterAlt(localctx, 1)
-                self.state = 290
+                self.state = 291
                 self.circuitGate()
                 pass
 
             elif la_ == 2:
                 self.enterOuterAlt(localctx, 2)
-                self.state = 291
+                self.state = 292
                 self.circuitMeasure()
                 pass
 
             elif la_ == 3:
                 self.enterOuterAlt(localctx, 3)
-                self.state = 292
+                self.state = 293
                 self.circuitResetState()
                 pass
 
             elif la_ == 4:
                 self.enterOuterAlt(localctx, 4)
-                self.state = 293
+                self.state = 294
                 self.instr()
                 pass
 
@@ -1972,24 +1971,24 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 40, self.RULE_circuit)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 302
+            self.state = 303
             self._errHandler.sync(self)
             _alt = self._interp.adaptivePredict(self._input,24,self._ctx)
             while _alt!=2 and _alt!=ATN.INVALID_ALT_NUMBER:
                 if _alt==1:
-                    self.state = 296
-                    self.match(QuilParser.TAB)
                     self.state = 297
-                    self.circuitInstr()
+                    self.match(QuilParser.TAB)
                     self.state = 298
+                    self.circuitInstr()
+                    self.state = 299
                     self.match(QuilParser.NEWLINE) 
-                self.state = 304
+                self.state = 305
                 self._errHandler.sync(self)
                 _alt = self._interp.adaptivePredict(self._input,24,self._ctx)
 
-            self.state = 305
-            self.match(QuilParser.TAB)
             self.state = 306
+            self.match(QuilParser.TAB)
+            self.state = 307
             self.circuitInstr()
         except RecognitionException as re:
             localctx.exception = re
@@ -2037,15 +2036,15 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 308
-            self.match(QuilParser.MEASURE)
             self.state = 309
+            self.match(QuilParser.MEASURE)
+            self.state = 310
             self.qubit()
-            self.state = 311
+            self.state = 312
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==QuilParser.IDENTIFIER or _la==QuilParser.LBRACKET:
-                self.state = 310
+                self.state = 311
                 self.addr()
 
 
@@ -2095,30 +2094,30 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 44, self.RULE_addr)
         self._la = 0 # Token type
         try:
-            self.state = 320
+            self.state = 321
             self._errHandler.sync(self)
             la_ = self._interp.adaptivePredict(self._input,27,self._ctx)
             if la_ == 1:
                 self.enterOuterAlt(localctx, 1)
-                self.state = 313
+                self.state = 314
                 self.match(QuilParser.IDENTIFIER)
                 pass
 
             elif la_ == 2:
                 self.enterOuterAlt(localctx, 2)
-                self.state = 315
+                self.state = 316
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 if _la==QuilParser.IDENTIFIER:
-                    self.state = 314
+                    self.state = 315
                     self.match(QuilParser.IDENTIFIER)
 
 
-                self.state = 317
-                self.match(QuilParser.LBRACKET)
                 self.state = 318
-                self.match(QuilParser.INT)
+                self.match(QuilParser.LBRACKET)
                 self.state = 319
+                self.match(QuilParser.INT)
+                self.state = 320
                 self.match(QuilParser.RBRACKET)
                 pass
 
@@ -2164,9 +2163,9 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 46, self.RULE_defLabel)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 322
-            self.match(QuilParser.LABEL)
             self.state = 323
+            self.match(QuilParser.LABEL)
+            self.state = 324
             self.label()
         except RecognitionException as re:
             localctx.exception = re
@@ -2208,9 +2207,9 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 48, self.RULE_label)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 325
-            self.match(QuilParser.AT)
             self.state = 326
+            self.match(QuilParser.AT)
+            self.state = 327
             self.match(QuilParser.IDENTIFIER)
         except RecognitionException as re:
             localctx.exception = re
@@ -2249,7 +2248,7 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 50, self.RULE_halt)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 328
+            self.state = 329
             self.match(QuilParser.HALT)
         except RecognitionException as re:
             localctx.exception = re
@@ -2292,9 +2291,9 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 52, self.RULE_jump)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 330
-            self.match(QuilParser.JUMP)
             self.state = 331
+            self.match(QuilParser.JUMP)
+            self.state = 332
             self.label()
         except RecognitionException as re:
             localctx.exception = re
@@ -2341,11 +2340,11 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 54, self.RULE_jumpWhen)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 333
-            self.match(QuilParser.JUMPWHEN)
             self.state = 334
-            self.label()
+            self.match(QuilParser.JUMPWHEN)
             self.state = 335
+            self.label()
+            self.state = 336
             self.addr()
         except RecognitionException as re:
             localctx.exception = re
@@ -2392,11 +2391,11 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 56, self.RULE_jumpUnless)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 337
-            self.match(QuilParser.JUMPUNLESS)
             self.state = 338
-            self.label()
+            self.match(QuilParser.JUMPUNLESS)
             self.state = 339
+            self.label()
+            self.state = 340
             self.addr()
         except RecognitionException as re:
             localctx.exception = re
@@ -2440,13 +2439,13 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 341
+            self.state = 342
             self.match(QuilParser.RESET)
-            self.state = 343
+            self.state = 344
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==QuilParser.INT:
-                self.state = 342
+                self.state = 343
                 self.qubit()
 
 
@@ -2487,7 +2486,7 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 60, self.RULE_wait)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 345
+            self.state = 346
             self.match(QuilParser.WAIT)
         except RecognitionException as re:
             localctx.exception = re
@@ -2552,39 +2551,39 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 347
-            self.match(QuilParser.DECLARE)
             self.state = 348
-            self.match(QuilParser.IDENTIFIER)
+            self.match(QuilParser.DECLARE)
             self.state = 349
             self.match(QuilParser.IDENTIFIER)
-            self.state = 353
+            self.state = 350
+            self.match(QuilParser.IDENTIFIER)
+            self.state = 354
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==QuilParser.LBRACKET:
-                self.state = 350
-                self.match(QuilParser.LBRACKET)
                 self.state = 351
-                self.match(QuilParser.INT)
+                self.match(QuilParser.LBRACKET)
                 self.state = 352
+                self.match(QuilParser.INT)
+                self.state = 353
                 self.match(QuilParser.RBRACKET)
 
 
-            self.state = 363
+            self.state = 364
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==QuilParser.SHARING:
-                self.state = 355
-                self.match(QuilParser.SHARING)
                 self.state = 356
+                self.match(QuilParser.SHARING)
+                self.state = 357
                 self.match(QuilParser.IDENTIFIER)
-                self.state = 360
+                self.state = 361
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
                 while _la==QuilParser.OFFSET:
-                    self.state = 357
+                    self.state = 358
                     self.offsetDescriptor()
-                    self.state = 362
+                    self.state = 363
                     self._errHandler.sync(self)
                     _la = self._input.LA(1)
 
@@ -2633,11 +2632,11 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 64, self.RULE_offsetDescriptor)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 365
-            self.match(QuilParser.OFFSET)
             self.state = 366
-            self.match(QuilParser.INT)
+            self.match(QuilParser.OFFSET)
             self.state = 367
+            self.match(QuilParser.INT)
+            self.state = 368
             self.match(QuilParser.IDENTIFIER)
         except RecognitionException as re:
             localctx.exception = re
@@ -2690,14 +2689,14 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 369
+            self.state = 370
             _la = self._input.LA(1)
             if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << QuilParser.NEG) | (1 << QuilParser.NOT) | (1 << QuilParser.TRUE) | (1 << QuilParser.FALSE))) != 0)):
                 self._errHandler.recoverInline(self)
             else:
                 self._errHandler.reportMatch(self)
                 self.consume()
-            self.state = 370
+            self.state = 371
             self.addr()
         except RecognitionException as re:
             localctx.exception = re
@@ -2752,32 +2751,32 @@ class QuilParser ( Parser ):
         localctx = QuilParser.ClassicalBinaryContext(self, self._ctx, self.state)
         self.enterRule(localctx, 68, self.RULE_classicalBinary)
         try:
-            self.state = 377
+            self.state = 378
             self._errHandler.sync(self)
             token = self._input.LA(1)
             if token in [QuilParser.AND, QuilParser.IOR, QuilParser.XOR, QuilParser.OR]:
                 self.enterOuterAlt(localctx, 1)
-                self.state = 372
+                self.state = 373
                 self.logicalBinaryOp()
                 pass
             elif token in [QuilParser.ADD, QuilParser.SUB, QuilParser.MUL, QuilParser.DIV]:
                 self.enterOuterAlt(localctx, 2)
-                self.state = 373
+                self.state = 374
                 self.arithmeticBinaryOp()
                 pass
             elif token in [QuilParser.MOVE]:
                 self.enterOuterAlt(localctx, 3)
-                self.state = 374
+                self.state = 375
                 self.move()
                 pass
             elif token in [QuilParser.EXCHANGE]:
                 self.enterOuterAlt(localctx, 4)
-                self.state = 375
+                self.state = 376
                 self.exchange()
                 pass
             elif token in [QuilParser.CONVERT]:
                 self.enterOuterAlt(localctx, 5)
-                self.state = 376
+                self.state = 377
                 self.convert()
                 pass
             else:
@@ -2840,24 +2839,24 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 379
+            self.state = 380
             _la = self._input.LA(1)
             if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << QuilParser.AND) | (1 << QuilParser.IOR) | (1 << QuilParser.XOR) | (1 << QuilParser.OR))) != 0)):
                 self._errHandler.recoverInline(self)
             else:
                 self._errHandler.reportMatch(self)
                 self.consume()
-            self.state = 380
+            self.state = 381
             self.addr()
-            self.state = 383
+            self.state = 384
             self._errHandler.sync(self)
             token = self._input.LA(1)
             if token in [QuilParser.IDENTIFIER, QuilParser.LBRACKET]:
-                self.state = 381
+                self.state = 382
                 self.addr()
                 pass
             elif token in [QuilParser.INT]:
-                self.state = 382
+                self.state = 383
                 self.match(QuilParser.INT)
                 pass
             else:
@@ -2921,24 +2920,24 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 385
+            self.state = 386
             _la = self._input.LA(1)
             if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << QuilParser.ADD) | (1 << QuilParser.SUB) | (1 << QuilParser.MUL) | (1 << QuilParser.DIV))) != 0)):
                 self._errHandler.recoverInline(self)
             else:
                 self._errHandler.reportMatch(self)
                 self.consume()
-            self.state = 386
+            self.state = 387
             self.addr()
-            self.state = 389
+            self.state = 390
             self._errHandler.sync(self)
             token = self._input.LA(1)
             if token in [QuilParser.IDENTIFIER, QuilParser.LBRACKET]:
-                self.state = 387
+                self.state = 388
                 self.addr()
                 pass
             elif token in [QuilParser.PI, QuilParser.I, QuilParser.MINUS, QuilParser.INT, QuilParser.FLOAT]:
-                self.state = 388
+                self.state = 389
                 self.number()
                 pass
             else:
@@ -2992,19 +2991,19 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 74, self.RULE_move)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 391
-            self.match(QuilParser.MOVE)
             self.state = 392
+            self.match(QuilParser.MOVE)
+            self.state = 393
             self.addr()
-            self.state = 395
+            self.state = 396
             self._errHandler.sync(self)
             token = self._input.LA(1)
             if token in [QuilParser.IDENTIFIER, QuilParser.LBRACKET]:
-                self.state = 393
+                self.state = 394
                 self.addr()
                 pass
             elif token in [QuilParser.PI, QuilParser.I, QuilParser.MINUS, QuilParser.INT, QuilParser.FLOAT]:
-                self.state = 394
+                self.state = 395
                 self.number()
                 pass
             else:
@@ -3054,11 +3053,11 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 76, self.RULE_exchange)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 397
-            self.match(QuilParser.EXCHANGE)
             self.state = 398
-            self.addr()
+            self.match(QuilParser.EXCHANGE)
             self.state = 399
+            self.addr()
+            self.state = 400
             self.addr()
         except RecognitionException as re:
             localctx.exception = re
@@ -3104,11 +3103,11 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 78, self.RULE_convert)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 401
-            self.match(QuilParser.CONVERT)
             self.state = 402
-            self.addr()
+            self.match(QuilParser.CONVERT)
             self.state = 403
+            self.addr()
+            self.state = 404
             self.addr()
         except RecognitionException as re:
             localctx.exception = re
@@ -3157,13 +3156,13 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 80, self.RULE_load)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 405
-            self.match(QuilParser.LOAD)
             self.state = 406
-            self.addr()
+            self.match(QuilParser.LOAD)
             self.state = 407
-            self.match(QuilParser.IDENTIFIER)
+            self.addr()
             self.state = 408
+            self.match(QuilParser.IDENTIFIER)
+            self.state = 409
             self.addr()
         except RecognitionException as re:
             localctx.exception = re
@@ -3216,21 +3215,21 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 82, self.RULE_store)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 410
-            self.match(QuilParser.STORE)
             self.state = 411
-            self.match(QuilParser.IDENTIFIER)
+            self.match(QuilParser.STORE)
             self.state = 412
+            self.match(QuilParser.IDENTIFIER)
+            self.state = 413
             self.addr()
-            self.state = 415
+            self.state = 416
             self._errHandler.sync(self)
             token = self._input.LA(1)
             if token in [QuilParser.IDENTIFIER, QuilParser.LBRACKET]:
-                self.state = 413
+                self.state = 414
                 self.addr()
                 pass
             elif token in [QuilParser.PI, QuilParser.I, QuilParser.MINUS, QuilParser.INT, QuilParser.FLOAT]:
-                self.state = 414
+                self.state = 415
                 self.number()
                 pass
             else:
@@ -3297,26 +3296,26 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 417
+            self.state = 418
             _la = self._input.LA(1)
             if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << QuilParser.EQ) | (1 << QuilParser.GT) | (1 << QuilParser.GE) | (1 << QuilParser.LT) | (1 << QuilParser.LE))) != 0)):
                 self._errHandler.recoverInline(self)
             else:
                 self._errHandler.reportMatch(self)
                 self.consume()
-            self.state = 418
-            self.addr()
             self.state = 419
             self.addr()
-            self.state = 422
+            self.state = 420
+            self.addr()
+            self.state = 423
             self._errHandler.sync(self)
             token = self._input.LA(1)
             if token in [QuilParser.IDENTIFIER, QuilParser.LBRACKET]:
-                self.state = 420
+                self.state = 421
                 self.addr()
                 pass
             elif token in [QuilParser.PI, QuilParser.I, QuilParser.MINUS, QuilParser.INT, QuilParser.FLOAT]:
-                self.state = 421
+                self.state = 422
                 self.number()
                 pass
             else:
@@ -3359,7 +3358,7 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 86, self.RULE_nop)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 424
+            self.state = 425
             self.match(QuilParser.NOP)
         except RecognitionException as re:
             localctx.exception = re
@@ -3401,9 +3400,9 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 88, self.RULE_include)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 426
-            self.match(QuilParser.INCLUDE)
             self.state = 427
+            self.match(QuilParser.INCLUDE)
+            self.state = 428
             self.match(QuilParser.STRING)
         except RecognitionException as re:
             localctx.exception = re
@@ -3456,25 +3455,25 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 429
-            self.match(QuilParser.PRAGMA)
             self.state = 430
+            self.match(QuilParser.PRAGMA)
+            self.state = 431
             self.match(QuilParser.IDENTIFIER)
-            self.state = 434
+            self.state = 435
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             while _la==QuilParser.IDENTIFIER or _la==QuilParser.INT:
-                self.state = 431
+                self.state = 432
                 self.pragma_name()
-                self.state = 436
+                self.state = 437
                 self._errHandler.sync(self)
                 _la = self._input.LA(1)
 
-            self.state = 438
+            self.state = 439
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==QuilParser.STRING:
-                self.state = 437
+                self.state = 438
                 self.match(QuilParser.STRING)
 
 
@@ -3519,7 +3518,7 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 440
+            self.state = 441
             _la = self._input.LA(1)
             if not(_la==QuilParser.IDENTIFIER or _la==QuilParser.INT):
                 self._errHandler.recoverInline(self)
@@ -3764,7 +3763,7 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 458
+            self.state = 459
             self._errHandler.sync(self)
             la_ = self._interp.adaptivePredict(self._input,40,self._ctx)
             if la_ == 1:
@@ -3772,11 +3771,11 @@ class QuilParser ( Parser ):
                 self._ctx = localctx
                 _prevctx = localctx
 
-                self.state = 443
-                self.match(QuilParser.LPAREN)
                 self.state = 444
-                self.expression(0)
+                self.match(QuilParser.LPAREN)
                 self.state = 445
+                self.expression(0)
+                self.state = 446
                 self.match(QuilParser.RPAREN)
                 pass
 
@@ -3784,9 +3783,9 @@ class QuilParser ( Parser ):
                 localctx = QuilParser.SignedExpContext(self, localctx)
                 self._ctx = localctx
                 _prevctx = localctx
-                self.state = 447
-                self.sign()
                 self.state = 448
+                self.sign()
+                self.state = 449
                 self.expression(8)
                 pass
 
@@ -3794,13 +3793,13 @@ class QuilParser ( Parser ):
                 localctx = QuilParser.FunctionExpContext(self, localctx)
                 self._ctx = localctx
                 _prevctx = localctx
-                self.state = 450
-                self.function()
                 self.state = 451
-                self.match(QuilParser.LPAREN)
+                self.function()
                 self.state = 452
-                self.expression(0)
+                self.match(QuilParser.LPAREN)
                 self.state = 453
+                self.expression(0)
+                self.state = 454
                 self.match(QuilParser.RPAREN)
                 pass
 
@@ -3808,7 +3807,7 @@ class QuilParser ( Parser ):
                 localctx = QuilParser.NumberExpContext(self, localctx)
                 self._ctx = localctx
                 _prevctx = localctx
-                self.state = 455
+                self.state = 456
                 self.number()
                 pass
 
@@ -3816,7 +3815,7 @@ class QuilParser ( Parser ):
                 localctx = QuilParser.VariableExpContext(self, localctx)
                 self._ctx = localctx
                 _prevctx = localctx
-                self.state = 456
+                self.state = 457
                 self.variable()
                 pass
 
@@ -3824,13 +3823,13 @@ class QuilParser ( Parser ):
                 localctx = QuilParser.AddrExpContext(self, localctx)
                 self._ctx = localctx
                 _prevctx = localctx
-                self.state = 457
+                self.state = 458
                 self.addr()
                 pass
 
 
             self._ctx.stop = self._input.LT(-1)
-            self.state = 471
+            self.state = 472
             self._errHandler.sync(self)
             _alt = self._interp.adaptivePredict(self._input,42,self._ctx)
             while _alt!=2 and _alt!=ATN.INVALID_ALT_NUMBER:
@@ -3838,60 +3837,60 @@ class QuilParser ( Parser ):
                     if self._parseListeners is not None:
                         self.triggerExitRuleEvent()
                     _prevctx = localctx
-                    self.state = 469
+                    self.state = 470
                     self._errHandler.sync(self)
                     la_ = self._interp.adaptivePredict(self._input,41,self._ctx)
                     if la_ == 1:
                         localctx = QuilParser.PowerExpContext(self, QuilParser.ExpressionContext(self, _parentctx, _parentState))
                         self.pushNewRecursionContext(localctx, _startState, self.RULE_expression)
-                        self.state = 460
+                        self.state = 461
                         if not self.precpred(self._ctx, 7):
                             from antlr4.error.Errors import FailedPredicateException
                             raise FailedPredicateException(self, "self.precpred(self._ctx, 7)")
-                        self.state = 461
-                        self.match(QuilParser.POWER)
                         self.state = 462
+                        self.match(QuilParser.POWER)
+                        self.state = 463
                         self.expression(7)
                         pass
 
                     elif la_ == 2:
                         localctx = QuilParser.MulDivExpContext(self, QuilParser.ExpressionContext(self, _parentctx, _parentState))
                         self.pushNewRecursionContext(localctx, _startState, self.RULE_expression)
-                        self.state = 463
+                        self.state = 464
                         if not self.precpred(self._ctx, 6):
                             from antlr4.error.Errors import FailedPredicateException
                             raise FailedPredicateException(self, "self.precpred(self._ctx, 6)")
-                        self.state = 464
+                        self.state = 465
                         _la = self._input.LA(1)
                         if not(_la==QuilParser.TIMES or _la==QuilParser.DIVIDE):
                             self._errHandler.recoverInline(self)
                         else:
                             self._errHandler.reportMatch(self)
                             self.consume()
-                        self.state = 465
+                        self.state = 466
                         self.expression(7)
                         pass
 
                     elif la_ == 3:
                         localctx = QuilParser.AddSubExpContext(self, QuilParser.ExpressionContext(self, _parentctx, _parentState))
                         self.pushNewRecursionContext(localctx, _startState, self.RULE_expression)
-                        self.state = 466
+                        self.state = 467
                         if not self.precpred(self._ctx, 5):
                             from antlr4.error.Errors import FailedPredicateException
                             raise FailedPredicateException(self, "self.precpred(self._ctx, 5)")
-                        self.state = 467
+                        self.state = 468
                         _la = self._input.LA(1)
                         if not(_la==QuilParser.PLUS or _la==QuilParser.MINUS):
                             self._errHandler.recoverInline(self)
                         else:
                             self._errHandler.reportMatch(self)
                             self.consume()
-                        self.state = 468
+                        self.state = 469
                         self.expression(6)
                         pass
 
              
-                self.state = 473
+                self.state = 474
                 self._errHandler.sync(self)
                 _alt = self._interp.adaptivePredict(self._input,42,self._ctx)
 
@@ -3945,7 +3944,7 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 474
+            self.state = 475
             _la = self._input.LA(1)
             if not((((_la) & ~0x3f) == 0 and ((1 << _la) & ((1 << QuilParser.SIN) | (1 << QuilParser.COS) | (1 << QuilParser.SQRT) | (1 << QuilParser.EXP) | (1 << QuilParser.CIS))) != 0)):
                 self._errHandler.recoverInline(self)
@@ -3993,7 +3992,7 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 476
+            self.state = 477
             _la = self._input.LA(1)
             if not(_la==QuilParser.PLUS or _la==QuilParser.MINUS):
                 self._errHandler.recoverInline(self)
@@ -4052,34 +4051,34 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 479
+            self.state = 480
             self._errHandler.sync(self)
             _la = self._input.LA(1)
             if _la==QuilParser.MINUS:
-                self.state = 478
+                self.state = 479
                 self.match(QuilParser.MINUS)
 
 
-            self.state = 485
+            self.state = 486
             self._errHandler.sync(self)
             la_ = self._interp.adaptivePredict(self._input,44,self._ctx)
             if la_ == 1:
-                self.state = 481
+                self.state = 482
                 self.realN()
                 pass
 
             elif la_ == 2:
-                self.state = 482
+                self.state = 483
                 self.imaginaryN()
                 pass
 
             elif la_ == 3:
-                self.state = 483
+                self.state = 484
                 self.match(QuilParser.I)
                 pass
 
             elif la_ == 4:
-                self.state = 484
+                self.state = 485
                 self.match(QuilParser.PI)
                 pass
 
@@ -4125,9 +4124,9 @@ class QuilParser ( Parser ):
         self.enterRule(localctx, 102, self.RULE_imaginaryN)
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 487
-            self.realN()
             self.state = 488
+            self.realN()
+            self.state = 489
             self.match(QuilParser.I)
         except RecognitionException as re:
             localctx.exception = re
@@ -4170,7 +4169,7 @@ class QuilParser ( Parser ):
         self._la = 0 # Token type
         try:
             self.enterOuterAlt(localctx, 1)
-            self.state = 490
+            self.state = 491
             _la = self._input.LA(1)
             if not(_la==QuilParser.INT or _la==QuilParser.FLOAT):
                 self._errHandler.recoverInline(self)

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -101,6 +101,7 @@ class Gate(AbstractInstruction):
 
         if not isinstance(qubits, list) or not qubits:
             raise TypeError("Gate arguments must be a non-empty list")
+
         for qubit in qubits:
             if not isinstance(qubit, (Qubit, QubitPlaceholder)):
                 raise TypeError("Gate arguments must all be Qubits")

--- a/pyquil/tests/test_parser.py
+++ b/pyquil/tests/test_parser.py
@@ -313,6 +313,18 @@ DEFCIRCUIT test_defcirc_reset_qubit:
     parse_equals(defcircuit_reset_qubit, RawInstr(defcircuit_reset_qubit))
 
 
+def test_defcircuit_zero_arguments():
+    circuit = """
+DEFCIRCUIT BELL:
+    H 0
+    CNOT 0 1
+""".strip()
+    circuit_app = """
+BELL
+""".strip()
+    parse_equals(circuit + "\n" + circuit_app, RawInstr(circuit), RawInstr(circuit_app))
+
+
 def test_parse_dagger():
     s = "DAGGER X 0"
     parse_equals(s, X(0).dagger())


### PR DESCRIPTION
Description
-----------

The Quil grammar allows for circuit definitions taking zero input
qubits, e.g.
```
DEFCIRCUIT BELL:
    H 0
    CNOT 0 1

TEST
```

The pyQuil grammar, however, was unable to process this because it
treated the `TEST` instruction as a gate application with the
expectation that gates take a non-zero number of qubits.

To allow circuit applications with zero qubits, I have:
  1. Removed the parse-time restriction that a gate instruction
  requires a non-empty list of qubits; and
  2. Where the parser tries to construct a `Gate` object, I test
  for an empty list of qubits. If this is true, I construct a
  `RawInstr` (same used for the circuit itself), otherwise I construct
  a `Gate` as normal.

This ought to be a safe change: all standard gates still require
input qubits (i.e. `parse("H")` and `H()` will error).

Closes #294.

Insert your PR description here. Thanks for contributing to pyQuil! :)

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The changelog (`docs/source/changes.rst`) has a description of this change.
