### PR TITLE
Prevent non-constant params in lifted_gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Changelog
     immediate `float` value. Finally, the `CONVERT` instruction now accepts any valid
     memory reference designator (a `MemoryReference`, a string, or a tuple of type
     `(str, int)`) for both its arguments (@appleby, gh-1010).
+-   Raise an error if a gate with non-constant parameters is provided to `lifted_gate`
+    (@notmgsk, gh-1012).
 
 [v2.11](https://github.com/rigetti/pyquil/compare/v2.10.0...v2.11.0) (September 3, 2019)
 ----------------------------------------------------------------------------------------

--- a/pyquil/tests/test_unitary_tools.py
+++ b/pyquil/tests/test_unitary_tools.py
@@ -8,7 +8,7 @@ from pyquil.operator_estimation import plusX, minusZ
 from pyquil.paulis import sX, sY, sZ
 from pyquil.unitary_tools import qubit_adjacent_lifted_gate, program_unitary, lifted_gate_matrix, \
     lifted_gate, lifted_pauli, lifted_state_operator
-from pyquil.quilatom import MemoryReference
+from pyquil.quilatom import MemoryReference, Parameter
 from pyquil.quilbase import Declare
 
 
@@ -405,3 +405,10 @@ def test_lifted_state_operator_backwards_qubits():
         np.kron(proj_plus, proj_one),
         lifted_state_operator(xz_state, qubits=[6, 5]),
     )
+
+
+def test_lifted_gate_with_nonconstant_params():
+    gate = RX(Parameter("theta"), 0)
+
+    with pytest.raises(TypeError):
+        lifted_gate(gate, 1)

--- a/pyquil/unitary_tools.py
+++ b/pyquil/unitary_tools.py
@@ -21,6 +21,7 @@ from pyquil.gate_matrices import SWAP, STATES, QUANTUM_GATES
 from pyquil.operator_estimation import TensorProductState
 from pyquil.paulis import PauliSum, PauliTerm
 from pyquil.quilbase import Gate, _strip_modifiers
+from pyquil.quilatom import Parameter
 
 
 def all_bitstrings(n_bits):
@@ -276,6 +277,9 @@ def lifted_gate(gate: Gate, n_qubits: int):
     zero[1, 1] = 0
     one = np.eye(2)
     one[0, 0] = 0
+
+    if any(isinstance(param, Parameter) for param in gate.params):
+        raise TypeError("Cannot produce a matrix from a gate with non-constant parameters.")
 
     # The main source of complexity is in handling handling FORKED gates. Given
     # a gate with modifiers, such as `FORKED CONTROLLED FORKED RX(a,b,c,d) 0 1


### PR DESCRIPTION
Description
-----------

Insert your PR description here. Thanks for contributing to pyQuil! 🙂

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
