### PR TITLE
Mark and skip particularly slow unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ Changelog
 
 ### Improvements and Changes
 
--   Certaint tests have been marked as "slow", and are skipped unless
-    `--runslow` is specified. (@kilimanjaro, gh-1001)
+-   Certain tests have been marked as "slow", and are skipped unless
+    the `--runslow` option is specified for `pytest` (@kilimanjaro, gh-1001).
 -   The `local_qvm` context manager has been renamed to `local_forest_runtime`,
     which now checks if the designated ports are used before starting `qvm`/`quilc`.
     The original `local_qvm` has been deprecated (@sauercrowd, gh-976).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changelog
 ### Improvements and Changes
 
 -   Certaint tests have been marked as "slow", and are skipped unless
-    `--include-slow-tests` is specified. (@kilimanjaro, gh-1001)
+    `--runslow` is specified. (@kilimanjaro, gh-1001)
 -   The `local_qvm` context manager has been renamed to `local_forest_runtime`,
     which now checks if the designated ports are used before starting `qvm`/`quilc`.
     The original `local_qvm` has been deprecated (@sauercrowd, gh-976).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ Changelog
 
 ### Improvements and Changes
 
--   Certain tests have been marked as "slow", and are skipped unless
-    the `--runslow` option is specified for `pytest` (@kilimanjaro, gh-1001).
 -   The `local_qvm` context manager has been renamed to `local_forest_runtime`,
     which now checks if the designated ports are used before starting `qvm`/`quilc`.
     The original `local_qvm` has been deprecated (@sauercrowd, gh-976).
@@ -29,6 +27,8 @@ Changelog
 -   Support non-gate instructions (e.g. `MEASURE`) in `to_latex()` (@notmgsk, gh-975).
 -   Test suite has been updated to reduce the use of deprecated features
     (@kilimanjaro, gh-998).
+-   Certain tests have been marked as "slow", and are skipped unless
+    the `--runslow` option is specified for `pytest` (@kilimanjaro, gh-1001).
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Changelog
 
 ### Improvements and Changes
 
+-   Certaint tests have been marked as "slow", and are skipped unless
+    `--include-slow-tests` is specified. (@kilimanjaro, gh-1001)
 -   The `local_qvm` context manager has been renamed to `local_forest_runtime`,
     which now checks if the designated ports are used before starting `qvm`/`quilc`.
     The original `local_qvm` has been deprecated (@sauercrowd, gh-976).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,8 +111,8 @@ full unit test suite will start!
 
 **NOTE**: Some tests (particularly those related to operator estimation and readout
 symmetrization) require a nontrivial amount of computation. For this reason, they have been marked 
-as slow and are not run by default unless pytest is given the `--runslow` option. For a 
-full, up-to-date list of these tests, you may invoke (from the base pyquil directory)
+as slow and are not run by default unless `pytest` is given the `--runslow` option. For a 
+full, up-to-date list of these tests, you may invoke (from the top-level directory):
 
 ```bash
 grep -A 1 -r pytest.mark.slow  pyquil/tests/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,12 +106,12 @@ We use `pytest` to run the pyQuil unit tests. These are run automatically on Pyt
 3.7 as part of the CI pipeline. But, you can run them yourself locally as well. Some of the
 tests depend on having running QVM and quilc servers, and otherwise will be skipped. Thus,
 to run the tests, you should begin by spinning up these servers via `qvm -S` and `quilc -S`,
-respectively. Once this is done, run `pytest** in the top-level directory of pyQuil, and the
+respectively. Once this is done, run `pytest` in the top-level directory of pyQuil, and the
 full unit test suite will start!
 
 **NOTE**: Some tests (particularly those related to operator estimation and readout
 symmetrization) require a nontrivial amount of computation. For this reason, they have been marked 
-as slow and are not run by default unless pytest is given the `--include-slow-tests` option. For a 
+as slow and are not run by default unless pytest is given the `--runslow` option. For a 
 full, up-to-date list of these tests, you may invoke (from the base pyquil directory)
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,17 @@ We use `pytest` to run the pyQuil unit tests. These are run automatically on Pyt
 3.7 as part of the CI pipeline. But, you can run them yourself locally as well. Some of the
 tests depend on having running QVM and quilc servers, and otherwise will be skipped. Thus,
 to run the tests, you should begin by spinning up these servers via `qvm -S` and `quilc -S`,
-respectively. Once this is done, run `pytest` in the top-level directory of pyQuil, and the
+respectively. Once this is done, run `pytest** in the top-level directory of pyQuil, and the
 full unit test suite will start!
+
+**NOTE**: Some tests (particularly those related to operator estimation and readout
+symmetrization) require a nontrivial amount of computation. For this reason, they have been marked 
+as slow and are not run by default unless pytest is given the `--include-slow-tests` option. For a 
+full, up-to-date list of these tests, you may invoke (from the base pyquil directory)
+
+```bash
+grep -A 1 -r pytest.mark.slow  pyquil/tests/
+```
 
 **NOTE**: When making considerable changes to `operator_estimation.py`, we recommend that you set
 the `pytest` option `--use-seed` to `False` to make sure you have not broken anything. You will

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -218,8 +218,10 @@ def pytest_addoption(parser):
                      help="run operator estimation tests faster by using a fixed random seed")
     parser.addoption("--include-slow-tests", action="store_true", default=False, help="run tests marked as being 'slow'")
 
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--include-slow-tests"):
@@ -229,6 +231,7 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
 
 @pytest.fixture()
 def use_seed(pytestconfig):

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -216,7 +216,7 @@ def _str_to_bool(s):
 def pytest_addoption(parser):
     parser.addoption("--use-seed", action="store", type=_str_to_bool, default=True,
                      help="run operator estimation tests faster by using a fixed random seed")
-    parser.addoption("--include-slow-tests", action="store_true", default=False, help="run tests marked as being 'slow'")
+    parser.addoption("--runslow", action="store_true", default=False, help="run tests marked as being 'slow'")
 
 
 def pytest_configure(config):
@@ -224,10 +224,10 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--include-slow-tests"):
-        # --include-slow-tests given in cli: do not skip slow tests
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
         return
-    skip_slow = pytest.mark.skip(reason="need --include-slow-tests option to run")
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -216,7 +216,19 @@ def _str_to_bool(s):
 def pytest_addoption(parser):
     parser.addoption("--use-seed", action="store", type=_str_to_bool, default=True,
                      help="run operator estimation tests faster by using a fixed random seed")
+    parser.addoption("--include-slow-tests", action="store_true", default=False, help="run tests marked as being 'slow'")
 
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--include-slow-tests"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --include-slow-tests option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
 
 @pytest.fixture()
 def use_seed(pytestconfig):

--- a/pyquil/tests/conftest.py
+++ b/pyquil/tests/conftest.py
@@ -225,7 +225,7 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--include-slow-tests"):
-        # --runslow given in cli: do not skip slow tests
+        # --include-slow-tests given in cli: do not skip slow tests
         return
     skip_slow = pytest.mark.skip(reason="need --include-slow-tests option to run")
     for item in items:

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -225,6 +225,7 @@ def _random_2q_programs(n_progs=3):
         prog += _random_1q_gate(1)
         yield prog
 
+
 @pytest.mark.slow
 def test_measure_observables_many_progs(forest):
     expts = [

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -225,7 +225,7 @@ def _random_2q_programs(n_progs=3):
         prog += _random_1q_gate(1)
         yield prog
 
-
+@pytest.mark.slow
 def test_measure_observables_many_progs(forest):
     expts = [
         ExperimentSetting(TensorProductState(), o1 * o2)

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -291,6 +291,7 @@ def test_readout_symmetrization(forest):
     diff_s = avg1_s - avg0_s
     assert diff_s < 0.05
 
+
 @pytest.mark.slow
 def test_run_symmetrized_readout_error():
     # This test checks if the function runs for any possible input on a small number of qubits.

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -291,7 +291,7 @@ def test_readout_symmetrization(forest):
     diff_s = avg1_s - avg0_s
     assert diff_s < 0.05
 
-
+@pytest.mark.slow
 def test_run_symmetrized_readout_error():
     # This test checks if the function runs for any possible input on a small number of qubits.
     # Locally this test was run on all 8 qubits, but it was slow.

--- a/pyquil/tests/test_reference_density_simulator.py
+++ b/pyquil/tests/test_reference_density_simulator.py
@@ -263,6 +263,7 @@ def test_multiqubit_decay_bellstate():
 
     assert np.allclose(qam.wf_simulator.density, state)
 
+
 @pytest.mark.slow
 def test_for_negative_probabilities():
     # trivial program to do state tomography on

--- a/pyquil/tests/test_reference_density_simulator.py
+++ b/pyquil/tests/test_reference_density_simulator.py
@@ -263,7 +263,7 @@ def test_multiqubit_decay_bellstate():
 
     assert np.allclose(qam.wf_simulator.density, state)
 
-
+@pytest.mark.slow
 def test_for_negative_probabilities():
     # trivial program to do state tomography on
     prog = Program(I(0))

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ recreate=
 deps=
     -rrequirements.txt
 commands=
-    py.test --include-slow-tests -v pyquil/tests
+    py.test --runslow -v pyquil/tests
 
 [testenv:docs]
 whitelist_externals = make

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ recreate=
 deps=
     -rrequirements.txt
 commands=
-    py.test -v pyquil/tests
+    py.test --include-slow-tests -v pyquil/tests
 
 [testenv:docs]
 whitelist_externals = make


### PR DESCRIPTION
Description
-----------

A few tests dominate the runtime of the test suite, and this makes me less likely to run tests. On my system,
```
== slowest 10 test durations ==
45.54s call     pyquil/tests/test_quantum_computer.py::test_run_symmetrized_readout_error
40.33s call     pyquil/tests/test_reference_density_simulator.py::test_for_negative_probabilities
15.67s call     pyquil/tests/test_operator_estimation.py::test_measure_observables_many_progs
6.24s call     pyquil/tests/test_quantum_computer.py::test_run_pyqvm_noisy
4.40s call     pyquil/tests/test_operator_estimation.py::test_measure_observables_symmetrize_calibrate
4.34s call     pyquil/tests/test_operator_estimation.py::test_2q_unitary_channel_fidelity_readout_error
2.97s call     pyquil/tests/test_operator_estimation.py::test_measure_observables
2.83s call     pyquil/tests/test_operator_estimation.py::test_measure_observables_symmetrize
2.33s call     pyquil/tests/test_operator_estimation.py::test_measure_observables_result_zero_symmetrization_calibration
2.26s call     pyquil/tests/test_operator_estimation.py::test_sic_process_tomo
== 596 passed, 6 skipped, 1 xfailed, 36 warnings in 160.55s (0:02:40) ==
```

This PR adds a `--include-slow-tests` flag, as well as a marker `pytest.marks.slow` for indicating that certain tests are slow. I've flagged the top 3 in the above list. If we decide to move forward with this idea, probably we need to configure gitlab to add the `--include-slow-tests` (since these things should be tested for a PR, for example).

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
