### PR TITLE
Allow non-gate instructions in to_latex()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog
 -   Deleted the deprecated modules `parameters.py` and `qpu.py` (@karalekas, gh-991).
 -   The test suite for pyQuil now runs much faster, by setting the default value
     of the `--use-seed` option for `pytest` to `True` (@karalekas, gh-992).
+-   Support non-gate instructions (e.g. `MEASURE`) in `to_latex()` (@notmgsk, gh-975).
 
 ### Bugfixes
 

--- a/pyquil/latex/latex_generation.py
+++ b/pyquil/latex/latex_generation.py
@@ -54,8 +54,9 @@ def to_latex(circuit, settings=None):
     Translates a given pyquil Program to a TikZ picture in a Latex document.
 
     :param Program circuit: The circuit to be drawn, represented as a pyquil program.
-    :param dict settings: An optional dictionary with settings for drawing the circuit. See `get_default_settings`
-     in `latex_config` for more information about what settings should contain.
+    :param dict settings: An optional dictionary with settings for drawing the circuit.
+        See `get_default_settings` in `latex_config` for more information about what settings
+        should contain.
     :return: LaTeX document string which can be compiled.
     :rtype: string
     """
@@ -86,15 +87,13 @@ def body(circuit, settings):
             inst.qubits = [inst.qubit]
             inst.name = "MEASURE"
         elif isinstance(inst, Gate):
-            qubits = inst.qubits
-            for qubit in qubits:
+            for qubit in inst.qubits:
                 qubit_instruction_mapping[qubit.index] = []
     for k, v in list(qubit_instruction_mapping.items()):
         v.append(command(ALLOCATE, [k], [], [k], k))
 
     for inst in circuit:
-        # Ignore everything that is neither a Gate nor a Measurement
-        # (e.g. a Pragma)
+        # Ignore everything that is neither a Gate nor a Measurement (e.g. a Pragma)
         if not isinstance(inst, Gate) and not isinstance(inst, Measurement):
             continue
         qubits = [qubit.index for qubit in inst.qubits]
@@ -118,12 +117,14 @@ def body(circuit, settings):
                 if gate == CZ:
                     ctrl_lines = list(explicit_lines)
                     ctrl_lines.remove(qubits[-1])
-                    qubit_instruction_mapping[qubit].append(command(Z, list(all_lines), list(ctrl_lines),
+                    qubit_instruction_mapping[qubit].append(command(Z, list(all_lines),
+                                                                    list(ctrl_lines),
                                                                     qubits[-1:], None))
                 elif gate == CNOT:
                     ctrl_lines = list(explicit_lines)
                     ctrl_lines.remove(qubits[-1])
-                    qubit_instruction_mapping[qubit].append(command(X, list(all_lines), list(ctrl_lines),
+                    qubit_instruction_mapping[qubit].append(command(X, list(all_lines),
+                                                                    list(ctrl_lines),
                                                                     qubits[-1:], None))
                 else:
                     qubit_instruction_mapping[qubit].append(command(gate, list(all_lines), [],
@@ -345,7 +346,8 @@ class CircuitTikzGenerator(object):
         op = self._op(line)
         gate_str = ("\n\\node[xstyle] ({op}) at ({pos},-{line}) {{}};\n\\draw"
                     "[edgestyle] ({op}.north)--({op}.south);\n\\draw"
-                    "[edgestyle] ({op}.west)--({op}.east);").format(op=op, line=line, pos=self.pos[line])
+                    "[edgestyle] ({op}.west)--({op}.east);").format(op=op, line=line,
+                                                                    pos=self.pos[line])
         if len(ctrl_lines) > 0:
             for ctrl in ctrl_lines:
                 gate_str += self._phase(ctrl, self.pos[line])
@@ -538,7 +540,8 @@ class CircuitTikzGenerator(object):
             if l in used_lines:
                 tex_str += self._phase(l, pos)
             node2 = ("\n\\node[none,minimum height={}cm,outer sep=0] ({}) at"
-                     " ({},-{}) {{}};").format(gate_height, self._op(l, offset=1), pos + gate_width / 2., l)
+                     " ({},-{}) {{}};").format(gate_height, self._op(l, offset=1),
+                                               pos + gate_width / 2., l)
             node3 = node_str.format(self._op(l, offset=2), pos + gate_width, l)
             tex_str += node1 + node2 + node3
         tex_str += ("\n\\draw[operator,edgestyle,outer sep={width}cm]"

--- a/pyquil/latex/latex_generation.py
+++ b/pyquil/latex/latex_generation.py
@@ -34,7 +34,7 @@
 from copy import copy
 
 from pyquil.latex.latex_config import get_default_settings, header, footer
-from pyquil.quil import Measurement
+from pyquil.quil import Measurement, Gate
 from collections import namedtuple
 
 
@@ -85,14 +85,16 @@ def body(circuit, settings):
         if isinstance(inst, Measurement):
             inst.qubits = [inst.qubit]
             inst.name = "MEASURE"
-        else:
+        elif isinstance(inst, Gate):
             qubits = inst.qubits
-        for qubit in qubits:
-            qubit_instruction_mapping[qubit.index] = []
+            for qubit in qubits:
+                qubit_instruction_mapping[qubit.index] = []
     for k, v in list(qubit_instruction_mapping.items()):
         v.append(command(ALLOCATE, [k], [], [k], k))
 
     for inst in circuit:
+        if not isinstance(inst, Gate) and not isinstance(inst, Measurement):
+            continue
         qubits = [qubit.index for qubit in inst.qubits]
         gate = inst.name
         # If this is a single qubit instruction.

--- a/pyquil/latex/latex_generation.py
+++ b/pyquil/latex/latex_generation.py
@@ -93,6 +93,8 @@ def body(circuit, settings):
         v.append(command(ALLOCATE, [k], [], [k], k))
 
     for inst in circuit:
+        # Ignore everything that is neither a Gate nor a Measurement
+        # (e.g. a Pragma)
         if not isinstance(inst, Gate) and not isinstance(inst, Measurement):
             continue
         qubits = [qubit.index for qubit in inst.qubits]


### PR DESCRIPTION
Description
-----------

Allow non-gate instructions in `to_latex()`. Closes #637.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] ~There is a unit test that covers these changes.~
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
