### PR TITLE
First pass at PersistentQVM class + app-ng ForestConnection

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -182,6 +182,19 @@ def forest():
 
 
 @pytest.fixture(scope='session')
+def forest_app_ng():
+    # TODO:(appleby) delete this forest_app_ng fixture and replace all occurrences with the
+    # standard forest fixture once qvm-app-ng is stable and/or backwards compatible enough to be
+    # used by all tests that require a ForestConnection.
+    try:
+        connection = ForestConnection()
+        connection._qvm_ng_get_version_info()
+        return connection
+    except (RequestException, UnknownApiError) as e:
+        return pytest.skip("This test requires a QVM app-ng connection: {}".format(e))
+
+
+@pytest.fixture(scope='session')
 def benchmarker():
     try:
         bm = get_benchmarker(timeout=2)

--- a/pyquil/api/__init__.py
+++ b/pyquil/api/__init__.py
@@ -21,7 +21,8 @@ import warnings
 __all__ = ['QVMConnection', 'QVMCompiler', 'QPUCompiler',
            'QVMAllocationMethod', 'QVMSimulationMethod',
            'Job', 'Device', 'ForestConnection', 'pyquil_protect',
-           'WavefunctionSimulator', 'QuantumComputer', 'PersistentQVM'
+           'WavefunctionSimulator', 'QuantumComputer',
+           'PersistentQVM', 'get_qvm_memory_estimate',
            'list_quantum_computers', 'get_qc', 'local_forest_runtime', 'local_qvm',
            'QAM', 'QVM', 'QPU', 'QPUConnection',
            'BenchmarkConnection', 'get_benchmarker']
@@ -37,7 +38,7 @@ from pyquil.api._quantum_computer import (QuantumComputer, list_quantum_computer
                                           get_qc, local_forest_runtime, local_qvm)
 from pyquil.api._qvm import QVMConnection, QVM
 from pyquil.api._wavefunction_simulator import WavefunctionSimulator
-from pyquil.api._persistent_qvm import PersistentQVM
+from pyquil.api._persistent_qvm import PersistentQVM, get_qvm_memory_estimate
 from pyquil.device import Device
 
 

--- a/pyquil/api/__init__.py
+++ b/pyquil/api/__init__.py
@@ -19,13 +19,14 @@ Module for facilitating connections to the QVM / QPU.
 import warnings
 
 __all__ = ['QVMConnection', 'QVMCompiler', 'QPUCompiler',
+           'QVMAllocationMethod', 'QVMSimulationMethod',
            'Job', 'Device', 'ForestConnection', 'pyquil_protect',
-           'WavefunctionSimulator', 'QuantumComputer',
+           'WavefunctionSimulator', 'QuantumComputer', 'PersistentQVM'
            'list_quantum_computers', 'get_qc', 'local_forest_runtime', 'local_qvm',
            'QAM', 'QVM', 'QPU', 'QPUConnection',
            'BenchmarkConnection', 'get_benchmarker']
 
-from pyquil.api._base_connection import ForestConnection
+from pyquil.api._base_connection import ForestConnection, QVMAllocationMethod, QVMSimulationMethod
 from pyquil.api._benchmark import BenchmarkConnection, get_benchmarker
 from pyquil.api._compiler import QVMCompiler, QPUCompiler
 from pyquil.api._error_reporting import pyquil_protect
@@ -36,6 +37,7 @@ from pyquil.api._quantum_computer import (QuantumComputer, list_quantum_computer
                                           get_qc, local_forest_runtime, local_qvm)
 from pyquil.api._qvm import QVMConnection, QVM
 from pyquil.api._wavefunction_simulator import WavefunctionSimulator
+from pyquil.api._persistent_qvm import PersistentQVM
 from pyquil.device import Device
 
 

--- a/pyquil/api/__init__.py
+++ b/pyquil/api/__init__.py
@@ -22,7 +22,8 @@ __all__ = ['QVMConnection', 'QVMCompiler', 'QPUCompiler',
            'QVMAllocationMethod', 'QVMSimulationMethod',
            'Job', 'Device', 'ForestConnection', 'pyquil_protect',
            'WavefunctionSimulator', 'QuantumComputer',
-           'PersistentQVM', 'get_job_info', 'get_job_result', 'get_qvm_memory_estimate',
+           'PersistentQVM', 'delete_job', 'get_job_info', 'get_job_result',
+           'get_qvm_memory_estimate',
            'list_quantum_computers', 'get_qc', 'local_forest_runtime', 'local_qvm',
            'QAM', 'QVM', 'QPU', 'QPUConnection',
            'BenchmarkConnection', 'get_benchmarker']
@@ -38,7 +39,7 @@ from pyquil.api._quantum_computer import (QuantumComputer, list_quantum_computer
                                           get_qc, local_forest_runtime, local_qvm)
 from pyquil.api._qvm import QVMConnection, QVM
 from pyquil.api._wavefunction_simulator import WavefunctionSimulator
-from pyquil.api._persistent_qvm import (PersistentQVM, get_job_info, get_job_result,
+from pyquil.api._persistent_qvm import (PersistentQVM, delete_job, get_job_info, get_job_result,
                                         get_qvm_memory_estimate)
 from pyquil.device import Device
 

--- a/pyquil/api/__init__.py
+++ b/pyquil/api/__init__.py
@@ -22,7 +22,7 @@ __all__ = ['QVMConnection', 'QVMCompiler', 'QPUCompiler',
            'QVMAllocationMethod', 'QVMSimulationMethod',
            'Job', 'Device', 'ForestConnection', 'pyquil_protect',
            'WavefunctionSimulator', 'QuantumComputer',
-           'PersistentQVM', 'get_qvm_memory_estimate',
+           'PersistentQVM', 'get_job_result', 'get_qvm_memory_estimate',
            'list_quantum_computers', 'get_qc', 'local_forest_runtime', 'local_qvm',
            'QAM', 'QVM', 'QPU', 'QPUConnection',
            'BenchmarkConnection', 'get_benchmarker']
@@ -38,7 +38,7 @@ from pyquil.api._quantum_computer import (QuantumComputer, list_quantum_computer
                                           get_qc, local_forest_runtime, local_qvm)
 from pyquil.api._qvm import QVMConnection, QVM
 from pyquil.api._wavefunction_simulator import WavefunctionSimulator
-from pyquil.api._persistent_qvm import PersistentQVM, get_qvm_memory_estimate
+from pyquil.api._persistent_qvm import PersistentQVM, get_job_result, get_qvm_memory_estimate
 from pyquil.device import Device
 
 

--- a/pyquil/api/__init__.py
+++ b/pyquil/api/__init__.py
@@ -22,8 +22,7 @@ __all__ = ['QVMConnection', 'QVMCompiler', 'QPUCompiler',
            'QVMAllocationMethod', 'QVMSimulationMethod',
            'Job', 'Device', 'ForestConnection', 'pyquil_protect',
            'WavefunctionSimulator', 'QuantumComputer',
-           'PersistentQVM', 'delete_job', 'get_job_info', 'get_job_result',
-           'get_qvm_memory_estimate',
+           'AsyncJob', 'PersistentQVM', 'get_qvm_memory_estimate',
            'list_quantum_computers', 'get_qc', 'local_forest_runtime', 'local_qvm',
            'QAM', 'QVM', 'QPU', 'QPUConnection',
            'BenchmarkConnection', 'get_benchmarker']
@@ -39,8 +38,7 @@ from pyquil.api._quantum_computer import (QuantumComputer, list_quantum_computer
                                           get_qc, local_forest_runtime, local_qvm)
 from pyquil.api._qvm import QVMConnection, QVM
 from pyquil.api._wavefunction_simulator import WavefunctionSimulator
-from pyquil.api._persistent_qvm import (PersistentQVM, delete_job, get_job_info, get_job_result,
-                                        get_qvm_memory_estimate)
+from pyquil.api._persistent_qvm import (AsyncJob, PersistentQVM, get_qvm_memory_estimate)
 from pyquil.device import Device
 
 

--- a/pyquil/api/__init__.py
+++ b/pyquil/api/__init__.py
@@ -22,7 +22,7 @@ __all__ = ['QVMConnection', 'QVMCompiler', 'QPUCompiler',
            'QVMAllocationMethod', 'QVMSimulationMethod',
            'Job', 'Device', 'ForestConnection', 'pyquil_protect',
            'WavefunctionSimulator', 'QuantumComputer',
-           'PersistentQVM', 'get_job_result', 'get_qvm_memory_estimate',
+           'PersistentQVM', 'get_job_info', 'get_job_result', 'get_qvm_memory_estimate',
            'list_quantum_computers', 'get_qc', 'local_forest_runtime', 'local_qvm',
            'QAM', 'QVM', 'QPU', 'QPUConnection',
            'BenchmarkConnection', 'get_benchmarker']
@@ -38,7 +38,8 @@ from pyquil.api._quantum_computer import (QuantumComputer, list_quantum_computer
                                           get_qc, local_forest_runtime, local_qvm)
 from pyquil.api._qvm import QVMConnection, QVM
 from pyquil.api._wavefunction_simulator import WavefunctionSimulator
-from pyquil.api._persistent_qvm import PersistentQVM, get_job_result, get_qvm_memory_estimate
+from pyquil.api._persistent_qvm import (PersistentQVM, get_job_info, get_job_result,
+                                        get_qvm_memory_estimate)
 from pyquil.device import Device
 
 

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -172,7 +172,7 @@ def validate_qubit_list(qubit_list):
 
 
 def validate_num_qubits(num_qubits):
-    if not isinstance(num_qubits, integer_types) or num_qubits < 0:
+    if not isinstance(num_qubits, int) or num_qubits < 0:
         raise TypeError("num_qubits must be a positive integer.")
 
 
@@ -440,7 +440,7 @@ def qvm_ng_run_program_async_payload(qvm_token, quil_program):
 def qvm_ng_qvm_memory_estimate_payload(simulation_method, allocation_method, num_qubits,
                                        measurement_noise, gate_noise):
     """REST payload for :py:func:`ForestConnection._qvm_ng_qvm_memory_estimate`"""
-    if not isinstance(num_qubits, integer_types) or num_qubits < 0:
+    if not isinstance(num_qubits, int) or num_qubits < 0:
         raise ValueError("num_qubits must be a positive integer.")
 
     validate_simulation_method(simulation_method)
@@ -465,7 +465,7 @@ def qvm_ng_qvm_memory_estimate_payload(simulation_method, allocation_method, num
 def qvm_ng_create_qvm_payload(simulation_method, allocation_method, num_qubits, measurement_noise,
                               gate_noise):
     """REST payload for :py:func:`ForestConnection._qvm_ng_create_qvm`"""
-    if not isinstance(num_qubits, integer_types) or num_qubits < 0:
+    if not isinstance(num_qubits, int) or num_qubits < 0:
         raise ValueError("num_qubits must be a positive integer.")
 
     validate_simulation_method(simulation_method)

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -165,6 +165,11 @@ def validate_qubit_list(qubit_list):
     return qubit_list
 
 
+def validate_num_qubits(num_qubits):
+    if not isinstance(num_qubits, integer_types) or num_qubits < 0:
+        raise TypeError("num_qubits must be a positive integer.")
+
+
 def is_valid_v4_uuid(uuid_string):
     """
     Is uuid_string a valid string representation of a v4 UUID?
@@ -369,6 +374,9 @@ def qvm_ng_create_qvm_payload(simulation_method, allocation_method, num_qubits, 
 
     validate_simulation_method(simulation_method)
     validate_allocation_method(allocation_method)
+    validate_num_qubits(num_qubits)
+    validate_noise_probabilities(gate_noise)
+    validate_noise_probabilities(measurement_noise)
 
     payload = {"type": TYPE_CREATE_QVM,
                "simulation-method": simulation_method.value,

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -411,7 +411,7 @@ def qvm_run_payload(quil_program, classical_addresses, trials,
 
 
 def qvm_ng_run_program_payload(quil_program, qvm_token, simulation_method, allocation_method,
-                               classical_addresses, measurement_noise, gate_noise):
+                               classical_addresses, measurement_noise, gate_noise, random_seed):
     """REST payload for :py:func:`ForestConnection._qvm_ng_run_program`"""
     if not quil_program:
         raise ValueError("You have attempted to run an empty program."
@@ -443,6 +443,8 @@ def qvm_ng_run_program_payload(quil_program, qvm_token, simulation_method, alloc
         payload["measurement-noise"] = measurement_noise
     if gate_noise is not None:
         payload["gate-noise"] = gate_noise
+    if random_seed is not None:
+        payload['rng-seed'] = random_seed
 
     return payload
 
@@ -665,14 +667,16 @@ class ForestConnection:
         return qvm_version
 
     @_record_call
-    def _qvm_ng_run_program(self, quil_program, qvm_token, simulation_method, allocation_method,
-                            classical_addresses, measurement_noise, gate_noise) -> np.ndarray:
+    def _qvm_ng_run_program(
+            self, quil_program, qvm_token, simulation_method, allocation_method,
+            classical_addresses, measurement_noise, gate_noise, random_seed
+    ) -> np.ndarray:
         """
         Run a Forest ``run_program`` job on a QVM.
         """
         payload = qvm_ng_run_program_payload(quil_program, qvm_token, simulation_method,
                                              allocation_method, classical_addresses,
-                                             measurement_noise, gate_noise)
+                                             measurement_noise, gate_noise, random_seed)
         response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
         ram = response.json()
 

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -529,7 +529,7 @@ class ForestConnection:
         json = response.json()
 
         if not isinstance(json, dict) or "token" not in json or not is_valid_v4_uuid(json["token"]):
-            raise TypeError(f'Malformed persistent QVM token returned by the QVM: {json}')
+            raise TypeError(f"Malformed persistent QVM token returned by the QVM: {json}")
 
         return json["token"]
 

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -49,6 +49,7 @@ TYPE_READ_MEMORY_QVM = "read-memory"
 TYPE_WRITE_MEMORY_QVM = "write-memory"
 TYPE_RESUME = "resume"
 TYPE_QVM_INFO = "qvm-info"
+TYPE_JOB_INFO = "job-info"
 TYPE_JOB_RESULT = "job-result"
 
 
@@ -527,6 +528,12 @@ def qvm_ng_qvm_info_payload(token):
     return {"type": TYPE_QVM_INFO, "qvm-token": token}
 
 
+def qvm_ng_job_info_payload(token):
+    """REST payload for :py:func:`ForestConnection._qvm_ng_job_info`"""
+    validate_job_token(token)
+    return {"type": TYPE_JOB_INFO, "job-token": token}
+
+
 def qvm_ng_job_result_payload(token):
     """REST payload for :py:func:`ForestConnection._qvm_ng_job_result`"""
     validate_job_token(token)
@@ -766,6 +773,15 @@ class ForestConnection:
         Run a Forest ``qvm_info`` job.
         """
         payload = qvm_ng_qvm_info_payload(token)
+        response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
+        return response.json()
+
+    @_record_call
+    def _qvm_ng_job_info(self, token):
+        """
+        Run a Forest ``job_info`` job.
+        """
+        payload = qvm_ng_job_info_payload(token)
         response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
         return response.json()
 

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -14,9 +14,10 @@
 #    limitations under the License.
 ##############################################################################
 
-from enum import Enum
 import re
+import uuid
 import warnings
+from enum import Enum
 from json.decoder import JSONDecodeError
 from typing import Dict, Union, Sequence
 
@@ -24,7 +25,6 @@ import numpy as np
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
-import uuid
 
 from pyquil import Program
 from pyquil.api._config import PyquilConfig

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -14,6 +14,7 @@
 #    limitations under the License.
 ##############################################################################
 
+from enum import Enum
 import re
 import warnings
 from json.decoder import JSONDecodeError
@@ -23,6 +24,7 @@ import numpy as np
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
+import uuid
 
 from pyquil import Program
 from pyquil.api._config import PyquilConfig
@@ -35,6 +37,22 @@ TYPE_EXPECTATION = "expectation"
 TYPE_MULTISHOT = "multishot"
 TYPE_MULTISHOT_MEASURE = "multishot-measure"
 TYPE_WAVEFUNCTION = "wavefunction"
+
+# The following RPC methods are only available in qvm-ng.
+TYPE_RUN_PROGRAM = "run-program"
+TYPE_CREATE_QVM = "create-qvm"
+TYPE_DELETE_QVM = "delete-qvm"
+TYPE_QVM_INFO = "qvm-info"
+
+
+class QVMSimulationMethod(Enum):
+    PURE_STATE = "pure-state"
+    FULL_DENSITY_MATRIX = "full-density-matrix"
+
+
+class QVMAllocationMethod(Enum):
+    NATIVE = "native"
+    FOREIGN = "foreign"
 
 
 def get_json(session, url, params: dict = None):
@@ -145,6 +163,52 @@ def validate_qubit_list(qubit_list):
     if any(not isinstance(i, int) or i < 0 for i in qubit_list):
         raise TypeError("run_items list must contain positive integer values")
     return qubit_list
+
+
+def is_valid_v4_uuid(uuid_string):
+    """
+    Is uuid_string a valid string representation of a v4 UUID?
+
+    :param str uuid_string: The UUID string to check.
+    """
+    try:
+        uid = uuid.UUID(uuid_string)
+    except Exception:
+        return False
+    else:
+        return uid.version == 4
+
+
+def validate_persistent_qvm_token(qvm_token):
+    """
+    Check that qvm_token is a valid persistent QVM token.
+
+    :param str qvm_token: The persistent QVM token string.
+    """
+    if not is_valid_v4_uuid(qvm_token):
+        raise ValueError("qvm_token must be a valid v4 UUID. Got {qvm_token}.")
+
+
+def validate_allocation_method(allocation_method):
+    """
+    Check that allocation_method is a valid QVM allocation method.
+
+    :param QVMAllocationMethod allocation_method: The allocation method.
+    """
+    if not isinstance(allocation_method, QVMAllocationMethod):
+        raise TypeError("allocation_method must be a QVMAllocationMethod. "
+                        f"Got '{allocation_method}'.")
+
+
+def validate_simulation_method(simulation_method):
+    """
+    Check that simulation_method is a valid QVM simulation method.
+
+    :param QVMSimulationMethod simulation_method: The simulation method.
+    """
+    if not isinstance(simulation_method, QVMSimulationMethod):
+        raise TypeError("simulation_method must be a QVMSimulationMethod. "
+                        f"Got '{simulation_method}'.")
 
 
 def prepare_register_list(register_dict: Dict[str, Union[bool, Sequence[int]]]):
@@ -260,9 +324,81 @@ def qvm_run_payload(quil_program, classical_addresses, trials,
     return payload
 
 
+def qvm_ng_run_program_payload(quil_program, qvm_token, simulation_method, allocation_method,
+                               classical_addresses, measurement_noise, gate_noise):
+    """REST payload for :py:func:`ForestConnection._qvm_ng_run_program`"""
+    if not quil_program:
+        raise ValueError("You have attempted to run an empty program."
+                         " Please provide gates or measure instructions to your program.")
+    if not isinstance(quil_program, Program):
+        raise TypeError("quil_program must be a Quil program object")
+    if qvm_token is not None:
+        if (simulation_method is not None or allocation_method is not None
+              or measurement_noise is not None or gate_noise is not None):
+            raise ValueError("Cannot provide both qvm_token and any of the following: "
+                             "simulation_method, allocation_method, measurement_noise, gate_noise")
+        validate_persistent_qvm_token(qvm_token)
+    else:
+        validate_simulation_method(simulation_method)
+        validate_allocation_method(allocation_method)
+
+    classical_addresses = prepare_register_list(classical_addresses)
+    payload = {"type": TYPE_RUN_PROGRAM,
+               "addresses": classical_addresses,
+               "compiled-quil": quil_program.out()}
+
+    if qvm_token is not None:
+        payload["qvm-token"] = qvm_token
+    else:
+        payload["simulation-method"] = simulation_method.value
+        payload["allocation-method"] = allocation_method.value
+
+    if measurement_noise is not None:
+        payload["measurement-noise"] = measurement_noise
+    if gate_noise is not None:
+        payload["gate-noise"] = gate_noise
+
+    return payload
+
+
+def qvm_ng_create_qvm_payload(simulation_method, allocation_method, num_qubits, measurement_noise,
+                              gate_noise):
+    """REST payload for :py:func:`ForestConnection._qvm_ng_create_qvm`"""
+    if not isinstance(num_qubits, integer_types) or num_qubits < 0:
+        raise ValueError("num_qubits must be a positive integer.")
+
+    validate_simulation_method(simulation_method)
+    validate_allocation_method(allocation_method)
+
+    payload = {"type": TYPE_CREATE_QVM,
+               "simulation-method": simulation_method.value,
+               "allocation-method": allocation_method.value,
+               "num-qubits": num_qubits}
+
+    if measurement_noise is not None:
+        payload["measurement-noise"] = measurement_noise
+    if gate_noise is not None:
+        payload["gate-noise"] = gate_noise
+
+    return payload
+
+
+def qvm_ng_delete_qvm_payload(token):
+    """REST payload for :py:func:`ForestConnection._qvm_ng_delete_qvm`"""
+    validate_persistent_qvm_token(token)
+    return {"type": TYPE_DELETE_QVM, "qvm-token": token}
+
+
+def qvm_ng_qvm_info_payload(token):
+    """REST payload for :py:func:`ForestConnection._qvm_ng_qvm_info`"""
+    validate_persistent_qvm_token(token)
+    return {"type": TYPE_QVM_INFO, "qvm-token": token}
+
+
 class ForestConnection:
     @_record_call
-    def __init__(self, sync_endpoint=None, compiler_endpoint=None, forest_cloud_endpoint=None):
+    def __init__(self, sync_endpoint=None, compiler_endpoint=None, forest_cloud_endpoint=None,
+                 qvm_ng_endpoint=None):
         """
         Represents a connection to Forest containing methods to wrap all possible API endpoints.
 
@@ -279,10 +415,13 @@ class ForestConnection:
             compiler_endpoint = pyquil_config.quilc_url
         if forest_cloud_endpoint is None:
             forest_cloud_endpoint = pyquil_config.forest_url
+        if qvm_ng_endpoint is None:
+            qvm_ng_endpoint = pyquil_config.qvm_ng_url
 
         self.sync_endpoint = sync_endpoint
         self.compiler_endpoint = compiler_endpoint
         self.forest_cloud_endpoint = forest_cloud_endpoint
+        self.qvm_ng_endpoint = qvm_ng_endpoint
         self.session = get_session()
 
     @_record_call
@@ -354,6 +493,72 @@ class ForestConnection:
         :return: String of QVM version
         """
         response = post_json(self.session, self.sync_endpoint, {'type': 'version'})
+        split_version_string = response.text.split()
+        try:
+            qvm_version = split_version_string[0]
+        except ValueError:
+            raise TypeError(f'Malformed version string returned by the QVM: {response.text}')
+        return qvm_version
+
+    @_record_call
+    def _qvm_ng_run_program(self, quil_program, qvm_token, simulation_method, allocation_method,
+                            classical_addresses, measurement_noise, gate_noise) -> np.ndarray:
+        """
+        Run a Forest ``run_program`` job on a QVM.
+        """
+        payload = qvm_ng_run_program_payload(quil_program, qvm_token, simulation_method,
+                                             allocation_method, classical_addresses, measurement_noise,
+                                             gate_noise)
+        response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
+        ram = response.json()
+
+        for k in ram.keys():
+            ram[k] = np.array(ram[k])
+
+        return ram
+
+    @_record_call
+    def _qvm_ng_create_qvm(self, simulation_method, allocation_method, num_qubits, measurement_noise,
+                           gate_noise) -> str:
+        """
+        Run a Forest ``create_qvm`` job.
+        """
+        payload = qvm_ng_create_qvm_payload(simulation_method, allocation_method, num_qubits,
+                                            measurement_noise, gate_noise)
+        response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
+        json = response.json()
+
+        if not isinstance(json, dict) or "token" not in json or not is_valid_v4_uuid(json["token"]):
+            raise TypeError(f'Malformed persistent QVM token returned by the QVM: {json}')
+
+        return json["token"]
+
+    @_record_call
+    def _qvm_ng_delete_qvm(self, token) -> bool:
+        """
+        Run a Forest ``delete_qvm`` job.
+        """
+        payload = qvm_ng_delete_qvm_payload(token)
+        response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
+        return response.ok
+
+    @_record_call
+    def _qvm_ng_qvm_info(self, token) -> dict:
+        """
+        Run a Forest ``qvm_info`` job.
+        """
+        payload = qvm_ng_qvm_info_payload(token)
+        response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
+        return response.json()
+
+    @_record_call
+    def _qvm_ng_get_version_info(self) -> dict:
+        """
+        Return version information for the QVM-NG.
+
+        :return: String of QVM version
+        """
+        response = post_json(self.session, self.qvm_ng_endpoint, {'type': 'version'})
         split_version_string = response.text.split()
         try:
             qvm_version = split_version_string[0]

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -51,6 +51,7 @@ TYPE_RESUME = "resume"
 TYPE_QVM_INFO = "qvm-info"
 TYPE_JOB_INFO = "job-info"
 TYPE_JOB_RESULT = "job-result"
+TYPE_DELETE_JOB = "delete-job"
 
 
 class QVMSimulationMethod(Enum):
@@ -540,6 +541,12 @@ def qvm_ng_job_result_payload(token):
     return {"type": TYPE_JOB_RESULT, "job-token": token}
 
 
+def qvm_ng_delete_job_payload(token):
+    """REST payload for :py:func:`ForestConnection._qvm_ng_delete_job`"""
+    validate_job_token(token)
+    return {"type": TYPE_DELETE_JOB, "job-token": token}
+
+
 class ForestConnection:
     @_record_call
     def __init__(self, sync_endpoint=None, compiler_endpoint=None, forest_cloud_endpoint=None,
@@ -794,6 +801,15 @@ class ForestConnection:
         response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
         # TODO(appleby): this might not return JSON
         return response.json()
+
+    @_record_call
+    def _qvm_ng_delete_job(self, token) -> bool:
+        """
+        Run a Forest ``delete_job`` job.
+        """
+        payload = qvm_ng_delete_job_payload(token)
+        response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
+        return response.ok
 
     @_record_call
     def _qvm_ng_get_version_info(self) -> dict:

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -99,11 +99,11 @@ def parse_error(res):
     except JSONDecodeError:
         raise UnknownApiError(res.text)
 
-    if 'error_type' not in body:
+    if "error_type" not in body:
         raise UnknownApiError(str(body))
 
-    error_type = body['error_type']
-    status = body['status']
+    error_type = body["error_type"]
+    status = body["status"]
 
     if re.search(r"[0-9]+ qubits were requested, but the QVM is limited to [0-9]+ qubits.", status):
         return TooManyQubitsError(status)
@@ -122,7 +122,7 @@ def get_session():
     config = PyquilConfig()
     session = requests.Session()
     retry_adapter = HTTPAdapter(max_retries=Retry(total=3,
-                                                  method_whitelist=['POST'],
+                                                  method_whitelist=["POST"],
                                                   status_forcelist=[502, 503, 504, 521, 523],
                                                   backoff_factor=0.2,
                                                   raise_on_status=False))
@@ -136,7 +136,7 @@ def get_session():
                             "X-Api-Key": config.api_key})
 
     session.headers.update({
-        'Content-Type': 'application/json; charset=utf-8'
+        "Content-Type": "application/json; charset=utf-8"
     })
 
     return session
@@ -346,7 +346,7 @@ def run_and_measure_payload(quil_program, qubits, trials, random_seed):
                "compiled-quil": quil_program.out()}
 
     if random_seed is not None:
-        payload['rng-seed'] = random_seed
+        payload["rng-seed"] = random_seed
 
     return payload
 
@@ -356,11 +356,11 @@ def wavefunction_payload(quil_program, random_seed):
     if not isinstance(quil_program, Program):
         raise TypeError("quil_program must be a Quil program object")
 
-    payload = {'type': TYPE_WAVEFUNCTION,
-               'compiled-quil': quil_program.out()}
+    payload = {"type": TYPE_WAVEFUNCTION,
+               "compiled-quil": quil_program.out()}
 
     if random_seed is not None:
-        payload['rng-seed'] = random_seed
+        payload["rng-seed"] = random_seed
 
     return payload
 
@@ -373,12 +373,12 @@ def expectation_payload(prep_prog, operator_programs, random_seed):
     if not isinstance(prep_prog, Program):
         raise TypeError("prep_prog variable must be a Quil program object")
 
-    payload = {'type': TYPE_EXPECTATION,
-               'state-preparation': prep_prog.out(),
-               'operators': [x.out() for x in operator_programs]}
+    payload = {"type": TYPE_EXPECTATION,
+               "state-preparation": prep_prog.out(),
+               "operators": [x.out() for x in operator_programs]}
 
     if random_seed is not None:
-        payload['rng-seed'] = random_seed
+        payload["rng-seed"] = random_seed
 
     return payload
 
@@ -405,7 +405,7 @@ def qvm_run_payload(quil_program, classical_addresses, trials,
     if gate_noise is not None:
         payload["gate-noise"] = gate_noise
     if random_seed is not None:
-        payload['rng-seed'] = random_seed
+        payload["rng-seed"] = random_seed
 
     return payload
 
@@ -444,7 +444,7 @@ def qvm_ng_run_program_payload(quil_program, qvm_token, simulation_method, alloc
     if gate_noise is not None:
         payload["gate-noise"] = gate_noise
     if random_seed is not None:
-        payload['rng-seed'] = random_seed
+        payload["rng-seed"] = random_seed
 
     return payload
 
@@ -658,12 +658,12 @@ class ForestConnection:
 
         :return: String of QVM version
         """
-        response = post_json(self.session, self.sync_endpoint, {'type': 'version'})
+        response = post_json(self.session, self.sync_endpoint, {"type": "version"})
         split_version_string = response.text.split()
         try:
             qvm_version = split_version_string[0]
         except ValueError:
-            raise TypeError(f'Malformed version string returned by the QVM: {response.text}')
+            raise TypeError(f"Malformed version string returned by the QVM: {response.text}")
         return qvm_version
 
     @_record_call
@@ -697,7 +697,7 @@ class ForestConnection:
         response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
         json = response.json()
 
-        if not isinstance(json, dict) or "bytes" not in json or not isinstance(json['bytes'], int):
+        if not isinstance(json, dict) or "bytes" not in json or not isinstance(json["bytes"], int):
             raise TypeError(f"Malformed persistent QVM token returned by the QVM: {json}")
 
         # TODO(appleby): maybe this should return the whole json response object rather than just
@@ -829,10 +829,10 @@ class ForestConnection:
 
         :return: String of QVM version
         """
-        response = post_json(self.session, self.qvm_ng_endpoint, {'type': 'version'})
+        response = post_json(self.session, self.qvm_ng_endpoint, {"type": "version"})
         split_version_string = response.text.split()
         try:
             qvm_version = split_version_string[0]
         except ValueError:
-            raise TypeError(f'Malformed version string returned by the QVM: {response.text}')
+            raise TypeError(f"Malformed version string returned by the QVM: {response.text}")
         return qvm_version

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -277,8 +277,11 @@ def prepare_memory_contents(
         raise TypeError(f"register_dict must be a dict but got {register_dict}")
 
     for reg_name, vs in register_dict.items():
+        if not isinstance(reg_name, str):
+            raise TypeError(f"All register_dict keys must be strings that name a memory region."
+                            f"Got '{reg_name}'.")
         if not isinstance(vs, collections.abc.Iterable) or isinstance(vs, str):
-            raise TypeError(f"Values for register '{reg_name}' must be a non-string Sequence."
+            raise TypeError(f"Values for register '{reg_name}' must be a non-string Iterable."
                             f" Got '{vs}'.")
 
         vlist = list(vs)
@@ -290,15 +293,14 @@ def prepare_memory_contents(
         # Allow the caller to specify an Iterable of dense values, rather than (index, value) pairs.
         if not isinstance(vlist[0], tuple):
             vlist = [(i, v) for i, v in enumerate(vlist)]
-            register_dict[reg_name] = vlist
 
         for i, v in vlist:
             if i < 0:
                 raise TypeError(f"Negative index {i} into classical register {reg_name} is invalid.")
-            if not (isinstance(v, int) or isinstance(v, float) or isinstance(v, complex)):
+            if not isinstance(v, (int, float, complex)):
                 raise TypeError(f"Value for classical register {reg_name}[{i}] must be of type int,"
                                 f" float, or complex. Got '{v}'.")
-
+        register_dict[reg_name] = vlist
     return register_dict
 
 

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -654,12 +654,12 @@ class ForestConnection:
         """
         payload = qvm_ng_run_program_async_payload(qvm_token, quil_program)
         response = post_json(self.session, self.qvm_ng_endpoint + "/", payload)
-        ok = response.json()
+        json = response.json()
 
-        if not isinstance(ok, bool):
-            raise TypeError(f"Malformed run-program-async response returned by the QVM: {ok}")
+        if not isinstance(json, dict) or "token" not in json or not is_valid_v4_uuid(json["token"]):
+            raise TypeError(f"Malformed JOB token returned by the QVM: {json}")
 
-        return ok
+        return json["token"]
 
     @_record_call
     def _qvm_ng_qvm_memory_estimate(self, simulation_method, allocation_method, num_qubits,

--- a/pyquil/api/_config.py
+++ b/pyquil/api/_config.py
@@ -80,6 +80,14 @@ class PyquilConfig(object):
         "default": "http://127.0.0.1:5000"
     }
 
+    QVM_NG_URL = {
+        "env": "QVM_NG_URL",
+        "file": FOREST_CONFIG,
+        "section": "Rigetti Forest",
+        "name": "qvm_ng_address",
+        "default": "http://127.0.0.1:5222"
+    }
+
     QUILC_URL = {
         "env": "QUILC_URL",
         "file": FOREST_CONFIG,
@@ -147,6 +155,10 @@ class PyquilConfig(object):
     @property
     def qvm_url(self):
         return self._env_or_config_or_default(**self.QVM_URL)
+
+    @property
+    def qvm_ng_url(self):
+        return self._env_or_config_or_default(**self.QVM_NG_URL)
 
     @property
     def quilc_url(self):

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -178,7 +178,7 @@ class PersistentQVM:
         :return: A Dict mapping classical memory names to values.
         """
         if not isinstance(quil_program, Program):
-            raise TypeError("quil_program must be a Quil Program. Got {quil_program}.")
+            raise TypeError(f"quil_program must be a Quil Program. Got {quil_program}.")
 
         classical_addresses = get_classical_addresses_from_program(quil_program)
         return self.connection._qvm_ng_run_program(quil_program=quil_program,

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -68,17 +68,17 @@ class PersistentQVM:
         :param random_seed: A seed for the QVM's random number generators. Either None (for an
             automatically generated seed) or a non-negative integer.
         """
+        validate_num_qubits(num_qubits)
         validate_simulation_method(simulation_method)
         validate_allocation_method(allocation_method)
-        validate_num_qubits(num_qubits)
-        validate_noise_probabilities(gate_noise)
         validate_noise_probabilities(measurement_noise)
+        validate_noise_probabilities(gate_noise)
 
+        self.num_qubits = num_qubits
         self.simulation_method = simulation_method
         self.allocation_method = allocation_method
-        self.num_qubits = num_qubits
-        self.gate_noise = gate_noise
         self.measurement_noise = measurement_noise
+        self.gate_noise = gate_noise
 
         if random_seed is None:
             self.random_seed = None

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -38,6 +38,48 @@ def check_qvm_ng_version(version: str):
                                  f'have QVM {version}.')
 
 
+@_record_call
+def get_qvm_memory_estimate(num_qubits: int,
+                            connection: Optional[ForestConnection] = None,
+                            simulation_method: QVMSimulationMethod = QVMSimulationMethod.PURE_STATE,
+                            allocation_method: QVMAllocationMethod = QVMAllocationMethod.NATIVE,
+                            measurement_noise: Optional[List[float]] = None,
+                            gate_noise: Optional[List[float]] = None,) -> int:
+    """
+    Return an estimate of the number of bytes required to store the quantum state of a
+    PersistentQVM.
+
+    :param num_qubits: The maximum number of qubits available to this QVM.
+    :param connection: An optional :py:class:`ForestConnection` object.  If not specified, the
+        default values for URL endpoints will be used, and your API key will be read from
+        ~/.pyquil_config.  If you deign to change any of these parameters, pass your own
+        :py:class:`ForestConnection` object.
+    :param simulation_method: The simulation method to use for this PersistentQVM.  See the enum
+        QVMSimulationmethod for valid values.
+    :param allocation_method: The allocation method to use for this PersistentQVM.  See the enum
+        QVMAllocationmethod for valid values.
+    :param measurement_noise: A list of three numbers [Px, Py, Pz] indicating the probability of an
+        X, Y, or Z gate getting applied before a measurement.  The default value of None indicates
+        no noise.
+    :param gate_noise: A list of three numbers [Px, Py, Pz] indicating the probability of an X, Y,
+        or Z gate getting applied to each qubit after a gate application or reset.  The default
+        value of None indicates no noise.
+
+    :return: the number of bytes
+    """
+    validate_num_qubits(num_qubits)
+    validate_simulation_method(simulation_method)
+    validate_allocation_method(allocation_method)
+    validate_noise_probabilities(measurement_noise)
+    validate_noise_probabilities(gate_noise)
+
+    if connection is None:
+        connection = ForestConnection()
+
+    return connection._qvm_ng_qvm_memory_estimate(simulation_method, allocation_method,
+                                                  num_qubits, measurement_noise, gate_noise)
+
+
 class PersistentQVM:
     """
     Represents a connection to a PersistentQVM.

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -1,0 +1,153 @@
+##############################################################################
+# Copyright 2019 Rigetti Computing
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+##############################################################################
+from typing import Any, Dict, List, Optional
+
+from six import integer_types
+import numpy as np
+
+from pyquil.api._base_connection import (ForestConnection, QVMAllocationMethod, QVMSimulationMethod,
+                                         validate_simulation_method, validate_allocation_method,
+                                         validate_persistent_qvm_token)
+from pyquil.api._error_reporting import _record_call
+from pyquil.api._qvm import QVMNotRunning, QVMVersionMismatch, validate_noise_probabilities
+from pyquil.quil import Program, get_classical_addresses_from_program
+
+
+def check_qvm_ng_version(version: str):
+    """
+    Verify that there is no mismatch between pyquil and QVM versions.
+
+    :param version: The version of the QVM
+    """
+    major, minor, patch = map(int, version.split('.'))
+    if major == 1 and minor < 11:
+        raise QVMVersionMismatch('Must use QVM >= 1.11.0 with the PersistentQVM, but you '
+                                 f'have QVM {version}.')
+
+
+class PersistentQVM:
+    """
+    Represents a connection to a PersistentQVM.
+    """
+    @_record_call
+    def __init__(self, num_qubits: int,
+                 connection: ForestConnection = None,
+                 simulation_method: QVMSimulationMethod = QVMSimulationMethod.PURE_STATE,
+                 allocation_method: QVMAllocationMethod = QVMAllocationMethod.NATIVE,
+                 measurement_noise: Optional[List[float]] = None,
+                 gate_noise: Optional[List[float]] = None,
+                 random_seed: Optional[int] = None) -> None:
+        """
+        A PersistentQVM that classically emulates the execution of Quil programs.
+
+        :param num_qubits: The maximum number of qubits available to this QVM.
+        :param connection: A connection to the Forest web API.
+        :param simulation_method: The simulation method to use for this PersistentQVM.
+            See the enum QVMSimulationmethod for valid values.
+        :param allocation_method: The allocation method to use for this PersistentQVM.
+            See the enum QVMAllocationmethod for valid values.
+        :param measurement_noise: A list of three numbers [Px, Py, Pz] indicating the probability
+            of an X, Y, or Z gate getting applied before a measurement. The default value of
+            None indicates no noise.
+        :param gate_noise: A list of three numbers [Px, Py, Pz] indicating the probability of an X,
+           Y, or Z gate getting applied to each qubit after a gate application or reset. The
+           default value of None indicates no noise.
+        :param random_seed: A seed for the QVM's random number generators. Either None (for an
+            automatically generated seed) or a non-negative integer.
+        """
+        if not isinstance(num_qubits, integer_types) or num_qubits < 0:
+            raise TypeError(f"num_qubits must be a positive integer. Got {num_qubits}.")
+
+        validate_simulation_method(simulation_method)
+        validate_allocation_method(allocation_method)
+        validate_noise_probabilities(gate_noise)
+        validate_noise_probabilities(measurement_noise)
+
+        self.simulation_method = simulation_method
+        self.allocation_method = allocation_method
+        self.num_qubits = num_qubits
+        self.gate_noise = gate_noise
+        self.measurement_noise = measurement_noise
+
+        if random_seed is None:
+            self.random_seed = None
+        elif isinstance(random_seed, integer_types) and random_seed >= 0:
+            self.random_seed = random_seed
+        else:
+            raise TypeError("random_seed should be None or a non-negative int")
+
+        if connection is None:
+            connection = ForestConnection()
+        self.connection = connection
+        self.connect()
+        self.token = self.connection._qvm_ng_create_qvm(simulation_method,
+                                                        allocation_method,
+                                                        num_qubits,
+                                                        measurement_noise,
+                                                        gate_noise)
+
+    def __del__(self) -> None:
+        self.connection._qvm_ng_delete_qvm(self.token)
+
+    def connect(self) -> None:
+        try:
+            version = self.get_version_info()
+            check_qvm_ng_version(version)
+        except ConnectionError:
+            raise QVMNotRunning(f'No QVM-NG server running at {self.connection.qvm_ng_endpoint}')
+
+    @_record_call
+    def get_version_info(self) -> str:
+        """
+        Return version information for the connected QVM.
+
+        :return: String with version information
+        :rtype: str
+        """
+        return self.connection._qvm_ng_get_version_info()
+
+    @_record_call
+    def get_qvm_info(self) -> Dict[str, Any]:
+        """
+        Return configuration information about the PersistentQVM.
+
+        :return: Dict with QVM information
+        :rtype: Dict[str, Any]
+        """
+        return self.connection._qvm_ng_qvm_info(self.token)
+
+    @_record_call
+    def run_program(self, quil_program: Program) -> Dict[str, np.array]:
+        """
+        Run quil_program on this PersistentQVM instance, and return the values stored in all of the
+        classical registers assigned to by the program.
+
+        :param Program quil_program: the Quil program to run.
+
+        :return: A Dict mapping classical memory names to values.
+        :rtype: Dict[str, np.array]
+        """
+        if not isinstance(quil_program, Program):
+            raise TypeError("quil_program must be a Quil Program. Got {quil_program}.")
+
+        classical_addresses = get_classical_addresses_from_program(quil_program)
+        return self.connection._qvm_ng_run_program(quil_program=quil_program,
+                                                   qvm_token=self.token,
+                                                   simulation_method=None,
+                                                   allocation_method=None,
+                                                   classical_addresses=classical_addresses,
+                                                   measurement_noise=None,
+                                                   gate_noise=None)

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -115,7 +115,6 @@ class PersistentQVM:
         Return version information for the connected QVM.
 
         :return: String with version information
-        :rtype: str
         """
         return self.connection._qvm_ng_get_version_info()
 
@@ -125,7 +124,6 @@ class PersistentQVM:
         Return configuration information about the PersistentQVM.
 
         :return: Dict with QVM information
-        :rtype: Dict[str, Any]
         """
         return self.connection._qvm_ng_qvm_info(self.token)
 
@@ -135,10 +133,9 @@ class PersistentQVM:
         Run quil_program on this PersistentQVM instance, and return the values stored in all of the
         classical registers assigned to by the program.
 
-        :param Program quil_program: the Quil program to run.
+        :param quil_program: the Quil program to run.
 
         :return: A Dict mapping classical memory names to values.
-        :rtype: Dict[str, np.array]
         """
         if not isinstance(quil_program, Program):
             raise TypeError("quil_program must be a Quil Program. Got {quil_program}.")

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -178,6 +178,23 @@ class PersistentQVM:
         return self.connection._qvm_ng_read_memory(self.token, classical_addresses)
 
     @_record_call
+    def write_memory(self, memory_contents) -> None:
+        """
+        Write ``memory_contents`` to this PersistentQVM's classical memory registers.
+
+        :param memory_contents: A dictionary specifying the classical memory to overwrite.  The keys
+            are the names of memory regions, and the values are either (1) a sequence of (index,
+            value) pairs such that each value is stored at the corresponding index in the given
+            memory region, or (2) a sequence of values such that the ith item in the sequence will
+            be stored at the ith index of the memory region.  For example, ``memory_contents`` of
+            ``{"theta": [(0, 1.0), (1, 2.3)]}`` indicates that the value ``1.0`` will be written to
+            ``theta[0]`` while the value ``2.3`` is writtent to ``theta[1]``.  Equivalently, the
+            caller may instead pass a ``memory_contents`` of ``{"theta": [1.0, 2.3]}`` to acheive
+            the same result.
+        """
+        self.connection._qvm_ng_write_memory(self.token, memory_contents)
+
+    @_record_call
     def run_program(self, quil_program: Program) -> Dict[str, np.array]:
         """
         Run quil_program on this PersistentQVM instance, and return the values stored in all of the

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -19,8 +19,8 @@ from six import integer_types
 import numpy as np
 
 from pyquil.api._base_connection import (ForestConnection, QVMAllocationMethod, QVMSimulationMethod,
-                                         validate_simulation_method, validate_allocation_method,
-                                         validate_persistent_qvm_token)
+                                         validate_allocation_method, validate_num_qubits,
+                                         validate_persistent_qvm_token, validate_simulation_method)
 from pyquil.api._error_reporting import _record_call
 from pyquil.api._qvm import QVMNotRunning, QVMVersionMismatch, validate_noise_probabilities
 from pyquil.quil import Program, get_classical_addresses_from_program
@@ -68,11 +68,9 @@ class PersistentQVM:
         :param random_seed: A seed for the QVM's random number generators. Either None (for an
             automatically generated seed) or a non-negative integer.
         """
-        if not isinstance(num_qubits, integer_types) or num_qubits < 0:
-            raise TypeError(f"num_qubits must be a positive integer. Got {num_qubits}.")
-
         validate_simulation_method(simulation_method)
         validate_allocation_method(allocation_method)
+        validate_num_qubits(num_qubits)
         validate_noise_probabilities(gate_noise)
         validate_noise_probabilities(measurement_noise)
 

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -168,6 +168,16 @@ class PersistentQVM:
         return self.connection._qvm_ng_qvm_info(self.token)
 
     @_record_call
+    def read_memory(self, classical_addresses) -> Dict[str, np.array]:
+        """
+        Return the contents of this PersistentQVM's classical memory registers.
+
+        :param classical_addresses: A mapping from memory region names to lists of offsets.
+        :return: Dict mapping memory region names to values for the corresponding requested offsets.
+        """
+        return self.connection._qvm_ng_read_memory(self.token, classical_addresses)
+
+    @_record_call
     def run_program(self, quil_program: Program) -> Dict[str, np.array]:
         """
         Run quil_program on this PersistentQVM instance, and return the values stored in all of the

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -44,7 +44,7 @@ class PersistentQVM:
     """
     @_record_call
     def __init__(self, num_qubits: int,
-                 connection: ForestConnection = None,
+                 connection: Optional[ForestConnection] = None,
                  simulation_method: QVMSimulationMethod = QVMSimulationMethod.PURE_STATE,
                  allocation_method: QVMAllocationMethod = QVMAllocationMethod.NATIVE,
                  measurement_noise: Optional[List[float]] = None,

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -195,6 +195,16 @@ class PersistentQVM:
         self.connection._qvm_ng_write_memory(self.token, memory_contents)
 
     @_record_call
+    def resume(self) -> None:
+        """
+        Resume execution of the PersistentQVM.
+
+        The PersistentQVM must be in the WAITING state due to having executed a Quil WAIT
+        instruction.
+        """
+        self.connection._qvm_ng_resume(self.token)
+
+    @_record_call
     def run_program(self, quil_program: Program) -> Dict[str, np.array]:
         """
         Run quil_program on this PersistentQVM instance, and return the values stored in all of the
@@ -215,3 +225,15 @@ class PersistentQVM:
                                                    classical_addresses=classical_addresses,
                                                    measurement_noise=None,
                                                    gate_noise=None)
+
+    @_record_call
+    def run_program_async(self, quil_program: Program) -> None:
+        """
+        Like ``run_program``, but run the program asynchronously, for effect.
+
+        :param quil_program: the Quil program to run.
+        """
+        if not isinstance(quil_program, Program):
+            raise TypeError(f"quil_program must be a Quil Program. Got {quil_program}.")
+
+        self.connection._qvm_ng_run_program_async(self.token, quil_program)

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -316,7 +316,8 @@ class PersistentQVM:
                                                    allocation_method=None,
                                                    classical_addresses=classical_addresses,
                                                    measurement_noise=None,
-                                                   gate_noise=None)
+                                                   gate_noise=None,
+                                                   random_seed=self.random_seed)
 
     @_record_call
     def run_program_async(self, quil_program: Program) -> AsyncJob:
@@ -336,5 +337,6 @@ class PersistentQVM:
                                                  allocation_method=None,
                                                  classical_addresses=classical_addresses,
                                                  measurement_noise=None,
-                                                 gate_noise=None)
+                                                 gate_noise=None,
+                                                 random_seed=self.random_seed)
         return AsyncJob(sub_request, connection=self.connection)

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -235,4 +235,4 @@ class PersistentQVM:
         if not isinstance(quil_program, Program):
             raise TypeError(f"quil_program must be a Quil Program. Got {quil_program}.")
 
-        self.connection._qvm_ng_run_program_async(self.token, quil_program)
+        return self.connection._qvm_ng_run_program_async(self.token, quil_program)

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -19,7 +19,8 @@ import numpy as np
 
 from pyquil.api._base_connection import (ForestConnection, QVMAllocationMethod, QVMSimulationMethod,
                                          validate_allocation_method, validate_num_qubits,
-                                         validate_persistent_qvm_token, validate_simulation_method)
+                                         validate_job_token, validate_persistent_qvm_token,
+                                         validate_simulation_method)
 from pyquil.api._error_reporting import _record_call
 from pyquil.api._qvm import QVMNotRunning, QVMVersionMismatch, validate_noise_probabilities
 from pyquil.quil import Program, get_classical_addresses_from_program
@@ -77,6 +78,27 @@ def get_qvm_memory_estimate(num_qubits: int,
 
     return connection._qvm_ng_qvm_memory_estimate(simulation_method, allocation_method,
                                                   num_qubits, measurement_noise, gate_noise)
+
+
+@_record_call
+def get_job_result(job_token: str, connection: Optional[ForestConnection] = None):
+    """
+    Fetch the result of the async job associated with ``job_token``.
+
+    The return type varies depending on the async job that was run.
+
+    :param job_token: a valid job token returned by ``run_program_async``.
+    :param connection: An optional :py:class:`ForestConnection` object.  If not specified, the
+        default values for URL endpoints will be used, and your API key will be read from
+        ~/.pyquil_config.  If you deign to change any of these parameters, pass your own
+        :py:class:`ForestConnection` object.
+    """
+    validate_job_token(job_token)
+
+    if connection is None:
+        connection = ForestConnection()
+
+    return connection._qvm_ng_job_result(job_token)
 
 
 class PersistentQVM:

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -15,7 +15,6 @@
 ##############################################################################
 from typing import Any, Dict, List, Optional
 
-from six import integer_types
 import numpy as np
 
 from pyquil.api._base_connection import (ForestConnection, QVMAllocationMethod, QVMSimulationMethod,
@@ -124,7 +123,7 @@ class PersistentQVM:
 
         if random_seed is None:
             self.random_seed = None
-        elif isinstance(random_seed, integer_types) and random_seed >= 0:
+        elif isinstance(random_seed, int) and random_seed >= 0:
             self.random_seed = random_seed
         else:
             raise TypeError("random_seed should be None or a non-negative int")

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -34,10 +34,10 @@ def check_qvm_ng_version(version: str):
 
     :param version: The version of the QVM
     """
-    major, minor, patch = map(int, version.split('.'))
+    major, minor, patch = map(int, version.split("."))
     if major == 1 and minor < 11:
-        raise QVMVersionMismatch('Must use QVM >= 1.11.0 with the PersistentQVM, but you '
-                                 f'have QVM {version}.')
+        raise QVMVersionMismatch("Must use QVM >= 1.11.0 with the PersistentQVM, but you "
+                                 f"have QVM {version}.")
 
 
 @_record_call
@@ -103,7 +103,7 @@ class AsyncJob:
     def __del__(self) -> None:
         self.close()
 
-    def __enter__(self) -> 'AsyncJob':
+    def __enter__(self) -> "AsyncJob":
         return self
 
     def __exit__(self,
@@ -118,7 +118,7 @@ class AsyncJob:
             version = self.get_version_info()
             check_qvm_ng_version(version)
         except ConnectionError:
-            raise QVMNotRunning(f'No QVM-NG server running at {self.connection.qvm_ng_endpoint}')
+            raise QVMNotRunning(f"No QVM-NG server running at {self.connection.qvm_ng_endpoint}")
 
     def close(self) -> None:
         if self.connection is not None:
@@ -219,7 +219,7 @@ class PersistentQVM:
     def __del__(self) -> None:
         self.close()
 
-    def __enter__(self) -> 'PersistentQVM':
+    def __enter__(self) -> "PersistentQVM":
         return self
 
     def __exit__(self,
@@ -234,7 +234,7 @@ class PersistentQVM:
             version = self.get_version_info()
             check_qvm_ng_version(version)
         except ConnectionError:
-            raise QVMNotRunning(f'No QVM-NG server running at {self.connection.qvm_ng_endpoint}')
+            raise QVMNotRunning(f"No QVM-NG server running at {self.connection.qvm_ng_endpoint}")
 
     def close(self) -> None:
         if self.connection is not None:

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -226,13 +226,20 @@ class PersistentQVM:
                                                    gate_noise=None)
 
     @_record_call
-    def run_program_async(self, quil_program: Program) -> None:
+    def run_program_async(self, quil_program: Program) -> str:
         """
-        Like ``run_program``, but run the program asynchronously, for effect.
+        Like ``run_program``, but run the program asynchronously.
 
         :param quil_program: the Quil program to run.
         """
         if not isinstance(quil_program, Program):
             raise TypeError(f"quil_program must be a Quil Program. Got {quil_program}.")
 
-        return self.connection._qvm_ng_run_program_async(self.token, quil_program)
+        classical_addresses = get_classical_addresses_from_program(quil_program)
+        return self.connection._qvm_ng_run_program_async(quil_program=quil_program,
+                                                         qvm_token=self.token,
+                                                         simulation_method=None,
+                                                         allocation_method=None,
+                                                         classical_addresses=classical_addresses,
+                                                         measurement_noise=None,
+                                                         gate_noise=None)

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -13,7 +13,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-from typing import Any, Dict, List, Optional
+from types import TracebackType
+from typing import Any, Dict, List, Optional, Type
 
 import numpy as np
 
@@ -101,6 +102,16 @@ class AsyncJob:
 
     def __del__(self) -> None:
         self.close()
+
+    def __enter__(self) -> 'AsyncJob':
+        return self
+
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc_value: Optional[BaseException],
+                 traceback: Optional[TracebackType]) -> bool:
+        self.close()
+        return False
 
     def connect(self) -> None:
         try:
@@ -207,6 +218,16 @@ class PersistentQVM:
 
     def __del__(self) -> None:
         self.close()
+
+    def __enter__(self) -> 'PersistentQVM':
+        return self
+
+    def __exit__(self,
+                 exc_type: Optional[Type[BaseException]],
+                 exc_value: Optional[BaseException],
+                 traceback: Optional[TracebackType]) -> bool:
+        self.close()
+        return False
 
     def connect(self) -> None:
         try:

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -81,6 +81,26 @@ def get_qvm_memory_estimate(num_qubits: int,
 
 
 @_record_call
+def get_job_info(job_token: str, connection: Optional[ForestConnection] = None) -> Dict[str, Any]:
+    """
+    Fetch the status of the async job associated with ``job_token``.
+
+    :param job_token: a valid job token returned by ``run_program_async``.
+    :param connection: An optional :py:class:`ForestConnection` object.  If not specified, the
+        default values for URL endpoints will be used, and your API key will be read from
+        ~/.pyquil_config.  If you deign to change any of these parameters, pass your own
+        :py:class:`ForestConnection` object.
+    :return: a dict with the async job's status info
+    """
+    validate_job_token(job_token)
+
+    if connection is None:
+        connection = ForestConnection()
+
+    return connection._qvm_ng_job_info(job_token)
+
+
+@_record_call
 def get_job_result(job_token: str, connection: Optional[ForestConnection] = None):
     """
     Fetch the result of the async job associated with ``job_token``.

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -20,15 +20,15 @@ import numpy as np
 
 from pyquil.api._base_connection import (ForestConnection, QVMAllocationMethod, QVMSimulationMethod,
                                          validate_allocation_method, validate_num_qubits,
-                                         validate_job_sub_request, validate_job_token,
-                                         validate_persistent_qvm_token, validate_simulation_method,
-                                         qvm_ng_run_program_payload)
+                                         validate_noise_probabilities, validate_job_sub_request,
+                                         validate_job_token, validate_persistent_qvm_token,
+                                         validate_simulation_method, qvm_ng_run_program_payload)
 from pyquil.api._error_reporting import _record_call
-from pyquil.api._qvm import QVMNotRunning, QVMVersionMismatch, validate_noise_probabilities
+from pyquil.api._qvm import QVMNotRunning, QVMVersionMismatch
 from pyquil.quil import Program, get_classical_addresses_from_program
 
 
-def check_qvm_ng_version(version: str):
+def check_qvm_ng_version(version: str) -> None:
     """
     Verify that there is no mismatch between pyquil and QVM versions.
 
@@ -106,12 +106,19 @@ class AsyncJob:
     def __enter__(self) -> "AsyncJob":
         return self
 
+    # If the return type annotation here is changed to bool, mypy complains:
+    #
+    #     "bool" is invalid as return type for "__exit__" that always returns False. Use
+    #     "typing_extensions.Literal[False]" as the return type or change it to "None". If return
+    #     type of "__exit__" implies that it may return True, the context manager may swallow
+    #     exceptions
+    #
+    # Use None for now to placate mypy and avoid a dependency on typing_extensions.
     def __exit__(self,
                  exc_type: Optional[Type[BaseException]],
                  exc_value: Optional[BaseException],
-                 traceback: Optional[TracebackType]) -> bool:
+                 traceback: Optional[TracebackType]) -> None:
         self.close()
-        return False
 
     def connect(self) -> None:
         try:
@@ -222,12 +229,19 @@ class PersistentQVM:
     def __enter__(self) -> "PersistentQVM":
         return self
 
+    # If the return type annotation here is changed to bool, mypy complains:
+    #
+    #     "bool" is invalid as return type for "__exit__" that always returns False. Use
+    #     "typing_extensions.Literal[False]" as the return type or change it to "None". If return
+    #     type of "__exit__" implies that it may return True, the context manager may swallow
+    #     exceptions
+    #
+    # Use None for now to placate mypy and avoid a dependency on typing_extensions.
     def __exit__(self,
                  exc_type: Optional[Type[BaseException]],
                  exc_value: Optional[BaseException],
-                 traceback: Optional[TracebackType]) -> bool:
+                 traceback: Optional[TracebackType]) -> None:
         self.close()
-        return False
 
     def connect(self) -> None:
         try:

--- a/pyquil/api/_persistent_qvm.py
+++ b/pyquil/api/_persistent_qvm.py
@@ -121,6 +121,26 @@ def get_job_result(job_token: str, connection: Optional[ForestConnection] = None
     return connection._qvm_ng_job_result(job_token)
 
 
+@_record_call
+def delete_job(job_token: str, connection: Optional[ForestConnection] = None) -> bool:
+    """
+    Delete the async job associated with ``job_token``.
+
+    :param job_token: a valid job token returned by ``run_program_async``.
+    :param connection: An optional :py:class:`ForestConnection` object.  If not specified, the
+        default values for URL endpoints will be used, and your API key will be read from
+        ~/.pyquil_config.  If you deign to change any of these parameters, pass your own
+        :py:class:`ForestConnection` object.
+    :return: True on success
+    """
+    validate_job_token(job_token)
+
+    if connection is None:
+        connection = ForestConnection()
+
+    return connection._qvm_ng_delete_job(job_token)
+
+
 class PersistentQVM:
     """
     Represents a connection to a PersistentQVM.

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -234,12 +234,27 @@ def test_validate_noise_probabilities():
     with pytest.raises(ValueError):
         validate_noise_probabilities([-0.5, -0.5, -0.5])
 
+    validate_noise_probabilities([0.0, 0.0, 0.0])
+    validate_noise_probabilities([1.0, 0.0, 0.0])
+    validate_noise_probabilities([0.0, 1.0, 0.0])
+    validate_noise_probabilities([0.0, 0.0, 1.0])
+    validate_noise_probabilities([0.1, 0.1, 0.1])
+    validate_noise_probabilities([0.25, 0.25, 0.5])
+
 
 def test_validate_qubit_list():
     with pytest.raises(TypeError):
         validate_qubit_list([-1, 1])
     with pytest.raises(TypeError):
         validate_qubit_list(['a', 0], 1)
+
+    validate_qubit_list([0])
+    validate_qubit_list([0, 1])
+    validate_qubit_list([1, 1])
+    validate_qubit_list([2, 10])
+    validate_qubit_list(range(1))
+    validate_qubit_list(range(2))
+    validate_qubit_list(range(10))
 
 
 def test_prepare_register_list():

--- a/pyquil/tests/test_persistent_qvm.py
+++ b/pyquil/tests/test_persistent_qvm.py
@@ -1,4 +1,7 @@
+from typing import Dict
+
 import pytest
+import numpy as np
 
 from pyquil import Program
 from pyquil.api import (ForestConnection, PersistentQVM, QVMSimulationMethod, QVMAllocationMethod,
@@ -6,6 +9,24 @@ from pyquil.api import (ForestConnection, PersistentQVM, QVMSimulationMethod, QV
 from pyquil.api._errors import QVMError
 from pyquil.gates import MEASURE, X
 from pyquil.tests.utils import is_qvm_version_string
+
+
+MemoryContentsDict = Dict[str, np.array]
+
+
+def _check_mem_equal(a: MemoryContentsDict, b: MemoryContentsDict) -> None:
+    """Assert that the MemoryContentsDicts a and b are equal
+
+    A MemoryContentsDict is a mapping where the keys are ``str`` and the values are ``np.array``s.
+    A MemoryContentsDict corresponds to the data structure returned by ``PersistentQVM.run_program``
+    and ``PersistentQVM.read_memory``.
+
+    :param a: a dict of memory contents
+    :param b: a dict of memory contents
+    """
+    assert a.keys() == b.keys()
+    for k in a:
+        assert np.array_equal(a[k], b[k])
 
 
 def test_pqvm_version(forest_app_ng: ForestConnection):
@@ -78,14 +99,14 @@ def test_pqvm_create_and_info(forest_app_ng: ForestConnection):
 
 def test_pqvm_read_memory(forest_app_ng: ForestConnection):
     pqvm = PersistentQVM(num_qubits=2, connection=forest_app_ng)
-    assert pqvm.read_memory({}) == {}
+    _check_mem_equal(pqvm.read_memory({}), {})
 
     # No classical memory has been configured yet.
     with pytest.raises(QVMError):
         pqvm.read_memory({"ro": True})
 
     pqvm.run_program(Program("DECLARE ro BIT"))
-    assert pqvm.read_memory({"ro": True}) == {"ro": [0]}
+    _check_mem_equal(pqvm.read_memory({"ro": True}), {"ro": [[0]]})
 
     # The ro register exists, but nothing else.
     with pytest.raises(QVMError):
@@ -93,7 +114,65 @@ def test_pqvm_read_memory(forest_app_ng: ForestConnection):
 
     # Request memory at a specific offset.
     pqvm.run_program(Program("DECLARE byte BIT[8]\nX 0\nMEASURE 0 byte[4]"))
-    assert pqvm.read_memory({"byte": [4]}) == {"byte": [1]}
+    _check_mem_equal(pqvm.read_memory({"byte": [4]}), {"byte": [[1]]})
+
+
+def test_write_memory(forest_app_ng: ForestConnection):
+    pqvm = PersistentQVM(num_qubits=2, connection=forest_app_ng)
+    p = Program()
+    p.declare("ro", "BIT", 2)
+    p.declare("theta", "REAL", 4)
+    pqvm.run_program(p)
+
+    with pytest.raises(TypeError):
+        pqvm.write_memory("ro")
+
+    with pytest.raises(TypeError):
+        pqvm.write_memory(("ro", 2))
+
+    with pytest.raises(TypeError):
+        pqvm.write_memory({"ro": 1})
+
+    with pytest.raises(TypeError):
+        pqvm.write_memory({"ro": "2"})
+
+    with pytest.raises(TypeError):
+        pqvm.write_memory({"ro": object()})
+
+    with pytest.raises(TypeError):
+        # str is invalid value type
+        pqvm.write_memory({"ro": [(1, "hey")]})
+
+    with pytest.raises(TypeError):
+        # index cannot be negative
+        pqvm.write_memory({"ro": [(-1, 1)]})
+
+    with pytest.raises(ValueError):
+        # empty values not allowed
+        pqvm.write_memory({"ro": []})
+
+    with pytest.raises(ValueError):
+        # value must be 2-tuple
+        pqvm.write_memory({"ro": [(1, 2, 3)]})
+
+    _check_mem_equal(pqvm.read_memory({"ro": True}), {"ro": [[0, 0]]})
+    _check_mem_equal(pqvm.read_memory({"theta": True}), {"theta": [[0.0, 0.0, 0.0, 0.0]]})
+
+    # sparse (index, value) encoding
+    pqvm.write_memory({"ro": [(1, 1)]})
+    _check_mem_equal(pqvm.read_memory({"ro": True}), {"ro": [[0, 1]]})
+
+    # range
+    pqvm.write_memory({"ro": reversed(range(2))})
+    _check_mem_equal(pqvm.read_memory({"ro": True}), {"ro": [[1, 0]]})
+
+    # numpy array
+    pqvm.write_memory({"theta": np.arange(0.0, 4.0, 1.0)})
+    _check_mem_equal(pqvm.read_memory({"theta": True}), {"theta": [[0.0, 1.0, 2.0, 3.0]]})
+
+    # tuple of values
+    pqvm.write_memory({"theta": (4.1, 3.1, 2.1, 1.1)})
+    _check_mem_equal(pqvm.read_memory({"theta": True}), {"theta": [[4.1, 3.1, 2.1, 1.1]]})
 
 
 def test_pqvm_run_program(forest_app_ng: ForestConnection):
@@ -108,7 +187,7 @@ def test_pqvm_run_program(forest_app_ng: ForestConnection):
                                  simulation_method=simulation_method,
                                  allocation_method=allocation_method)
             mem = pqvm.run_program(p)
-            assert mem == {'ro': [[1]]}
+            _check_mem_equal(mem, {'ro': [[1]]})
 
 
 def test_pqvm_run_program_with_pauli_noise(forest_app_ng: ForestConnection):
@@ -126,4 +205,4 @@ def test_pqvm_run_program_with_pauli_noise(forest_app_ng: ForestConnection):
                          measurement_noise=[1.0, 0.0, 0.0],
                          gate_noise=[1.0, 0.0, 0.0])
     mem = pqvm.run_program(p)
-    assert mem == {'ro': [[1]]}
+    _check_mem_equal(mem, {'ro': [[1]]})

--- a/pyquil/tests/test_persistent_qvm.py
+++ b/pyquil/tests/test_persistent_qvm.py
@@ -1,0 +1,75 @@
+import pytest
+
+from pyquil import Program
+from pyquil.api import ForestConnection, PersistentQVM, QVMSimulationMethod, QVMAllocationMethod
+from pyquil.gates import MEASURE, X
+from pyquil.tests.utils import is_qvm_version_string
+
+
+def test_pqvm_version(forest_app_ng: ForestConnection):
+    pqvm = PersistentQVM(num_qubits=0, connection=forest_app_ng)
+    version = pqvm.get_version_info()
+    assert is_qvm_version_string(version)
+
+
+def test_pqvm_create_and_info(forest_app_ng: ForestConnection):
+    pqvm = PersistentQVM(num_qubits=0, connection=forest_app_ng)
+    info = pqvm.get_qvm_info()
+    assert info['qvm-type'] == 'PURE-STATE-QVM'
+    assert info['num-qubits'] == 0
+    assert info['metadata']['allocation-method'] == 'NATIVE'
+
+    pqvm = PersistentQVM(num_qubits=1, connection=forest_app_ng,
+                         allocation_method=QVMAllocationMethod.FOREIGN)
+    info = pqvm.get_qvm_info()
+    assert info['qvm-type'] == 'PURE-STATE-QVM'
+    assert info['num-qubits'] == 1
+    assert info['metadata']['allocation-method'] == 'FOREIGN'
+
+    pqvm = PersistentQVM(num_qubits=2, connection=forest_app_ng,
+                         simulation_method=QVMSimulationMethod.FULL_DENSITY_MATRIX)
+    info = pqvm.get_qvm_info()
+    assert info['qvm-type'] == 'DENSITY-QVM'
+    assert info['num-qubits'] == 2
+    assert info['metadata']['allocation-method'] == 'NATIVE'
+
+    pqvm = PersistentQVM(num_qubits=3, connection=forest_app_ng,
+                         simulation_method=QVMSimulationMethod.FULL_DENSITY_MATRIX,
+                         allocation_method=QVMAllocationMethod.FOREIGN)
+    info = pqvm.get_qvm_info()
+    assert info['qvm-type'] == 'DENSITY-QVM'
+    assert info['num-qubits'] == 3
+    assert info['metadata']['allocation-method'] == 'FOREIGN'
+
+
+def test_pqvm_run_program(forest_app_ng: ForestConnection):
+    p = Program()
+    p.declare('ro')
+    p += X(0)
+    p += MEASURE(0, "ro")
+
+    for simulation_method in QVMSimulationMethod:
+        for allocation_method in QVMAllocationMethod:
+            pqvm = PersistentQVM(num_qubits=2, connection=forest_app_ng,
+                                 simulation_method=simulation_method,
+                                 allocation_method=allocation_method)
+            mem = pqvm.run_program(p)
+            assert mem == {'ro': [[1]]}
+
+
+def test_pqvm_run_program_with_pauli_noise(forest_app_ng: ForestConnection):
+    p = Program()
+    p.declare('ro')
+    p += X(0)
+    p += MEASURE(0, "ro")
+
+    pqvm = PersistentQVM(num_qubits=2, connection=forest_app_ng,
+                         measurement_noise=[1.0, 0.0, 0.0])
+    mem = pqvm.run_program(p)
+    assert mem == {'ro': [[0]]}
+
+    pqvm = PersistentQVM(num_qubits=2, connection=forest_app_ng,
+                         measurement_noise=[1.0, 0.0, 0.0],
+                         gate_noise=[1.0, 0.0, 0.0])
+    mem = pqvm.run_program(p)
+    assert mem == {'ro': [[1]]}

--- a/pyquil/tests/test_persistent_qvm.py
+++ b/pyquil/tests/test_persistent_qvm.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from pyquil import Program
 from pyquil.api import (ForestConnection, PersistentQVM, QVMSimulationMethod, QVMAllocationMethod,
-                        get_job_info, get_job_result, get_qvm_memory_estimate)
+                        delete_job, get_job_info, get_job_result, get_qvm_memory_estimate)
 from pyquil.api._errors import QVMError
 from pyquil.gates import MEASURE, RX, WAIT, X
 from pyquil.tests.utils import is_qvm_version_string
@@ -203,6 +203,7 @@ def test_wait_resume(forest_app_ng: ForestConnection):
     _wait_for_pqvm(pqvm, "READY")
     result = get_job_result(job_token)
     assert result == {}
+    delete_job(job_token)
 
     # It's an error to call resume on pqvm that's not in the WAITING state
     with pytest.raises(QVMError):
@@ -223,6 +224,7 @@ def test_wait_resume(forest_app_ng: ForestConnection):
     _wait_for_pqvm(pqvm, "READY")
     _check_mem_equal(pqvm.read_memory({"ro": True}), {"ro": [[1]]})
     _check_mem_equal(get_job_result(job_token), {"ro": [[1]]})
+    delete_job(job_token)
 
 
 def test_pqvm_run_program(forest_app_ng: ForestConnection):
@@ -265,3 +267,4 @@ def test_job_info(forest_app_ng: ForestConnection):
     _wait_for_job(job_token, "RUNNING")
     pqvm.resume()
     _wait_for_job(job_token, "FINISHED")
+    delete_job(job_token)

--- a/pyquil/tests/test_persistent_qvm.py
+++ b/pyquil/tests/test_persistent_qvm.py
@@ -89,31 +89,31 @@ def test_qvm_memory_estimate(forest_app_ng: ForestConnection):
 def test_pqvm_create_and_info(forest_app_ng: ForestConnection):
     with PersistentQVM(num_qubits=0, connection=forest_app_ng) as pqvm:
         info = pqvm.get_qvm_info()
-        assert info['qvm-type'] == 'PURE-STATE-QVM'
-        assert info['num-qubits'] == 0
-        assert info['metadata']['allocation-method'] == 'NATIVE'
+        assert info["qvm-type"] == "PURE-STATE-QVM"
+        assert info["num-qubits"] == 0
+        assert info["metadata"]["allocation-method"] == "NATIVE"
 
     with PersistentQVM(num_qubits=1, connection=forest_app_ng,
                        allocation_method=QVMAllocationMethod.FOREIGN) as pqvm:
         info = pqvm.get_qvm_info()
-        assert info['qvm-type'] == 'PURE-STATE-QVM'
-        assert info['num-qubits'] == 1
-        assert info['metadata']['allocation-method'] == 'FOREIGN'
+        assert info["qvm-type"] == "PURE-STATE-QVM"
+        assert info["num-qubits"] == 1
+        assert info["metadata"]["allocation-method"] == "FOREIGN"
 
     with PersistentQVM(num_qubits=2, connection=forest_app_ng,
                        simulation_method=QVMSimulationMethod.FULL_DENSITY_MATRIX) as pqvm:
         info = pqvm.get_qvm_info()
-        assert info['qvm-type'] == 'DENSITY-QVM'
-        assert info['num-qubits'] == 2
-        assert info['metadata']['allocation-method'] == 'NATIVE'
+        assert info["qvm-type"] == "DENSITY-QVM"
+        assert info["num-qubits"] == 2
+        assert info["metadata"]["allocation-method"] == "NATIVE"
 
     with PersistentQVM(num_qubits=3, connection=forest_app_ng,
                        simulation_method=QVMSimulationMethod.FULL_DENSITY_MATRIX,
                        allocation_method=QVMAllocationMethod.FOREIGN) as pqvm:
         info = pqvm.get_qvm_info()
-        assert info['qvm-type'] == 'DENSITY-QVM'
-        assert info['num-qubits'] == 3
-        assert info['metadata']['allocation-method'] == 'FOREIGN'
+        assert info["qvm-type"] == "DENSITY-QVM"
+        assert info["num-qubits"] == 3
+        assert info["metadata"]["allocation-method"] == "FOREIGN"
 
 
 def test_pqvm_read_memory(forest_app_ng: ForestConnection):
@@ -226,7 +226,7 @@ def test_wait_resume(forest_app_ng: ForestConnection):
 
 def test_pqvm_run_program(forest_app_ng: ForestConnection):
     p = Program()
-    p.declare('ro')
+    p.declare("ro")
     p += X(0)
     p += MEASURE(0, "ro")
 
@@ -236,26 +236,26 @@ def test_pqvm_run_program(forest_app_ng: ForestConnection):
                                  simulation_method=simulation_method,
                                  allocation_method=allocation_method)
             mem = pqvm.run_program(p)
-            _check_mem_equal(mem, {'ro': [[1]]})
+            _check_mem_equal(mem, {"ro": [[1]]})
             pqvm.close()
 
 
 def test_pqvm_run_program_with_pauli_noise(forest_app_ng: ForestConnection):
     p = Program()
-    p.declare('ro')
+    p.declare("ro")
     p += X(0)
     p += MEASURE(0, "ro")
 
     with PersistentQVM(num_qubits=2, connection=forest_app_ng,
                        measurement_noise=[1.0, 0.0, 0.0]) as pqvm:
         mem = pqvm.run_program(p)
-        assert mem == {'ro': [[0]]}
+        assert mem == {"ro": [[0]]}
 
     with PersistentQVM(num_qubits=2, connection=forest_app_ng,
                        measurement_noise=[1.0, 0.0, 0.0],
                        gate_noise=[1.0, 0.0, 0.0]) as pqvm:
         mem = pqvm.run_program(p)
-        _check_mem_equal(mem, {'ro': [[1]]})
+        _check_mem_equal(mem, {"ro": [[1]]})
 
 
 def test_job_info(forest_app_ng: ForestConnection):
@@ -272,7 +272,7 @@ def test_random_seed(forest_app_ng: ForestConnection):
         PersistentQVM(num_qubits=2, connection=forest_app_ng, random_seed=1.0)
 
     p = Program()
-    ro = p.declare('ro', 'BIT', 1)
+    ro = p.declare("ro", "BIT", 1)
     p += H(0)
     p += MEASURE(0, ro)
 
@@ -280,13 +280,13 @@ def test_random_seed(forest_app_ng: ForestConnection):
     # always get the same result, due to the fixed random_seed.
     with PersistentQVM(num_qubits=1, connection=forest_app_ng, random_seed=0) as pqvm:
         assert pqvm.random_seed == 0
-        first = pqvm.run_program(p)['ro'][0][0]
-        assert all(first == pqvm.run_program(p)['ro'][0][0] for _ in range(10))
+        first = pqvm.run_program(p)["ro"][0][0]
+        assert all(first == pqvm.run_program(p)["ro"][0][0] for _ in range(10))
 
     # now check that random_seed=None produces at least one different result.
     with PersistentQVM(num_qubits=1, connection=forest_app_ng) as pqvm:
         assert pqvm.random_seed is None
-        first = pqvm.run_program(p)['ro'][0][0]
+        first = pqvm.run_program(p)["ro"][0][0]
         # Increase the number of iterations to 20 for this test, so that you need to be
         # astronomically unlucky to get a spurious failure here.
-        assert any(first != pqvm.run_program(p)['ro'][0][0] for _ in range(20))
+        assert any(first != pqvm.run_program(p)["ro"][0][0] for _ in range(20))

--- a/pyquil/tests/test_qvm.py
+++ b/pyquil/tests/test_qvm.py
@@ -10,6 +10,7 @@ from pyquil.api._compiler import _extract_program_from_pyquil_executable_respons
 from pyquil.device import NxDevice
 from pyquil.gates import MEASURE, X, CNOT, H
 from pyquil.quilbase import Declare, MemoryReference
+from pyquil.tests.utils import is_qvm_version_string
 
 
 def test_qvm_run_pqer(forest: ForestConnection):
@@ -77,13 +78,4 @@ def test_roundtrip_pyquilexecutableresponse(compiler):
 def test_qvm_version(forest: ForestConnection):
     qvm = QVM(connection=forest)
     version = qvm.get_version_info()
-
-    def is_a_version_string(version_string: str):
-        parts = version_string.split('.')
-        try:
-            map(int, parts)
-        except ValueError:
-            return False
-        return True
-
-    assert is_a_version_string(version)
+    assert is_qvm_version_string(version)

--- a/pyquil/tests/utils.py
+++ b/pyquil/tests/utils.py
@@ -9,6 +9,15 @@ def parse_equals(quil_string, *instructions):
     assert expected == actual
 
 
+def is_qvm_version_string(version_string: str):
+    parts = version_string.split('.')
+    try:
+        map(int, parts)
+    except ValueError:
+        return False
+    return True
+
+
 class DummyCompiler(AbstractCompiler):
     def get_version_info(self):
         return {}

--- a/pyquil/tests/utils.py
+++ b/pyquil/tests/utils.py
@@ -9,7 +9,7 @@ def parse_equals(quil_string, *instructions):
     assert expected == actual
 
 
-def is_qvm_version_string(version_string: str):
+def is_qvm_version_string(version_string: str) -> bool:
     parts = version_string.split('.')
     try:
         map(int, parts)


### PR DESCRIPTION
Description
-----------

This commit includes `ForestConnection` methods to call the new create-qvm, delete-qvm, qvm-info, and run-program qvm-ng endpoints.

It also includes a `PersistentQVM` class for wrapping those new `ForestConnection` methods.

Additionally, add a separate `forest_qvm_ng` pytest fixture for qvm-ng-only tests. This is not yet hooked in to the CI runners and expects you to have a qvm-ng process running on localhost:5222 or else the tests will be skipped.

This is still a WIP, but I'd love suggestions from the wizend old pyQuil elders about where/how the new app-ng and persistent QVM should fit into pyQuil, hence I'm opening a draft PR to solicit feedback. For now, it's convenient to have a single class that wraps access to qvm-ng, but eventually we might want to split things along similar lines to the existing QVM-as-a-QAM and WavefunctionSimulator classes. Or maybe not. The current naming is also not ideal since PersistentQVM makes it sound like a subtype of the QVM class, which it is not. Likewise with QVM_NG or whatever else came readily to mind.

I'm also open to suggestions about how to eventually land these changes in pyQuil. Do we prefer to wait until app-ng is full-featured enough to outright replace the existing QVM API in one fell swoop, or would we rather merge it in stages (without breaking backwards compat, obviously).

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
