### PR TITLE
Renamed local_qvm, added options to start quilc and qvm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Changelog
 -   PyQuil now sends “modern” ISA payloads to quilc, which must be of version
     \>= `1.10.0`. Check out the details of `get_isa` for information on how to
     specify custom payloads (@ecpeterson, gh-961).
+-		`local_qvm` has been renamed to `lcocal_runtime` (@sauercrowd, gh-976)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Changelog
     \>= `1.10.0`. Check out the details of `get_isa` for information on how to
     specify custom payloads (@ecpeterson, gh-961).
 -   The `local_qvm` context manager has been renamed to `local_forest_runtime`
-    (@sauercrowd, gh-976)
+    and the original `local_qvm` has been deprecated (@sauercrowd, gh-976).
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Changelog
 -   PyQuil now sends “modern” ISA payloads to quilc, which must be of version
     \>= `1.10.0`. Check out the details of `get_isa` for information on how to
     specify custom payloads (@ecpeterson, gh-961).
--		`local_qvm` has been renamed to `lcocal_runtime` (@sauercrowd, gh-976)
+-		The `local_qvm` context manager has been renamed to `local_forest_runtime` (@sauercrowd, gh-976)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 ### Announcements
 
 ### Improvements and Changes
+-   The `local_qvm` context manager has been renamed to `local_forest_runtime`
+    and the original `local_qvm` has been deprecated (@sauercrowd, gh-976).
 
 ### Bugfixes
 
@@ -54,8 +56,6 @@ Changelog
 -   PyQuil now sends “modern” ISA payloads to quilc, which must be of version
     \>= `1.10.0`. Check out the details of `get_isa` for information on how to
     specify custom payloads (@ecpeterson, gh-961).
--   The `local_qvm` context manager has been renamed to `local_forest_runtime`
-    and the original `local_qvm` has been deprecated (@sauercrowd, gh-976).
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changelog
 
 ### Improvements and Changes
 -   The `local_qvm` context manager has been renamed to `local_forest_runtime`,
-    which now checks if the designated ports are used before starting `QVM`/`QUILC`.
+    which now checks if the designated ports are used before starting `qvm`/`quilc`.
     The original `local_qvm` has been deprecated (@sauercrowd, gh-976).
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ Changelog
 ### Announcements
 
 ### Improvements and Changes
--   The `local_qvm` context manager has been renamed to `local_forest_runtime`
-    and the original `local_qvm` has been deprecated (@sauercrowd, gh-976).
+-   The `local_qvm` context manager has been renamed to `local_forest_runtime`,
+    which now checks if the designated ports are used before starting `QVM`/`QUILC`.
+    The original `local_qvm` has been deprecated (@sauercrowd, gh-976).
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ Changelog
 -   PyQuil now sends “modern” ISA payloads to quilc, which must be of version
     \>= `1.10.0`. Check out the details of `get_isa` for information on how to
     specify custom payloads (@ecpeterson, gh-961).
--		The `local_qvm` context manager has been renamed to `local_forest_runtime` (@sauercrowd, gh-976)
+-   The `local_qvm` context manager has been renamed to `local_forest_runtime`
+    (@sauercrowd, gh-976)
 
 ### Bugfixes
 

--- a/docs/source/apidocs/quantum_computer.rst
+++ b/docs/source/apidocs/quantum_computer.rst
@@ -4,6 +4,7 @@ Quantum Computer
 ================
 
 .. autofunction:: pyquil.get_qc
+.. autofunction:: pyquil.api.local_runtime
 .. autofunction:: pyquil.list_quantum_computers
 
 .. autoclass:: pyquil.api.QuantumComputer

--- a/docs/source/apidocs/quantum_computer.rst
+++ b/docs/source/apidocs/quantum_computer.rst
@@ -4,7 +4,7 @@ Quantum Computer
 ================
 
 .. autofunction:: pyquil.get_qc
-.. autofunction:: pyquil.api.local_runtime
+.. autofunction:: pyquil.api.local_forest_runtime
 .. autofunction:: pyquil.list_quantum_computers
 
 .. autoclass:: pyquil.api.QuantumComputer

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -268,10 +268,10 @@ gates from the ``pyquil.gates`` module, which allows us to add operations to our
         from pyquil.gates import CNOT, Z
         from pyquil.api import local_forest_runtime
 
+        prog = Program(Z(0), CNOT(0, 1))
+
         with local_forest_runtime():
             qvm = get_qc('9q-square-qvm')
-            prog = Program(Z(0), CNOT(0, 1))
-
             results = qvm.run_and_measure(prog, trials=10)
 
 Next, let's construct our Bell State.

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -258,7 +258,7 @@ gates from the ``pyquil.gates`` module, which allows us to add operations to our
 
     PyQuil also provides a handy function for you to ensure that a local qvm and quilc are currently running in
     your environment. To make sure both are available you import `from pyquil.api import local_forest_runtime` and then run
-    `local_forest_runtime()`. This will start a qvm and quilc instances using subprocesses if they have not already been started.
+    `local_forest_runtime()`. This will start qvm and quilc instances using subprocesses if they have not already been started.
     You can also use it as a context manager as in the following example:
 
     .. code:: python

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -229,6 +229,7 @@ programs to native Quil, and to simulate those programs on the QVM.
 
 **NOTE**: Prior to quilc version 1.10 there existed two methods for communicating with the quilc server: over HTTP by creating the server with the ``-S`` flag, or over RPCQ by creating the server with the ``-R`` flag. The HTTP server mode was deprecated in early 2019, and removed in mid 2019. The ``-S`` and ``-R`` flags now both start the RPCQ server.
 
+
 Run Your First Program
 ----------------------
 Now that our local endpoints are up and running, we can start running pyQuil programs!
@@ -267,10 +268,10 @@ gates from the ``pyquil.gates`` module, which allows us to add operations to our
         from pyquil.gates import CNOT, Z
         from pyquil.api import local_forest_runtime
 
-        qvm = get_qc('9q-square-qvm')
-        prog = Program(Z(0), CNOT(0, 1))
-
         with local_forest_runtime():
+            qvm = get_qc('9q-square-qvm')
+            prog = Program(Z(0), CNOT(0, 1))
+
             results = qvm.run_and_measure(prog, trials=10)
 
 Next, let's construct our Bell State.

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -257,20 +257,20 @@ gates from the ``pyquil.gates`` module, which allows us to add operations to our
 .. note::
 
     PyQuil also provides a handy function for you to ensure that a local qvm and quilc are currently running in
-    your environment. To make sure both are available you import `from pyquil.api import local_runtime` and then run
-    `local_runtime()`. This will start a qvm and quilc instances using subprocesses if they have not already been started.
+    your environment. To make sure both are available you import `from pyquil.api import local_forest_runtime` and then run
+    `local_forest_runtime()`. This will start a qvm and quilc instances using subprocesses if they have not already been started.
     You can also use it as a context manager as in the following example:
 
     .. code:: python
 
         from pyquil import get_qc, Program
         from pyquil.gates import CNOT, Z
-        from pyquil.api import local_runtime
+        from pyquil.api import local_forest_runtime
 
         qvm = get_qc('9q-square-qvm')
         prog = Program(Z(0), CNOT(0, 1))
 
-        with local_runtime():
+        with local_forest_runtime():
             results = qvm.run_and_measure(prog, trials=10)
 
 Next, let's construct our Bell State.

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -257,20 +257,20 @@ gates from the ``pyquil.gates`` module, which allows us to add operations to our
 .. note::
 
     PyQuil also provides a handy function for you to ensure that a local qvm and quilc are currently running in
-    your environment. To make sure both are available you import `from pyquil.api import local_qvm` and then run
-    `local_qvm()`. This will start a qvm and quilc instances using subprocesses if they have not already been started.
+    your environment. To make sure both are available you import `from pyquil.api import local_runtime` and then run
+    `local_runtime()`. This will start a qvm and quilc instances using subprocesses if they have not already been started.
     You can also use it as a context manager as in the following example:
 
     .. code:: python
 
         from pyquil import get_qc, Program
         from pyquil.gates import CNOT, Z
-        from pyquil.api import local_qvm
+        from pyquil.api import local_runtime
 
         qvm = get_qc('9q-square-qvm')
         prog = Program(Z(0), CNOT(0, 1))
 
-        with local_qvm():
+        with local_runtime():
             results = qvm.run_and_measure(prog, trials=10)
 
 Next, let's construct our Bell State.

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -257,8 +257,8 @@ gates from the ``pyquil.gates`` module, which allows us to add operations to our
 .. note::
 
     PyQuil also provides a handy function for you to ensure that a local qvm and quilc are currently running in
-    your environment. To make sure both are available you import `from pyquil.api import local_forest_runtime` and then run
-    `local_forest_runtime()`. This will start qvm and quilc instances using subprocesses if they have not already been started.
+    your environment. To make sure both are available you execute ``from pyquil.api import local_forest_runtime`` and then use
+    :py:func:`~pyquil.api.local_forest_runtime()`. This will start qvm and quilc instances using subprocesses if they have not already been started.
     You can also use it as a context manager as in the following example:
 
     .. code:: python

--- a/pyquil/api/__init__.py
+++ b/pyquil/api/__init__.py
@@ -20,7 +20,8 @@ import warnings
 
 __all__ = ['QVMConnection', 'QVMCompiler', 'QPUCompiler',
            'Job', 'Device', 'ForestConnection', 'pyquil_protect',
-           'WavefunctionSimulator', 'QuantumComputer', 'list_quantum_computers', 'get_qc', 'local_runtime',
+           'WavefunctionSimulator', 'QuantumComputer',
+           'list_quantum_computers', 'get_qc', 'local_forest_runtime', 'local_qvm',
            'QAM', 'QVM', 'QPU', 'QPUConnection',
            'BenchmarkConnection', 'get_benchmarker']
 
@@ -31,7 +32,8 @@ from pyquil.api._error_reporting import pyquil_protect
 from pyquil.api._job import Job
 from pyquil.api._qam import QAM
 from pyquil.api._qpu import QPU
-from pyquil.api._quantum_computer import QuantumComputer, list_quantum_computers, get_qc, local_runtime
+from pyquil.api._quantum_computer import (QuantumComputer, list_quantum_computers,
+                                          get_qc, local_forest_runtime, local_qvm)
 from pyquil.api._qvm import QVMConnection, QVM
 from pyquil.api._wavefunction_simulator import WavefunctionSimulator
 from pyquil.device import Device

--- a/pyquil/api/__init__.py
+++ b/pyquil/api/__init__.py
@@ -20,7 +20,7 @@ import warnings
 
 __all__ = ['QVMConnection', 'QVMCompiler', 'QPUCompiler',
            'Job', 'Device', 'ForestConnection', 'pyquil_protect',
-           'WavefunctionSimulator', 'QuantumComputer', 'list_quantum_computers', 'get_qc',
+           'WavefunctionSimulator', 'QuantumComputer', 'list_quantum_computers', 'get_qc', 'local_runtime',
            'QAM', 'QVM', 'QPU', 'QPUConnection',
            'BenchmarkConnection', 'get_benchmarker']
 
@@ -31,7 +31,7 @@ from pyquil.api._error_reporting import pyquil_protect
 from pyquil.api._job import Job
 from pyquil.api._qam import QAM
 from pyquil.api._qpu import QPU
-from pyquil.api._quantum_computer import QuantumComputer, list_quantum_computers, get_qc, local_qvm
+from pyquil.api._quantum_computer import QuantumComputer, list_quantum_computers, get_qc, local_runtime
 from pyquil.api._qvm import QVMConnection, QVM
 from pyquil.api._wavefunction_simulator import WavefunctionSimulator
 from pyquil.device import Device

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -745,7 +745,8 @@ def local_forest_runtime(
     qvm = None
     quilc = None
 
-    # if host is 0.0.0.0 replace it with 127.0.01
+    # If the host we should listen to is 0.0.0.0, we replace it
+    # with 127.0.0.1 to use a valid IP when checking if the port is in use.
     if _port_used(host if host != '0.0.0.0' else '127.0.0.1', qvm_port):
         warning_msg = ("Unable to start qvm server, since the specified "
                        "port {} is in use.").format(qvm_port)

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -677,6 +677,7 @@ def local_qvm() -> Iterator[Tuple[subprocess.Popen, subprocess.Popen]]:
 
 @contextmanager
 def local_forest_runtime(
+        *,
         host: str = '127.0.0.1',
         qvm_port: int = 5000,
         quilc_port: int = 5555,

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -666,13 +666,22 @@ def get_qc(name: str, *, as_qvm: bool = None, noisy: bool = None,
 
 
 @contextmanager
-def local_runtime(
+def local_qvm() -> Iterator[Tuple[subprocess.Popen, subprocess.Popen]]:
+    """A context manager for the Rigetti local QVM and QUIL compiler.
+
+    .. deprecated:: 2.11
+        Use py:func:`local_forest_runtime` instead.
+    """
+    yield local_forest_runtime()
+
+
+@contextmanager
+def local_forest_runtime(
         host: str = '127.0.0.1',
         qvm_port: int = 5000,
         quilc_port: int = 5555,
         provide_http_server: bool = False,
-        use_protoquil: bool = False
-    ) -> Iterator[Tuple[subprocess.Popen, subprocess.Popen]]:
+        use_protoquil: bool = False) -> Iterator[Tuple[subprocess.Popen, subprocess.Popen]]:
     """A context manager for the Rigetti local QVM and QUIL compiler.
 
     You must first have installed the `qvm` and `quilc` executables from
@@ -687,18 +696,20 @@ def local_runtime(
 
     >>> from pyquil import get_qc, Program
     >>> from pyquil.gates import CNOT, Z
-    >>> from pyquil.api import local_runtime
+    >>> from pyquil.api import local_forest_runtime
     >>>
     >>> qvm = get_qc('9q-square-qvm')
     >>> prog = Program(Z(0), CNOT(0, 1))
     >>>
-    >>> with local_runtime():
+    >>> with local_forest_runtime():
     >>>     results = qvm.run_and_measure(prog, trials=10)
 
     :param host: host on which qvm and quilc should listen on
     :param qvm_port: port which should be used by qvm
     :param quilc_port: port which should be used by quilc
-    :param provide_http_server: additionally start a http server to the rpcq server (quilc). If true ignores quilc_port and will use 6000 for the http server and 5555 for the rpcq server
+    :param provide_http_server: additionally start a http server to the rpcq
+               server (quilc). If true ignores quilc_port and will use 6000
+               for the http server and 5555 for the rpcq server.
     :param use_protoquil: restrict input/output to protoquil
 
     .. warning::

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -681,7 +681,6 @@ def local_forest_runtime(
         host: str = '127.0.0.1',
         qvm_port: int = 5000,
         quilc_port: int = 5555,
-        provide_http_server: bool = False,
         use_protoquil: bool = False) -> Iterator[Tuple[subprocess.Popen, subprocess.Popen]]:
     """A context manager for the Rigetti local QVM and QUIL compiler.
 
@@ -708,13 +707,10 @@ def local_forest_runtime(
     :param host: host on which qvm and quilc should listen on
     :param qvm_port: port which should be used by qvm
     :param quilc_port: port which should be used by quilc
-    :param provide_http_server: additionally start a http server to the rpcq
-               server (quilc). If true ignores quilc_port and will use 6000
-               for the http server and 5555 for the rpcq server.
     :param use_protoquil: restrict input/output to protoquil
 
     .. warning::
-        use_protoquil may disables language features you need, use with caution
+        use_protoquil may disable language features you need, use with caution
 
     :raises: FileNotFoundError: If either executable is not installed.
     """
@@ -724,13 +720,7 @@ def local_forest_runtime(
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE)
 
-    quilc_cmd = ['quilc', '--host', host, '-p', str(quilc_port)]
-
-    # -S starts both a http server AND a RPCQ server
-    if provide_http_server:
-        quilc_cmd += ['-S']
-    else:
-        quilc_cmd += ['-R']
+    quilc_cmd = ['quilc', '--host', host, '-p', str(quilc_port), '-R']
 
     if use_protoquil:
         quilc_cmd += ['-P']

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -15,7 +15,6 @@
 ##############################################################################
 import re
 import socket
-import sys
 import warnings
 from math import pi, log
 from typing import List, Dict, Tuple, Iterator, Union
@@ -748,7 +747,7 @@ def local_forest_runtime(
 
     if _port_used('127.0.0.1', qvm_port):
         warning_msg = ("Unable to start qvm server, since the specified "
-               "port {} is in use.").format(qvm_port)
+                       "port {} is in use.").format(qvm_port)
         warnings.warn(RuntimeWarning(warning_msg))
     else:
         qvm_cmd = ['qvm', '-S', '--host', host, '-p', str(qvm_port)]
@@ -757,7 +756,7 @@ def local_forest_runtime(
                                stderr=subprocess.PIPE)
     if _port_used('127.0.0.1', quilc_port):
         warning_msg = ("Unable to start quilc server, since the specified "
-               "port {} is in use.").format(quilc_port)
+                       "port {} is in use.").format(quilc_port)
         warnings.warn(RuntimeWarning(warning_msg))
     else:
         quilc_cmd = ['quilc', '--host', host, '-p', str(quilc_port), '-R']

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -711,9 +711,8 @@ def local_forest_runtime(
 
     This context manager will ensure that the designated ports are not used, start up `qvm` and
     `quilc` proccesses if possible and terminate them when the context is exited.
-    The returned tuple contains two ``subprocess.Popen`` objects for the `qvm` and the `quilc` processes.
-    If one of the ports is in use, a ``RuntimeWarning`` will be issued, the `qvm`/`quilc` process
-    won't be started and the respective value in the tuple will be ``None``.
+    If one of the ports is in use, a ``RuntimeWarning`` will be issued and the `qvm`/`quilc` process
+    won't be started.
 
     .. note::
         Only processes started by this context manager will be terminated on exit, no external process will
@@ -740,6 +739,11 @@ def local_forest_runtime(
         may be disabled. Please use it with caution.
 
     :raises: FileNotFoundError: If either executable is not installed.
+
+    :returns: The returned tuple contains two ``subprocess.Popen`` objects
+        for the `qvm` and the `quilc` processes.  If one of the designated
+        ports is in use, the process won't be started and the respective
+        value in the tuple will be ``None``.
     """
 
     qvm = None

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -672,7 +672,10 @@ def local_qvm() -> Iterator[Tuple[subprocess.Popen, subprocess.Popen]]:
     .. deprecated:: 2.11
         Use py:func:`local_forest_runtime` instead.
     """
-    yield local_forest_runtime()
+    warnings.warn(DeprecationWarning("Use of pyquil.api.local_qvm has been deprecated.\n"
+                                     "Please use pyquil.api.local_forest_runtime instead."))
+    with local_forest_runtime() as (qvm, quilc):
+        yield (qvm, quilc)
 
 
 @contextmanager
@@ -704,13 +707,14 @@ def local_forest_runtime(
     >>> with local_forest_runtime():
     >>>     results = qvm.run_and_measure(prog, trials=10)
 
-    :param host: host on which qvm and quilc should listen on
-    :param qvm_port: port which should be used by qvm
-    :param quilc_port: port which should be used by quilc
-    :param use_protoquil: restrict input/output to protoquil
+    :param host: Host on which `qvm` and `quilc` should listen on.
+    :param qvm_port: Port which should be used by `qvm`.
+    :param quilc_port: Port which should be used by `quilc`.
+    :param use_protoquil: Restrict input/output to protoquil.
 
     .. warning::
-        use_protoquil may disable language features you need, use with caution
+        If ``use_protoquil`` is set to ``True`` language features you need
+        may be disabled. Please use it with caution.
 
     :raises: FileNotFoundError: If either executable is not installed.
     """

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -745,7 +745,8 @@ def local_forest_runtime(
     qvm = None
     quilc = None
 
-    if _port_used('127.0.0.1', qvm_port):
+    # if host is 0.0.0.0 replace it with 127.0.01
+    if _port_used(host if host != '0.0.0.0' else '127.0.0.1', qvm_port):
         warning_msg = ("Unable to start qvm server, since the specified "
                        "port {} is in use.").format(qvm_port)
         warnings.warn(RuntimeWarning(warning_msg))
@@ -754,7 +755,8 @@ def local_forest_runtime(
         qvm = subprocess.Popen(qvm_cmd,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
-    if _port_used('127.0.0.1', quilc_port):
+
+    if _port_used(host if host != '0.0.0.0' else '127.0.0.1', quilc_port):
         warning_msg = ("Unable to start quilc server, since the specified "
                        "port {} is in use.").format(quilc_port)
         warnings.warn(RuntimeWarning(warning_msg))

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -193,7 +193,7 @@ def benchmarker():
 
 
 @pytest.fixture(scope='session')
-def local__quilc():
+def local_qvm_quilc():
     """Execute test with local qvm and quilc running"""
     if shutil.which('qvm') is None or shutil.which('quilc') is None:
         return pytest.skip("This test requires 'qvm' and 'quilc' "

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from requests import RequestException
 
 from pyquil.api import (QVMConnection, QVMCompiler, ForestConnection,
-                        get_benchmarker, local_qvm)
+                        get_benchmarker, local_runtime)
 from pyquil.api._config import PyquilConfig
 from pyquil.api._errors import UnknownApiError
 from pyquil.api._compiler import QuilcNotRunning, QuilcVersionMismatch
@@ -193,13 +193,13 @@ def benchmarker():
 
 
 @pytest.fixture(scope='session')
-def local_qvm_quilc():
+def local__quilc():
     """Execute test with local qvm and quilc running"""
     if shutil.which('qvm') is None or shutil.which('quilc') is None:
         return pytest.skip("This test requires 'qvm' and 'quilc' "
                            "executables to be installed locally.")
 
-    with local_qvm() as context:
+    with local_runtime() as context:
         yield context
 
 

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from requests import RequestException
 
 from pyquil.api import (QVMConnection, QVMCompiler, ForestConnection,
-                        get_benchmarker, local_runtime)
+                        get_benchmarker, local_forest_runtime)
 from pyquil.api._config import PyquilConfig
 from pyquil.api._errors import UnknownApiError
 from pyquil.api._compiler import QuilcNotRunning, QuilcVersionMismatch
@@ -199,7 +199,7 @@ def local_qvm_quilc():
         return pytest.skip("This test requires 'qvm' and 'quilc' "
                            "executables to be installed locally.")
 
-    with local_runtime() as context:
+    with local_forest_runtime() as context:
         yield context
 
 

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from pyquil import Program, get_qc, list_quantum_computers
-from pyquil.api import QVM, QuantumComputer, local_runtime
+from pyquil.api import QVM, QuantumComputer, local_forest_runtime
 from pyquil.tests.utils import DummyCompiler
 from pyquil.api._quantum_computer import (_symmetrization, _flip_array_to_prog,
                                           _construct_orthogonal_array,

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -465,7 +465,7 @@ def test_run_and_measure(local_qvm_quilc):
     trials = 11
     # note to devs: this is included as an example in the run_and_measure docstrings
     # so if you change it here ... change it there!
-    with local_runtime():  # Redundant with test fixture.
+    with local_forest_runtime():  # Redundant with test fixture.
         bitstrings = qc.run_and_measure(prog, trials)
     bitstring_array = np.vstack(bitstrings[q] for q in qc.qubits()).T
     assert bitstring_array.shape == (trials, len(qc.qubits()))

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from pyquil import Program, get_qc, list_quantum_computers
-from pyquil.api import QVM, QuantumComputer, local_qvm
+from pyquil.api import QVM, QuantumComputer, local_runtime
 from pyquil.tests.utils import DummyCompiler
 from pyquil.api._quantum_computer import (_symmetrization, _flip_array_to_prog,
                                           _construct_orthogonal_array,
@@ -465,7 +465,7 @@ def test_run_and_measure(local_qvm_quilc):
     trials = 11
     # note to devs: this is included as an example in the run_and_measure docstrings
     # so if you change it here ... change it there!
-    with local_qvm():  # Redundant with test fixture.
+    with local_runtime():  # Redundant with test fixture.
         bitstrings = qc.run_and_measure(prog, trials)
     bitstring_array = np.vstack(bitstrings[q] for q in qc.qubits()).T
     assert bitstring_array.shape == (trials, len(qc.qubits()))


### PR DESCRIPTION
Description
-----------

I renamed `local_qvm` to `local_runtime`, hinting that it does not just start a qvm but also takes care of quilc.

Additionally I added optional parameters that can be provided to that function, giving the user more control over the running processes. 

use_protoQuil defaults to `False`, is that a sensible default?

Currently also exposes options to define custom ports for quilc and qvm, but tbh I'm not sure if that makes sense since (at least right now) I don't see that any other than default ports would work. What do you think?

I also enabled documentation to be generated by this method in sphinx.

Let me know your thoughts on all these and if there are any other options that should get exposed!

Resolves #972 

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
