### PR TITLE
Undo erroneous logic filling out non-“ro” memory on QPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ Changelog
 -   The `merge_programs` function now supports merging programs with
     `DefPermutationGate`, instead of throwing an error, and avoids
     redundant readout declaration (@kylegulshen, gh-971).
+-   Remove unsound logic to fill out non-"ro" memory regions when
+    targeting a QPU (@notmgsk, gh-982).
 
 [v2.10](https://github.com/rigetti/pyquil/compare/v2.9.1...v2.10.0) (July 31, 2019)
 -----------------------------------------------------------------------------------

--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -172,8 +172,6 @@ support at support@rigetti.com.""")
             bitstrings = None
 
         self._memory_results = defaultdict(lambda: None)
-        for aref, vals in self._variables_shim.items():
-            self._memory_results[aref] = [vals] * ro_sources[0].shape[0]
         self._memory_results["ro"] = bitstrings
         self._last_results = results
 


### PR DESCRIPTION
Description
-----------

This is a bandaid to close #981.  #873 modified `QVM` and `QPU` to remove the restriction that declared memory regions be named "ro". The `QVM` change works nicely, but upon testing on the QPU an error was found. There was a type error (ndarray vs list), but more importantly there was a logical error in using `ro_sources` where `len(bitstrings)` ought to have been used.

Note this is only a bandaid because memory regions on the QPU are still not populated in `_memory_results`. I will open an issue to fix that separately, in the interest of unblocking a release.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
