### PR TITLE
Clean up bulk of remaining test suite warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Changelog
     of the `--use-seed` option for `pytest` to `True` (@karalekas, gh-992).
 -   Support non-gate instructions (e.g. `MEASURE`) in `to_latex()` (@notmgsk, gh-975).
 -   Test suite has been updated to reduce the use of deprecated features
-    (@kilimanjaro, gh-998 and gh-1005).
+    (@kilimanjaro, gh-998, gh-1005).
 -   Certain tests have been marked as "slow", and are skipped unless
     the `--runslow` option is specified for `pytest` (@kilimanjaro, gh-1001).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Changelog
     of the `--use-seed` option for `pytest` to `True` (@karalekas, gh-992).
 -   Support non-gate instructions (e.g. `MEASURE`) in `to_latex()` (@notmgsk, gh-975).
 -   Test suite has been updated to reduce the use of deprecated features
-    (@kilimanjaro, gh-998).
+    (@kilimanjaro, gh-998 and gh-1005).
 -   Certain tests have been marked as "slow", and are skipped unless
     the `--runslow` option is specified for `pytest` (@kilimanjaro, gh-1001).
 

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -515,7 +515,6 @@ class PauliSum(object):
         elif isinstance(other, PauliTerm):
             return self == PauliSum([other])
         elif len(self.terms) != len(other.terms):
-            warnings.warn(UnequalLengthWarning("These PauliSums have a different number of terms."))
             return False
 
         return set(self.terms) == set(other.terms)

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -31,7 +31,8 @@ from pyquil.quilatom import QubitPlaceholder
 from .quil import Program
 from .gates import I, H, RZ, RX, CNOT, X, PHASE, QUANTUM_GATES
 from numbers import Number
-from collections import Sequence, OrderedDict
+from collections import OrderedDict
+from collections.abc import Sequence
 import warnings
 from six import integer_types as six_integer_types
 from six.moves import range

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -515,6 +515,7 @@ class PauliSum(object):
         elif isinstance(other, PauliTerm):
             return self == PauliSum([other])
         elif len(self.terms) != len(other.terms):
+            warnings.warn(UnequalLengthWarning("These PauliSums have a different number of terms."))
             return False
 
         return set(self.terms) == set(other.terms)

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -307,7 +307,10 @@ def test_quil_to_native_quil(compiler):
 def test_native_quil_to_binary(server, mock_qpu_compiler):
     p = COMPILED_BELL_STATE.copy()
     p.wrap_in_numshots_loop(10)
-    response = mock_qpu_compiler.native_quil_to_executable(p)
+    # `native_quil_to_executabl` will warn us that we haven't constructed our
+    # program via `quil_to_native_quil`.
+    with pytest.warns(UserWarning):
+        response = mock_qpu_compiler.native_quil_to_executable(p)
     assert response.program == COMPILED_BYTES_ARRAY
 
 

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -307,7 +307,7 @@ def test_quil_to_native_quil(compiler):
 def test_native_quil_to_binary(server, mock_qpu_compiler):
     p = COMPILED_BELL_STATE.copy()
     p.wrap_in_numshots_loop(10)
-    # `native_quil_to_executabl` will warn us that we haven't constructed our
+    # `native_quil_to_executable` will warn us that we haven't constructed our
     # program via `quil_to_native_quil`.
     with pytest.warns(UserWarning):
         response = mock_qpu_compiler.native_quil_to_executable(p)

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -254,7 +254,7 @@ def test_prepare_register_list():
 
 def test_get_qc_returns_remote_qvm_compiler(qvm: QVMConnection, compiler: QVMCompiler):
     with patch.dict('os.environ', {"COMPILER_URL": "tcp://192.168.0.0:5550"}):
-        qc = get_qc("9q-generic-qvm")
+        qc = get_qc("9q-square-qvm")
         assert isinstance(qc.compiler, QVMCompiler)
 
 

--- a/pyquil/tests/test_device.py
+++ b/pyquil/tests/test_device.py
@@ -79,10 +79,12 @@ def test_specs(specs_dict):
     assert specs.T1s() == {0: 20e-6, 1: 19e-6, 2: 21e-6, 3: 18e-6}
     assert specs.T2s() == {0: 15e-6, 1: 12e-6, 2: 16e-6, 3: 11e-6}
 
-    assert specs.fBellStates() == {(0, 1): 0.90, (0, 2): 0.92, (0, 3): 0.89, (1, 2): 0.91}
+    with pytest.warns(DeprecationWarning): # soon to be removed
+        assert specs.fBellStates() == {(0, 1): 0.90, (0, 2): 0.92, (0, 3): 0.89, (1, 2): 0.91}
     assert specs.fCZs() == {(0, 1): 0.89, (0, 2): 0.91, (0, 3): 0.88, (1, 2): 0.90}
     assert specs.fCZ_std_errs() == {(0, 1): 0.01, (0, 2): 0.20, (0, 3): 0.03, (1, 2): 0.12}
-    assert specs.fCPHASEs() == {(0, 1): 0.88, (0, 2): 0.90, (0, 3): 0.87, (1, 2): 0.89}
+    with pytest.warns(DeprecationWarning): # soon to be removed
+        assert specs.fCPHASEs() == {(0, 1): 0.88, (0, 2): 0.90, (0, 3): 0.87, (1, 2): 0.89}
 
 
 def test_kraus_model(kraus_model_I_dict):
@@ -132,8 +134,10 @@ def test_device(isa_dict, noise_model_dict):
 
     isa = ISA.from_dict(isa_dict)
     noise_model = NoiseModel.from_dict(noise_model_dict)
-    assert isinstance(device._isa, ISA)
-    assert device._isa == isa
+    # Device.isa is deprecated, but seemingly this is what we want here
+    with pytest.warns(DeprecationWarning):
+        assert isinstance(device.isa, ISA)
+        assert device.isa == isa
     assert isinstance(device.noise_model, NoiseModel)
     assert device.noise_model == noise_model
 

--- a/pyquil/tests/test_device.py
+++ b/pyquil/tests/test_device.py
@@ -79,11 +79,11 @@ def test_specs(specs_dict):
     assert specs.T1s() == {0: 20e-6, 1: 19e-6, 2: 21e-6, 3: 18e-6}
     assert specs.T2s() == {0: 15e-6, 1: 12e-6, 2: 16e-6, 3: 11e-6}
 
-    with pytest.warns(DeprecationWarning): # soon to be removed
+    with pytest.warns(DeprecationWarning):  # soon to be removed
         assert specs.fBellStates() == {(0, 1): 0.90, (0, 2): 0.92, (0, 3): 0.89, (1, 2): 0.91}
     assert specs.fCZs() == {(0, 1): 0.89, (0, 2): 0.91, (0, 3): 0.88, (1, 2): 0.90}
     assert specs.fCZ_std_errs() == {(0, 1): 0.01, (0, 2): 0.20, (0, 3): 0.03, (1, 2): 0.12}
-    with pytest.warns(DeprecationWarning): # soon to be removed
+    with pytest.warns(DeprecationWarning):  # soon to be removed
         assert specs.fCPHASEs() == {(0, 1): 0.88, (0, 2): 0.90, (0, 3): 0.87, (1, 2): 0.89}
 
 

--- a/pyquil/tests/test_device.py
+++ b/pyquil/tests/test_device.py
@@ -132,8 +132,8 @@ def test_device(isa_dict, noise_model_dict):
 
     isa = ISA.from_dict(isa_dict)
     noise_model = NoiseModel.from_dict(noise_model_dict)
-    assert isinstance(device.isa, ISA)
-    assert device.isa == isa
+    assert isinstance(device._isa, ISA)
+    assert device._isa == isa
     assert isinstance(device.noise_model, NoiseModel)
     assert device.noise_model == noise_model
 

--- a/pyquil/tests/test_parser.py
+++ b/pyquil/tests/test_parser.py
@@ -18,7 +18,6 @@ import pytest
 
 from pyquil.gates import *
 from pyquil.parser import parse
-from pyquil.quilatom import Addr
 from pyquil.quilatom import MemoryReference, Parameter, quil_cos, quil_sin
 from pyquil.quilbase import Declare, Reset, ResetQubit
 from pyquil.quilbase import Label, JumpTarget, Jump, JumpWhen, JumpUnless, DefGate, DefPermutationGate, Qubit, Pragma, \
@@ -214,7 +213,7 @@ def test_memory_commands():
 def test_classical():
     parse_equals("MOVE ro[0] 1", MOVE(MemoryReference("ro", 0), 1))
     parse_equals("MOVE ro[0] 0", MOVE(MemoryReference("ro", 0), 0))
-    parse_equals("NOT ro[0]", NOT(Addr(0)))
+    parse_equals("NOT ro[0]", NOT(MemoryReference("ro", 0)))
     parse_equals("AND ro[0] 1", AND(MemoryReference("ro", 0), 1))
     parse_equals("IOR ro[0] 1", IOR(MemoryReference("ro", 0), 1))
     parse_equals("MOVE ro[0] 1", MOVE(MemoryReference("ro", 0), 1))

--- a/pyquil/tests/test_parser.py
+++ b/pyquil/tests/test_parser.py
@@ -212,11 +212,11 @@ def test_memory_commands():
 
 
 def test_classical():
-    parse_equals("MOVE ro[0] 1", TRUE(0))
-    parse_equals("MOVE ro[0] 0", FALSE(0))
+    parse_equals("MOVE ro[0] 1", MOVE(MemoryReference("ro", 0), 1))
+    parse_equals("MOVE ro[0] 0", MOVE(MemoryReference("ro", 0), 0))
     parse_equals("NOT ro[0]", NOT(Addr(0)))
     parse_equals("AND ro[0] 1", AND(MemoryReference("ro", 0), 1))
-    parse_equals("IOR ro[0] 1", OR(1, MemoryReference("ro", 0)))
+    parse_equals("IOR ro[0] 1", IOR(MemoryReference("ro", 0), 1))
     parse_equals("MOVE ro[0] 1", MOVE(MemoryReference("ro", 0), 1))
     parse_equals("XOR ro[0] 1", XOR(MemoryReference("ro", 0), 1))
     parse_equals("ADD mem[0] 1.2", ADD(MemoryReference("mem", 0), 1.2))

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -626,7 +626,8 @@ def test_simplify():
 def test_dont_simplify():
     t1 = sZ(0) * sZ(1)
     t2 = sZ(2) * sZ(3)
-    assert (t1 + t2) != 2 * sZ(0) * sZ(1)
+    with pytest.warns(UnequalLengthWarning):
+        assert (t1 + t2) != 2 * sZ(0) * sZ(1)
 
 
 def test_simplify_warning():

--- a/pyquil/tests/test_paulis_with_placeholders.py
+++ b/pyquil/tests/test_paulis_with_placeholders.py
@@ -149,9 +149,10 @@ def test_ids():
     q = QubitPlaceholder.register(6)
     term_1 = PauliTerm("Z", q[0], 1.0) * PauliTerm("Z", q[1], 1.0) * PauliTerm("X", q[5], 5)
     term_2 = PauliTerm("X", q[5], 5) * PauliTerm("Z", q[0], 1.0) * PauliTerm("Z", q[1], 1.0)
+    # Not sortable
     with pytest.raises(TypeError):
-        # Not sortable
-        t = term_1.id() == term_2.id()
+        with pytest.warns(FutureWarning):
+            t = term_1.id() == term_2.id()
 
 
 def test_ids_no_sort():
@@ -596,7 +597,8 @@ def test_dont_simplify():
     q = QubitPlaceholder.register(8)
     t1 = sZ(q[0]) * sZ(q[1])
     t2 = sZ(q[2]) * sZ(q[3])
-    assert (t1 + t2) != 2 * sZ(q[0]) * sZ(q[1])
+    with pytest.warns(UnequalLengthWarning):
+        assert (t1 + t2) != 2 * sZ(q[0]) * sZ(q[1])
 
 
 def test_simplify_warning():

--- a/pyquil/tests/test_paulis_with_placeholders.py
+++ b/pyquil/tests/test_paulis_with_placeholders.py
@@ -331,24 +331,23 @@ def test_exponentiate_prog():
 
 def test_exponentiate_identity():
     q = QubitPlaceholder.register(11)
-    mapping = {qp: Qubit(i) for i, qp in enumerate(q)}
+
     generator = PauliTerm("I", q[1], 0.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst()
-    assert address_qubits(prog, mapping) == address_qubits(result_prog, mapping)
+    assert len(prog) == 0
 
     generator = PauliTerm("I", q[1], 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
     result_prog = Program().inst([X(q[0]), PHASE(-1.0, q[0]), X(q[0]), PHASE(-1.0, q[0])])
-    assert address_qubits(prog, mapping) == address_qubits(result_prog, mapping)
+    assert address_qubits(prog) == address_qubits(result_prog)
 
     generator = PauliTerm("I", q[10], 0.08)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
     result_prog = Program().inst([X(q[0]), PHASE(-0.08, q[0]), X(q[0]), PHASE(-0.08, q[0])])
-    assert address_qubits(prog, mapping) == address_qubits(result_prog, mapping)
+    assert address_qubits(prog) == address_qubits(result_prog)
 
 
 def test_trotterize():

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -179,7 +179,8 @@ def test_consolidate_symmetrization_outputs():
 
 def test_check_min_num_trials_for_symmetrized_readout():
     # trials = -2 should get bumped up to 4 trials
-    assert _check_min_num_trials_for_symmetrized_readout(num_qubits=2, trials=-2, symm_type=-1) == 4
+    with pytest.warns(Warning):
+        assert _check_min_num_trials_for_symmetrized_readout(num_qubits=2, trials=-2, symm_type=-1) == 4
     # can't have symm_type < -2 or > 3
     with pytest.raises(ValueError):
         _check_min_num_trials_for_symmetrized_readout(num_qubits=2, trials=-2, symm_type=-2)

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -470,7 +470,7 @@ def test_run_and_measure(local_qvm_quilc):
     # so if you change it here ... change it there!
     with local_forest_runtime():  # Redundant with test fixture.
         bitstrings = qc.run_and_measure(prog, trials)
-    bitstring_array = np.vstack(bitstrings[q] for q in qc.qubits()).T
+    bitstring_array = np.vstack([bitstrings[q] for q in qc.qubits()]).T
     assert bitstring_array.shape == (trials, len(qc.qubits()))
 
 

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -463,7 +463,7 @@ def test_qc_error():
 
 
 def test_run_and_measure(local_qvm_quilc):
-    qc = get_qc("9q-generic-qvm")
+    qc = get_qc("9q-square-qvm")
     prog = Program(I(8))
     trials = 11
     # note to devs: this is included as an example in the run_and_measure docstrings

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -494,11 +494,13 @@ def test_if_option():
 
     assert isinstance(p.instructions[3], JumpWhen)
 
+
 def test_alloc_deprecated():
     p = Program()
 
     with pytest.warns(DeprecationWarning):
         p.alloc()
+
 
 def test_qubit_placeholder():
     p = Program()

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -489,20 +489,25 @@ def test_if_option():
 
     assert isinstance(p.instructions[3], JumpWhen)
 
+def test_alloc_deprecated():
+    p = Program()
 
-def test_alloc():
+    with pytest.warns(DeprecationWarning):
+        p.alloc()
+
+def test_qubit_placeholder():
     p = Program()
 
     p.inst(H(0))  # H 0
 
-    q1 = p.alloc()  # q1 = 1
-    q2 = p.alloc()  # q2 = 3
+    q1 = QubitPlaceholder()  # q1 = 1
+    q2 = QubitPlaceholder()  # q2 = 3
 
     p.inst(CNOT(q1, q2))  # CNOT 1 3
 
     p.inst(H(2))
 
-    q3 = p.alloc()  # q3 = 4
+    q3 = QubitPlaceholder()  # q3 = 4
 
     p.inst(X(q3))  # X 4
 
@@ -511,19 +516,19 @@ def test_alloc():
     assert e.match(r'Qubit q\d+ has not been assigned an index')
 
 
-def test_alloc_2():
+def test_qubit_placeholder_2():
     p = Program()
 
     p.inst(H(0))  # H 0
 
-    q1 = p.alloc()  # q1 = 1
-    q2 = p.alloc()  # q2 = 3
+    q1 = QubitPlaceholder()  # q1 = 1
+    q2 = QubitPlaceholder()  # q2 = 3
 
     p.inst(CNOT(q1, q2))  # CNOT 1 3
 
     p.inst(H(2))
 
-    q3 = p.alloc()  # q3 = 4
+    q3 = QubitPlaceholder()  # q3 = 4
 
     p.inst(X(q3))  # X 4
     with pytest.raises(ValueError) as e:
@@ -536,7 +541,7 @@ def test_alloc_2():
     assert e.match('Your program mixes instantiated qubits with placeholders')
 
 
-def test_alloc_new():
+def test_qubit_placeholder_new():
     p = Program()
 
     q0 = QubitPlaceholder()
@@ -595,17 +600,17 @@ def test_multiaddress():
 
 def test_multiple_instantiate():
     p = Program()
-    q = p.alloc()
+    q = QubitPlaceholder()
     p.inst(H(q))
     p = address_qubits(p)
     assert p.out() == 'H 0\n'
     assert p.out() == 'H 0\n'
 
 
-def test_reuse_alloc():
+def test_reuse_placeholder():
     p = Program()
-    q1 = p.alloc()
-    q2 = p.alloc()
+    q1 = QubitPlaceholder()
+    q2 = QubitPlaceholder()
     p.inst(H(q1))
     p.inst(H(q2))
     p.inst(CNOT(q1, q2))
@@ -706,15 +711,15 @@ def test_get_qubits():
 
     q = [QubitPlaceholder() for _ in range(6)]
     pq = Program(Declare('ro', 'BIT'), X(q[0]), CNOT(q[0], q[4]), MEASURE(q[5], MemoryReference("ro", 0)))
-    qq = pq.alloc()
+    qq = QubitPlaceholder()
     pq.inst(Y(q[2]), X(qq))
     assert address_qubits(pq).get_qubits() == {0, 1, 2, 3, 4}
 
     qubit_index = 1
     p = Program(("H", qubit_index))
     assert p.get_qubits() == {qubit_index}
-    q1 = p.alloc()
-    q2 = p.alloc()
+    q1 = QubitPlaceholder()
+    q2 = QubitPlaceholder()
     p.inst(("CNOT", q1, q2))
     with pytest.raises(ValueError) as e:
         _ = address_qubits(p).get_qubits()
@@ -734,8 +739,8 @@ def test_get_qubits_not_as_indices():
 
 def test_eq():
     p1 = Program()
-    q1 = p1.alloc()
-    q2 = p1.alloc()
+    q1 = QubitPlaceholder()
+    q2 = QubitPlaceholder()
     p1.inst([H(q1), CNOT(q1, q2)])
     p1 = address_qubits(p1)
 
@@ -869,11 +874,11 @@ def test_if_then_inherits_defined_gates():
 # https://github.com/rigetti/pyquil/issues/124
 def test_allocating_qubits_on_multiple_programs():
     p = Program()
-    qubit0 = p.alloc()
+    qubit0 = QubitPlaceholder()
     p.inst(X(qubit0))
 
     q = Program()
-    qubit1 = q.alloc()
+    qubit1 = QubitPlaceholder()
     q.inst(X(qubit1))
 
     assert address_qubits(p + q).out() == "X 0\nX 1\n"
@@ -895,9 +900,9 @@ def test_nesting_a_program_inside_itself():
 
 
 # https://github.com/rigetti/pyquil/issues/170
-def test_inline_alloc():
+def test_inline_placeholder():
     p = Program()
-    p += H(p.alloc())
+    p += H(QubitPlaceholder())
     assert address_qubits(p).out() == "H 0\n"
 
 

--- a/pyquil/tests/test_qvm.py
+++ b/pyquil/tests/test_qvm.py
@@ -9,11 +9,12 @@ from pyquil.api import QVM, ForestConnection, QVMCompiler
 from pyquil.api._compiler import _extract_program_from_pyquil_executable_response
 from pyquil.device import NxDevice
 from pyquil.gates import MEASURE, X, CNOT, H
+from pyquil.quilbase import Declare, MemoryReference
 
 
 def test_qvm_run_pqer(forest: ForestConnection):
     qvm = QVM(connection=forest, gate_noise=[0.01] * 3)
-    p = Program(X(0), MEASURE(0, 0))
+    p = Program(Declare('ro', 'BIT'), X(0), MEASURE(0, MemoryReference('ro')))
     p.wrap_in_numshots_loop(1000)
     nq = PyQuilExecutableResponse(program=p.out(), attributes={'num_shots': 1000})
     qvm.load(nq)
@@ -26,7 +27,7 @@ def test_qvm_run_pqer(forest: ForestConnection):
 
 def test_qvm_run_just_program(forest: ForestConnection):
     qvm = QVM(connection=forest, gate_noise=[0.01] * 3)
-    p = Program(X(0), MEASURE(0, 0))
+    p = Program(Declare('ro', 'BIT'), X(0), MEASURE(0, MemoryReference('ro')))
     p.wrap_in_numshots_loop(1000)
     qvm.load(p)
     qvm.run()
@@ -38,7 +39,7 @@ def test_qvm_run_just_program(forest: ForestConnection):
 
 def test_qvm_run_only_pqer(forest: ForestConnection):
     qvm = QVM(connection=forest, gate_noise=[0.01] * 3, requires_executable=True)
-    p = Program(X(0), MEASURE(0, 0))
+    p = Program(Declare('ro', 'BIT'), X(0), MEASURE(0, MemoryReference('ro')))
     p.wrap_in_numshots_loop(1000)
 
     with pytest.raises(TypeError) as e:


### PR DESCRIPTION
Description
-----------

This addresses the bulk of the warnings from the test suite, and resolves #997. There are 12 remaining warnings; these should be addressed separately (e.g. in #1004, #1003, https://github.com/rigetti/pyquil/issues/837#issuecomment-532857053).


Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
