### PR TITLE
Check for multiples of pi at operator construction time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Changelog
     immediate `float` value. Finally, the `CONVERT` instruction now accepts any valid
     memory reference designator (a `MemoryReference`, a string, or a tuple of type
     `(str, int)`) for both its arguments (@appleby, gh-1010).
+-   Fix the interaction between pretty-printing multiples of π and discarding of
+    parentheses that would lead to incorrect arithmetic expressions (@notmgsk, gh-993).
 
 [v2.11](https://github.com/rigetti/pyquil/compare/v2.10.0...v2.11.0) (September 3, 2019)
 ----------------------------------------------------------------------------------------

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -538,10 +538,17 @@ def _check_for_pi(element):
     """
     Check to see if there exists a rational number r = p/q
     in reduced form for which the difference between element/np.pi
-    and r is small and q <= 8.
+    and r is small and q <= 8. Returns a string if no such rational
+    exists, or an Expression which will pretty print using the string
+    "pi".
+
+    For example,
+    In[1]:  _check_for_pi(2 * np.pi)
+    Out[1]: "2*pi"
 
     :param element: float
-    :return element: pretty print string if true, else standard representation.
+    :return element: an expression containing a rational of pi
+    :rtype: Union[str, Expression]
     """
     frac = Fraction(element / np.pi).limit_denominator(8)
     num, den = frac.numerator, frac.denominator

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -202,7 +202,7 @@ def format_parameter(element):
     if isinstance(element, integer_types) or isinstance(element, np.int_):
         return repr(element)
     elif isinstance(element, float):
-        return _check_for_pi(element)
+        return _expression_to_string(_check_for_pi(element))
     elif isinstance(element, complex):
         out = ''
         r = element.real
@@ -233,6 +233,8 @@ def format_parameter(element):
         return _expression_to_string(element)
     elif isinstance(element, MemoryReference):
         return element.out()
+    elif isinstance(element, str):
+        return element
     assert False, "Invalid parameter: %r" % element
 
 
@@ -464,7 +466,8 @@ class Div(BinaryExp):
         return a / b
 
     def __init__(self, op1, op2):
-        super(Div, self).__init__(op1, op2)
+        super(Div, self).__init__(_check_for_pi(op1) if isinstance(op1, float) else op1,
+                                  _check_for_pi(op2) if isinstance(op2, float) else op2)
 
 
 class Pow(BinaryExp):
@@ -483,7 +486,7 @@ class Pow(BinaryExp):
 def _expression_to_string(expression):
     """
     Recursively converts an expression to a string taking into account precedence and associativity for placing
-    parenthesis
+    parentheses.
 
     :param Expression expression: expression involving parameters
     :return: string such as '%x*(%y-4)'
@@ -549,11 +552,11 @@ def _check_for_pi(element):
         elif abs(num) == 1 and den == 1:
             return sign + "pi"
         elif abs(num) == 1:
-            return sign + "pi/" + repr(den)
+            return Div(sign + "pi", den)
         elif den == 1:
-            return repr(num) + "*pi"
+            return Mul(num, "pi")
         else:
-            return repr(num) + "*pi/" + repr(den)
+            return Mul(num, Div("pi", den))
     else:
         return repr(element)
 

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -1298,3 +1298,14 @@ def test_placeholders_preserves_modifiers():
     a = address_qubits(p)
 
     assert a[0].modifiers == g.modifiers
+
+
+def test_arithmetic_pretty_printing():
+    import numpy as np
+    from pyquil.quilatom import _expression_to_string
+    pi = np.pi
+    theta = [2]
+    math = "3 * theta[0] / (2 * pi)"
+    exp = Program(f"RX({math}) 0")[0].params[0]
+
+    assert eval(_expression_to_string(exp)) == eval(math)


### PR DESCRIPTION
Rather than trying to figure it out at the time of printing.

Closes #943.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated, including author and PR number (@username, gh-xxx).
