### PR TITLE
Fix strength 2 orthogonal array construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ Changelog
 
 ### Bugfixes
 
--   Strength two symmetrization was not correctly producing orthogonal arrays due to erroneous truncation, which has been fixed. (@kylegulshen, gh-990)
+-   Strength two symmetrization was not correctly producing orthogonal 
+    arrays due to erroneous truncation, which has been fixed 
+    (@kylegulshen, gh-990).
 
 [v2.11](https://github.com/rigetti/pyquil/compare/v2.10.0...v2.11.0) (September 3, 2019)
 ----------------------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Changelog
 
 ### Bugfixes
 
+-   Strength two symmetrization was not correctly producing orthogonal arrays due to erroneous truncation, which has been fixed. (@kylegulshen, gh-990)
+
 [v2.11](https://github.com/rigetti/pyquil/compare/v2.10.0...v2.11.0) (September 3, 2019)
 ----------------------------------------------------------------------------------------
 

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -851,12 +851,10 @@ def _symmetrization(program: Program, meas_qubits: List[int], symm_type: int = 3
     elif symm_type >= 0:
         flip_matrix = _construct_orthogonal_array(len(meas_qubits), symm_type)
 
-    # The next part is not rigorous the sense that we simply truncate to the desired
+    # The next part is not rigorous in the sense that we simply truncate to the desired
     # number of qubits. The problem is that orthogonal arrays of a certain strength for an
     # arbitrary number of qubits are not known to exist.
-    num_expts, num_qubits = flip_matrix.shape
-    if len(meas_qubits) != num_qubits:
-        flip_matrix = flip_matrix[0:num_expts, 0:len(meas_qubits)]
+    flip_matrix = flip_matrix[:, :len(meas_qubits)]
 
     symm_programs = []
     flip_arrays = []
@@ -1067,8 +1065,8 @@ def _construct_strength_two_orthogonal_array(num_qubits: int) -> np.ndarray:
     four_lam = min(x for x in valid_numbers if x >= num_qubits) + 1
     H = hadamard(_next_power_of_2(four_lam))
     # The minus sign in front of H fixes the 0 <-> 1 inversion relative to the reference [OATA]
-    orthogonal_array = ((-H[1:four_lam, 0:four_lam] + 1) / 2).astype(int)
-    return orthogonal_array.T
+    orthogonal_array = ((-H[1:, :].T + 1) / 2).astype(int)
+    return orthogonal_array
 
 
 def _check_min_num_trials_for_symmetrized_readout(num_qubits: int, trials: int, symm_type: int) \

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -603,7 +603,7 @@ def test_orthogonal_array():
         assert all([count == occurences[0] for count in occurences.values()])
 
     for strength in [0, 1, 2, 3]:
-        for num_q in range(1,64):
+        for num_q in range(1, 64):
             oa = _construct_orthogonal_array(num_q, strength=strength)
             for _ in range(10):
                 check_random_columns(oa, strength)

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -1,4 +1,5 @@
 import itertools
+import random
 
 import networkx as nx
 import numpy as np
@@ -583,3 +584,24 @@ def test_noisy(forest):
     qc = get_qc('1q-qvm', noisy=True)
     result = qc.run_and_measure(p, trials=10000)
     assert result[0].mean() < 1.0
+
+
+def test_orthogonal_array():
+    def bit_array_to_int(bit_array):
+        output = 0
+        for bit in bit_array:
+            output = (output << 1) | bit
+        return output
+
+    def check_random_columns(oa, strength):
+        column_idxs = random.sample(range(oa.shape[1]), strength)
+        occurences = {entry: 0 for entry in range(2 ** strength)}
+        for row in oa[:, column_idxs]:
+            occurences[bit_array_to_int(row)] += 1
+        assert all([count == occurences[0] for count in occurences.values()])
+
+    for strength in [0, 1, 2, 3]:
+        num_q = random.randint(1, 32)
+        oa = _construct_orthogonal_array(num_q, strength=strength)
+        for _ in range(10):
+            check_random_columns(oa, strength)

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -594,8 +594,10 @@ def test_orthogonal_array():
         return output
 
     def check_random_columns(oa, strength):
-        column_idxs = random.sample(range(oa.shape[1]), strength)
-        occurences = {entry: 0 for entry in range(2 ** strength)}
+        num_q = oa.shape[1]
+        num_cols = min(num_q, strength)
+        column_idxs = random.sample(range(num_q), num_cols)
+        occurences = {entry: 0 for entry in range(2 ** num_cols)}
         for row in oa[:, column_idxs]:
             occurences[bit_array_to_int(row)] += 1
         assert all([count == occurences[0] for count in occurences.values()])

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -603,7 +603,7 @@ def test_orthogonal_array():
         assert all([count == occurences[0] for count in occurences.values()])
 
     for strength in [0, 1, 2, 3]:
-        num_q = random.randint(1, 32)
-        oa = _construct_orthogonal_array(num_q, strength=strength)
-        for _ in range(10):
-            check_random_columns(oa, strength)
+        for num_q in range(1,64):
+            oa = _construct_orthogonal_array(num_q, strength=strength)
+            for _ in range(10):
+                check_random_columns(oa, strength)


### PR DESCRIPTION
Description
-----------

There was an accidental truncation of strength two arrays that yielded at least some of them invalid. I removed the truncation during creation of the array altogether, to match behavior of strength 3. Now, arrays are constructed for more than desired qubits if necessary, and automatically truncated to desired number of qubits in `_symmetrization`.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
