### PR TITLE
Remove rpc_timeout override for compiler requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Changelog
     `(str, int)`) for both its arguments (@appleby, gh-1010).
 -   Raise an error if a gate with non-constant parameters is provided to `lifted_gate`
     (@notmgsk, gh-1012).
+-   Uniformly use provided `timeout` in `QVMCompiler` and `QPUCompiler`
+    (@kilimanjaro, gh-1014).
 
 [v2.11](https://github.com/rigetti/pyquil/compare/v2.10.0...v2.11.0) (September 3, 2019)
 ----------------------------------------------------------------------------------------

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -219,23 +219,22 @@ class QPUCompiler(AbstractCompiler):
 
     def _connect_quilc(self):
         try:
-            quilc_version_dict = self.quilc_client.call('get_version_info', rpc_timeout=1)
+            quilc_version_dict = self.quilc_client.call('get_version_info')
             check_quilc_version(quilc_version_dict)
         except TimeoutError:
             raise QuilcNotRunning(f'No quilc server running at {self.quilc_client.endpoint}')
 
     def _connect_qpu_compiler(self):
         try:
-            self.qpu_compiler_client.call('get_version_info', rpc_timeout=1)
+            self.qpu_compiler_client.call('get_version_info')
         except TimeoutError:
             raise QPUCompilerNotRunning('No QPU compiler server running at '
                                         f'{self.qpu_compiler_client.endpoint}')
 
     def get_version_info(self) -> dict:
-        quilc_version_info = self.quilc_client.call('get_version_info', rpc_timeout=1)
+        quilc_version_info = self.quilc_client.call('get_version_info')
         if self.qpu_compiler_client:
-            qpu_compiler_version_info = self.qpu_compiler_client.call('get_version_info',
-                                                                      rpc_timeout=1)
+            qpu_compiler_version_info = self.qpu_compiler_client.call('get_version_info')
             return {'quilc': quilc_version_info, 'qpu_compiler': qpu_compiler_version_info}
         return {'quilc': quilc_version_info}
 
@@ -331,7 +330,7 @@ class QVMCompiler(AbstractCompiler):
             raise QuilcNotRunning(f'No quilc server running at {self.client.endpoint}')
 
     def get_version_info(self) -> dict:
-        return self.client.call('get_version_info', rpc_timeout=1)
+        return self.client.call('get_version_info')
 
     @_record_call
     def quil_to_native_quil(self, program: Program, *, protoquil=None) -> Program:


### PR DESCRIPTION
Description
-----------

Previously, we used two timeouts for requests to the compiler. For seemingly "quick" calls, a hardcoded timeout of 1s was used. For other calls, we use the `timeout` argument when constructing `QVMCompiler` or `QPUCompiler`. There is a certain logic to this, but it is sometimes confusing for users.

As an example, a user was running a few notebooks in parallel, and naturally getting timeout errors (reasonable behavior). But then this user tried to manually set the client timeouts and still got timeout errors (since `_connect_quilc` uses `rpc_timeout=1`).

The easy answer is that the compiler is not designed to handle concurrent requests. Still, I think we should honor the user's attempt to manually set the `timeout`.

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
