### PR TITLE
Run the GitLab CI test suite on Python 3.7 as well

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ services:
     alias: quilc
     command: ["-R"]
 
-test:
+test-py36:
   tags:
     - github
   script:
@@ -24,6 +24,17 @@ test:
     - echo "quilc_address = $QUILC_URL" >> ~/.forest_config
     - cat ~/.forest_config
     - tox -e py36
+
+test-py37:
+  image: python:3.7
+  tags:
+    - github
+  script:
+    - echo "[Rigetti Forest]" > ~/.forest_config
+    - echo "qvm_address = $QVM_URL" >> ~/.forest_config
+    - echo "quilc_address = $QUILC_URL" >> ~/.forest_config
+    - cat ~/.forest_config
+    - tox -e py37
 
 style:
   tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,18 @@ Changelog
 
 -   PyQuil now has a [Bug Report
     Template](https://github.com/rigetti/pyquil/blob/master/.github/ISSUE_TEMPLATE/BUG_REPORT.md),
-    which contains sections to fill out when filing a bug (@karalekas, gh-985).
--   PyQuil now has a [Feature Request Template
-    ](https://github.com/rigetti/pyquil/blob/master/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md),
-    which contains sections to fill out when suggesting an enhancement (@karalekas, gh-986).
+    and a [Feature Request
+    Template](https://github.com/rigetti/pyquil/blob/master/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md),
+    which contain sections to fill out when filing a bug or suggesting an enhancement
+    (@karalekas, gh-985, gh-986).
 
 ### Improvements and Changes
 
 -   The `local_qvm` context manager has been renamed to `local_forest_runtime`,
     which now checks if the designated ports are used before starting `qvm`/`quilc`.
     The original `local_qvm` has been deprecated (@sauercrowd, gh-976).
+-   The test suite for pyQuil now runs against both Python 3.6 and 3.7 to ensure
+    compatibility with the two most recent versions of Python (@karalekas, gh-987).
 
 ### Bugfixes
 


### PR DESCRIPTION
Description
-----------

The docs (and the tox.ini) say that we support Python 3.7, but we don't actually run the tests using that version of Python as part of the CI. Now we do!

Checklist
---------

- [x] The above description motivates these changes.
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
