### PR TITLE
Make the Docker image smaller and build faster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.coveragerc
+.git
+.gitlab-ci.yml
+.gitignore
+.github
+docs
+ACKNOWLEDGEMENTS.md
+CHANGELOG.md
+CONTRIBUTING.md
+Makefile
+MANIFEST.in
+NOTICE.md
+readthedocs.yml
+tox.ini

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,3 +54,15 @@ docs:
     - apt-get update && apt-get install -y pandoc
     - pandoc --from=markdown --to=rst --output=docs/source/changes.rst CHANGELOG.md
     - tox -e docs
+
+test-docker:
+  stage: test
+  image: docker:stable
+  tags:
+    - dockerd
+    - github
+  only:
+    refs:
+      - /^v(\d+\.)?(\d+\.)?(\d+)$/
+  script:
+    - docker run --rm $IMAGE:edge python -c "from pyquil import get_qc; qvm = get_qc('9q-qvm')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog
     to quickly get started with compiling and simulating quantum programs! When
     running the image, a user will be dropped into an `ipython` REPL that has
     pyQuil and its requirements preinstalled, along with quilc and qvm servers
-    running in the background (@karalekas, gh-1035).
+    running in the background (@karalekas, gh-1035, gh-1039).
 
 ### Improvements and Changes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # specify the dependency versions (can be overriden with --build-arg)
-ARG quilc_version=1.12.0
+ARG quilc_version=1.12.1
 ARG qvm_version=1.12.0
 ARG python_version=3.6
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ FROM rigetti/quilc:$quilc_version as quilc
 FROM rigetti/qvm:$qvm_version as qvm
 FROM python:$python_version
 
-# copy over the pre-built quilc binary from the first build stage
-COPY --from=quilc /src/quilc /src/quilc
+# copy over the pre-built quilc binary and tweedledum library from the first build stage
+COPY --from=quilc /usr/local/lib/libtweedledum.so /usr/local/lib/libtweedledum.so
+COPY --from=quilc /src/quilc/quilc /src/quilc/quilc
 
 # copy over the pre-built qvm binary from the second build stage
-COPY --from=qvm /src/qvm /src/qvm
+COPY --from=qvm /src/qvm/qvm /src/qvm/qvm
 
 # install the missing apt requirements that can't be copied over
 RUN echo "deb http://http.us.debian.org/debian/ testing non-free contrib main" >> /etc/apt/sources.list && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,8 @@ COPY --from=quilc /src/quilc/quilc /src/quilc/quilc
 # copy over the pre-built qvm binary from the second build stage
 COPY --from=qvm /src/qvm/qvm /src/qvm/qvm
 
-# install the missing apt requirements that can't be copied over
-RUN echo "deb http://http.us.debian.org/debian/ testing non-free contrib main" >> /etc/apt/sources.list && \
-    apt-get update && apt-get -yq dist-upgrade && \
+# install the missing apt that aren't copied over
+RUN apt-get update && apt-get -yq dist-upgrade && \
     apt-get install --no-install-recommends -yq \
     clang-7 git libblas-dev libffi-dev liblapack-dev libzmq3-dev && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Description
-----------

Fixes #1037.

The image is now much smaller:

- 935.72 MB -> 521.6 MB on DockerHub
- 2.31 GB -> 1.38GB on disk

And the build is much faster (5 mins to 2 mins).

Checklist
---------

- [x] The above description motivates these changes.
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
