### PR TITLE
Decompose `estimate_observables` and incorporate new symmetrization functionality.

### DIFF
--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -992,11 +992,6 @@ def calibrate_observable_estimates(qc: QuantumComputer, expt_results: List[Exper
         # TODO: we have to fabricate an ExperimentSetting to pass to _stats_from_measurements
         #  even though it only needs the observable.
         setting = ExperimentSetting(zeros_state(meas_qs), obs)
-        # TODO: current behavior removes sign information from the reported observable and
-        #  instead stores it here in the calibrated expectation. It might be more clear to change
-        #  this (by simply omitting coeff) to match the docstring description above where the
-        #  calibration expectation is simply the average magnitude of expectation over
-        #  eigenstates.
         obs_mean, obs_var = _stats_from_measurements(results,
                                                      {q: idx for idx, q in enumerate(meas_qs)},
                                                      setting)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ antlr4-python3-runtime
 requests
 six
 networkx >= 2.0.0
+tqdm
 
 # rigetti packages
 rpcq >= 2.7.2

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'six',
         'networkx>=2.0.0',
         'rpcq>=2.7.2',
+        'tqdm',
 
         # dependency of contextvars, which we vendor
         'immutables==0.6',


### PR DESCRIPTION
Description
-----------

closes #1028, which describes the purpose and approach of this PR. 

1) the logging callback isn't quite as straightforward now since there isn't one large loop. Incorporating that functionality is currently a TODO. Related, forest-benchmarking has been using tqdm progress bars, which I incorporated here but haven't yet updated the requirements. 

2) `get_calibration_program` largely mimics `_calibration_program` and replaces the latter's only usage in this module. The signature of `_calibration_program` requires a lot of extraneous information, and I think it makes sense to make this method public.

3) `_stats_from_measurements` also takes in extraneously high-level objects when it only needs a small bit of the wrapped information. This caused a small annoyance marked by a TODO. 

4) qc.run_symmetrized_readout takes in an integer symm strength or symm_type, but here we were using a string. I have made it compatible, but it is messier than using the int code used in qc.run_symmetrized_readout.

Checklist
-----------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
