### PR TITLE
Reduce deprecated feature warnings in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Changelog
 -   Deleted the deprecated modules `parameters.py` and `qpu.py` (@karalekas, gh-991).
 -   The test suite for pyQuil now runs much faster, by setting the default value
     of the `--use-seed` option for `pytest` to `True` (@karalekas, gh-992).
+-   Test suite has been updated to reduce the use of deprecated features
+    (@kilimanjaro, gh-998).
 
 ### Bugfixes
 

--- a/pyquil/api/_qvm.py
+++ b/pyquil/api/_qvm.py
@@ -518,7 +518,7 @@ To read more about supplying noise to the QVM, see http://pyquil.readthedocs.io/
                                                         gate_noise=self.gate_noise,
                                                         random_seed=self.random_seed)
 
-        if "ro" not in self._memory_results or self._memory_results["ro"] == []:
+        if "ro" not in self._memory_results or len(self._memory_results["ro"]) == 0:
             self._memory_results["ro"] = np.zeros((trials, 0), dtype=np.int64)
 
         return self

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -109,6 +109,20 @@ class TensorProductState:
         return TensorProductState(tuple(_OneQState.from_str(x) for x in s.split('*')))
 
 
+def _pauli_to_product_state(in_state: PauliTerm) -> TensorProductState:
+    """
+    Convert a Pauli term to a TensorProductState.
+    """
+    if is_identity(in_state):
+        in_state = TensorProductState()
+    else:
+        in_state = TensorProductState([
+            _OneQState(label=pauli_label, index=0, qubit=qubit)
+            for qubit, pauli_label in in_state._ops.items()
+        ])
+    return in_state
+
+
 def SIC0(q):
     return TensorProductState((_OneQState('SIC', 0, q),))
 
@@ -177,15 +191,7 @@ class ExperimentSetting:
         if isinstance(in_state, PauliTerm):
             warnings.warn("Please specify in_state as a TensorProductState",
                           DeprecationWarning, stacklevel=2)
-
-            if is_identity(in_state):
-                in_state = TensorProductState()
-            else:
-                in_state = TensorProductState([
-                    _OneQState(label=pauli_label, index=0, qubit=qubit)
-                    for qubit, pauli_label in in_state._ops.items()
-                ])
-
+            in_state = _pauli_to_product_state(in_state)
         object.__setattr__(self, 'in_state', in_state)
         object.__setattr__(self, 'out_operator', out_operator)
 

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -37,11 +37,16 @@ from pyquil.device import ISA, NxDevice
 from pyquil.gates import CNOT, H, MEASURE, PHASE, Z, RZ, RX, CZ
 from pyquil.paulis import PauliTerm
 from pyquil.quil import Program
-from pyquil.quilbase import Halt
+from pyquil.quilbase import Halt, Declare
+from pyquil.quilatom import MemoryReference
 
 EMPTY_PROGRAM = Program()
 BELL_STATE = Program(H(0), CNOT(0, 1))
-BELL_STATE_MEASURE = Program(H(0), CNOT(0, 1), MEASURE(0, 0), MEASURE(1, 1))
+BELL_STATE_MEASURE = Program(Declare('ro', 'BIT', 2),
+                             H(0),
+                             CNOT(0, 1),
+                             MEASURE(0, MemoryReference('ro', 0)),
+                             MEASURE(1, MemoryReference('ro', 1)))
 COMPILED_BELL_STATE = Program([
     RZ(pi / 2, 0),
     RX(pi / 2, 0),
@@ -139,7 +144,7 @@ WAVEFUNCTION_BINARY = (b'\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0
                        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00?\xe6\xa0\x9ef'
                        b'\x7f;\xcc\x00\x00\x00\x00\x00\x00\x00\x00\xbf\xe6\xa0\x9ef\x7f;\xcc\x00'
                        b'\x00\x00\x00\x00\x00\x00\x00')
-WAVEFUNCTION_PROGRAM = Program(H(0), CNOT(0, 1), MEASURE(0, 0), H(0))
+WAVEFUNCTION_PROGRAM = Program(Declare('ro', 'BIT'), H(0), CNOT(0, 1), MEASURE(0, MemoryReference('ro')), H(0))
 
 
 def test_sync_expectation_mock(qvm: QVMConnection):

--- a/pyquil/tests/test_magic.py
+++ b/pyquil/tests/test_magic.py
@@ -1,6 +1,5 @@
 from pyquil.magic import *
 
-
 @magicquil
 def bell_state(q1, q2):
     H(q1)
@@ -21,7 +20,7 @@ def fast_reset(q1):
 
 
 def test_fast_reset():
-    assert fast_reset(0) == Program('MEASURE 0 ro[0]').if_then(("ro", 0), Program('X 0'), Program('I 0'))
+    assert fast_reset(0) == Program('DECLARE ro BIT\nMEASURE 0 ro[0]').if_then(("ro", 0), Program('X 0'), Program('I 0'))
 
 
 @magicquil
@@ -32,7 +31,7 @@ def no_else(q1):
 
 
 def test_no_else():
-    assert no_else(0) == Program('MEASURE 0 ro[0]').if_then(("ro", 0), Program('X 0'))
+    assert no_else(0) == Program('DECLARE ro BIT\nMEASURE 0 ro[0]').if_then(("ro", 0), Program('X 0'))
 
 
 @magicquil
@@ -46,7 +45,7 @@ def with_elif(q1, q2):
 
 
 def test_with_elif():
-    assert with_elif(0, 1) == Program('MEASURE 0 ro[0]\nMEASURE 1 ro[1]')\
+    assert with_elif(0, 1) == Program('DECLARE ro BIT[2]\nMEASURE 0 ro[0]\nMEASURE 1 ro[1]')\
         .if_then(("ro", 0), Program('X 0'), Program().if_then(("ro", 1), Program('X 1')))
 
 

--- a/pyquil/tests/test_magic.py
+++ b/pyquil/tests/test_magic.py
@@ -1,5 +1,6 @@
 from pyquil.magic import *
 
+
 @magicquil
 def bell_state(q1, q2):
     H(q1)

--- a/pyquil/tests/test_numpy_simulator.py
+++ b/pyquil/tests/test_numpy_simulator.py
@@ -14,6 +14,7 @@ from pyquil.reference_simulator import ReferenceWavefunctionSimulator
 from pyquil.tests.test_reference_wavefunction_simulator import _generate_random_program, \
     _generate_random_pauli
 from pyquil.quilatom import MemoryReference
+from pyquil.quilbase import Declare
 
 
 def test_H_einsum():
@@ -98,6 +99,7 @@ def test_einsum_simulator_10q():
 def test_measure():
     qam = PyQVM(n_qubits=3, quantum_simulator_type=NumpyWavefunctionSimulator)
     qam.execute(Program(
+        Declare("ro", "BIT", 64),
         H(0),
         CNOT(0, 1),
         MEASURE(0, MemoryReference("ro", 63))

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -212,6 +212,7 @@ def test_run(forest):
     )
     bitstrings = qc.run(
         Program(
+            Declare("ro", "BIT", 3),
             H(0),
             CNOT(0, 1),
             CNOT(1, 2),
@@ -274,8 +275,8 @@ def test_readout_symmetrization(forest):
     )
 
     prog = Program(I(0), X(1),
-                   MEASURE(0, MemoryReference("ro", 0)),
-                   MEASURE(1, MemoryReference("ro", 1)))
+                   MEASURE(0, MemoryReference('ro', 0)),
+                   MEASURE(1, MemoryReference('ro', 1)))
     prog.wrap_in_numshots_loop(1000)
 
     bs1 = qc.run(prog)
@@ -473,7 +474,7 @@ def test_run_and_measure(local_qvm_quilc):
 
 
 def test_qvm_compile_pickiness(forest):
-    p = Program(X(0), MEASURE(0, 0))
+    p = Program(Declare('ro', 'BIT'), X(0), MEASURE(0, MemoryReference('ro')))
     p.wrap_in_numshots_loop(1000)
     nq = PyQuilExecutableResponse(program=p.out(), attributes={'num_shots': 1000})
 

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -461,7 +461,8 @@ def test_control_flows_2():
     # create a program that branches based on the value of a classical register
     x_prog = Program(X(0))
     z_prog = Program()
-    branch = Program(H(1)).measure(1, MemoryReference("ro", 1)) \
+    branch = Program(Declare('ro', 'BIT', 2), H(1)) \
+        .measure(1, MemoryReference("ro", 1)) \
         .if_then(MemoryReference("ro", 1), x_prog, z_prog) \
         .measure(0, MemoryReference("ro", 0))
     assert branch.out() == ('DECLARE ro BIT[2]\n'
@@ -700,11 +701,11 @@ pauli_noise 0
 
 
 def test_get_qubits():
-    pq = Program(X(0), CNOT(0, 4), MEASURE(5, MemoryReference("ro", 5)))
+    pq = Program(Declare('ro', 'BIT'), X(0), CNOT(0, 4), MEASURE(5, MemoryReference("ro", 0)))
     assert pq.get_qubits() == {0, 4, 5}
 
     q = [QubitPlaceholder() for _ in range(6)]
-    pq = Program(X(q[0]), CNOT(q[0], q[4]), MEASURE(q[5], MemoryReference("ro", 5)))
+    pq = Program(Declare('ro', 'BIT'), X(q[0]), CNOT(q[0], q[4]), MEASURE(q[5], MemoryReference("ro", 0)))
     qq = pq.alloc()
     pq.inst(Y(q[2]), X(qq))
     assert address_qubits(pq).get_qubits() == {0, 1, 2, 3, 4}
@@ -722,12 +723,12 @@ def test_get_qubits():
 
 def test_get_qubit_placeholders():
     qs = QubitPlaceholder.register(8)
-    pq = Program(X(qs[0]), CNOT(qs[0], qs[4]), MEASURE(qs[5], MemoryReference("ro", 5)))
+    pq = Program(Declare('ro', 'BIT'), X(qs[0]), CNOT(qs[0], qs[4]), MEASURE(qs[5], MemoryReference("ro", 0)))
     assert pq.get_qubits() == {qs[i] for i in [0, 4, 5]}
 
 
 def test_get_qubits_not_as_indices():
-    pq = Program(X(0), CNOT(0, 4), MEASURE(5, MemoryReference("ro", 5)))
+    pq = Program(Declare('ro', 'BIT'), X(0), CNOT(0, 4), MEASURE(5, MemoryReference("ro", 0)))
     assert pq.get_qubits(indices=False) == {Qubit(i) for i in [0, 4, 5]}
 
 
@@ -909,7 +910,7 @@ def test_defgate_integer_input():
 
 def test_out_vs_str():
     qs = QubitPlaceholder.register(6)
-    pq = Program(X(qs[0]), CNOT(qs[0], qs[4]), MEASURE(qs[5], MemoryReference("ro", 5)))
+    pq = Program(Declare('ro', 'BIT', 6), X(qs[0]), CNOT(qs[0], qs[4]), MEASURE(qs[5], MemoryReference("ro", 5)))
 
     with pytest.raises(RuntimeError) as e:
         pq.out()
@@ -921,7 +922,7 @@ def test_out_vs_str():
 
 
 def test_get_classical_addresses_from_program():
-    p = Program([H(i) for i in range(4)])
+    p = Program(Declare('ro', 'BIT', 4), [H(i) for i in range(4)])
     assert get_classical_addresses_from_program(p) == {}
 
     p += [MEASURE(i, MemoryReference("ro", i)) for i in [0, 3, 1]]
@@ -941,6 +942,7 @@ def test_get_classical_addresses_from_quil_program():
     assert get_classical_addresses_from_program(p) == {}
 
     p = Program('\n'.join([
+        'DECLARE ro BIT[2]',
         'X 0',
         'MEASURE 0 ro[1]'
     ]))
@@ -971,9 +973,10 @@ PRAGMA READOUT-POVM 1 "(0.9 0.19999999999999996 0.09999999999999998 0.8)"
 
 
 def test_implicit_declare():
-    program = Program(MEASURE(0, MemoryReference("ro", 0)))
-    assert program.out() == ('DECLARE ro BIT[1]\n'
-                             'MEASURE 0 ro[0]\n')
+    with pytest.warns(UserWarning):
+        program = Program(MEASURE(0, MemoryReference("ro", 0)))
+        assert program.out() == ('DECLARE ro BIT[1]\n'
+                                 'MEASURE 0 ro[0]\n')
 
 
 def test_no_implicit_declare():

--- a/pyquil/tests/test_unitary_tools.py
+++ b/pyquil/tests/test_unitary_tools.py
@@ -9,6 +9,7 @@ from pyquil.paulis import sX, sY, sZ
 from pyquil.unitary_tools import qubit_adjacent_lifted_gate, program_unitary, lifted_gate_matrix, \
     lifted_gate, lifted_pauli, lifted_state_operator
 from pyquil.quilatom import MemoryReference
+from pyquil.quilbase import Declare
 
 
 def test_random_gates():
@@ -62,7 +63,7 @@ def test_qaoa_unitary():
 
 
 def test_unitary_measure():
-    prog = Program(H(0), H(1), MEASURE(0, MemoryReference("ro", 0)))
+    prog = Program(Declare('ro', 'BIT'), H(0), H(1), MEASURE(0, MemoryReference("ro", 0)))
     with pytest.raises(ValueError):
         program_unitary(prog, n_qubits=2)
 


### PR DESCRIPTION
Description
-----------

This reduces from pytest warnings from 1365 to 63, and partially resolves #997. There is no substantial change in behavior of any code. Mostly this is just a matter of various features being deprecated without updating the tests which use them. I might fix the other 63 next week, but I am running out of spare time today.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
