### PR TITLE
Add merge_programs support for DefPermutationGate

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+v2.xx (in progress)
+-------------------
+Improvements and Changes:
+
+- ``merge_programs`` supports ``DefPermutationGate``
+
 v2.10 (July 31, 2019)
 ---------------------
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -5,7 +5,11 @@ v2.xx (in progress)
 -------------------
 Improvements and Changes:
 
-- ``merge_programs`` supports ``DefPermutationGate``
+
+Bugfixes:
+
+- ``merge_programs`` now supports merging programs with ``DefPermutationGate`` instead of throwing error (gh-971).
+- ``merge_programs`` now avoids redundant readout declaration (gh-971).
 
 v2.10 (July 31, 2019)
 ---------------------

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -950,7 +950,7 @@ def merge_programs(prog_list):
     new_definitions = [gate for key in seen.keys() for gate in reversed(seen[key])]
 
     # Combine programs without gate definitions; avoid call to _synthesize by using _instructions
-    p = sum([Program(prog)._instructions for prog in prog_list], Program())
+    p = Program(*[prog._instructions for prog in prog_list])
 
     for definition in new_definitions:
         if isinstance(definition, DefPermutationGate):

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -949,7 +949,8 @@ def merge_programs(prog_list):
             seen[name] = [definition]
     new_definitions = [gate for key in seen.keys() for gate in reversed(seen[key])]
 
-    p = sum([Program(prog).instructions for prog in prog_list], Program())  # Combine programs without gate definitions
+    # Combine programs without gate definitions; avoid call to _synthesize by using _instructions
+    p = sum([Program(prog)._instructions for prog in prog_list], Program())
 
     for definition in new_definitions:
         if isinstance(definition, DefPermutationGate):

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -36,7 +36,7 @@ from pyquil.quilatom import (LabelPlaceholder, QubitPlaceholder, unpack_qubit, A
 from pyquil.gates import MEASURE, QUANTUM_GATES, H, RESET
 from pyquil.quilbase import (DefGate, Gate, Measurement, Pragma, AbstractInstruction, Qubit,
                              Jump, Label, JumpConditional, JumpTarget, JumpUnless, JumpWhen,
-                             Declare, Halt, Reset, ResetQubit)
+                             Declare, Halt, Reset, ResetQubit, DefPermutationGate)
 
 
 class Program(object):
@@ -952,7 +952,10 @@ def merge_programs(prog_list):
     p = sum([Program(prog).instructions for prog in prog_list], Program())  # Combine programs without gate definitions
 
     for definition in new_definitions:
-        p.defgate(definition.name, definition.matrix, definition.parameters)
+        if isinstance(definition, DefPermutationGate):
+            p.inst(DefPermutationGate(definition.name, list(definition.permutation)))
+        else:
+            p.defgate(definition.name, definition.matrix, definition.parameters)
 
     return p
 

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -657,6 +657,28 @@ H 0
 MEASURE 0 ro[0]
 """
 
+    q0 = QubitPlaceholder()
+    q0_str = "{" + str(q0) + "}"
+    p0 = Program(X(q0))
+    p1 = Program(Z(q0))
+    merged = merge_programs([p0, p1])
+    assert str(merged) == f"""X {q0_str}
+Z {q0_str}
+"""
+    assert address_qubits(merged, {q0: 1}).out() == """X 1
+Z 1
+"""
+    q1 = QubitPlaceholder()
+    p2 = Program(Z(q1))
+    assert address_qubits(merge_programs([p0, p2]), {q0: 1, q1: 2}).out() == """X 1
+Z 2
+"""
+    p0 = address_qubits(p0, {q0: 2})
+    p1 = address_qubits(p1, {q0: 1})
+    assert merge_programs([p0, p1]).out() == """X 2
+Z 1
+"""
+
 
 def test_merge_with_pauli_noise():
     p = Program(X(0)).inst(Z(0))

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -650,6 +650,12 @@ Y 0
 test 0
 PERM 1 0
 """
+    assert merge_programs([Program("DECLARE ro BIT[1]"),
+                           Program("H 0"),
+                           Program("MEASURE 0 ro[0]")]).out() == """DECLARE ro BIT[1]
+H 0
+MEASURE 0 ro[0]
+"""
 
 
 def test_merge_with_pauli_noise():


### PR DESCRIPTION
Description
-----------

Closes #970

Also threw in the fix that closes #634 

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The changelog (`docs/source/changes.rst`) has a description of this change.
