### PR TITLE
Update Rigetti Forest Slack Workspace invitation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Changelog
 
 ### Bugfixes
 
+-   Fixed the Slack Workspace invite link in the README (@amyfbrown, gh-1042).
+
 [v2.12](https://github.com/rigetti/pyquil/compare/v2.11.0...v2.12.0) (September 28, 2019)
 ----------------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Joining the Forest Community
 ----------------------------
 
 If you'd like to get involved with pyQuil and Forest, joining the [Rigetti Forest Slack
-Workspace](https://join.slack.com/t/rigetti-forest/shared_invite/enQtNTUyNTE1ODg3MzE2LWExZWU5OTE4YTJhMmE2NGNjMThjOTM1MjlkYTA5ZmUxNTJlOTVmMWE0YjA3Y2M2YmQzNTZhNTBlMTYyODRjMzA)
+Workspace](https://join.slack.com/t/rigetti-forest/shared_invite/enQtNTUyNTE1ODg3MzE2LWQwNzBlMjZlMmNlN2M5MzQyZDlmOGViODQ5ODI0NWMwNmYzODY4YTc2ZjdjOTNmNzhiYTk2YjVhNTE2NTRkODY)
 is a great place to start! You can do so by clicking the invite link in the previous sentence,
 or in the badge at the top of this README. The Slack Workspace is a great place to ask general
 questions, join high-level design discussions, and hear about updates to pyQuil and the Forest SDK.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ PyQuil: Quantum programming in Python
 [![pypi downloads](https://img.shields.io/pypi/dm/pyquil.svg)](https://pypi.org/project/pyquil/)
 [![pypi version](https://img.shields.io/pypi/v/pyquil.svg)](https://pypi.org/project/pyquil/)
 [![conda-forge version](https://img.shields.io/conda/vn/conda-forge/pyquil.svg)](https://anaconda.org/conda-forge/pyquil)
-[![slack workspace](https://img.shields.io/badge/slack-rigetti--forest-812f82.svg?)](https://join.slack.com/t/rigetti-forest/shared_invite/enQtNTUyNTE1ODg3MzE2LWExZWU5OTE4YTJhMmE2NGNjMThjOTM1MjlkYTA5ZmUxNTJlOTVmMWE0YjA3Y2M2YmQzNTZhNTBlMTYyODRjMzA)
+[![slack workspace](https://img.shields.io/badge/slack-rigetti--forest-812f82.svg?)][slack_invite]
 
 PyQuil is a Python library for quantum programming using [Quil](https://arxiv.org/abs/1608.03355),
 the quantum instruction language developed at [Rigetti Computing](https://www.rigetti.com/).
@@ -97,7 +97,7 @@ Joining the Forest Community
 ----------------------------
 
 If you'd like to get involved with pyQuil and Forest, joining the [Rigetti Forest Slack
-Workspace](https://join.slack.com/t/rigetti-forest/shared_invite/enQtNTUyNTE1ODg3MzE2LWQwNzBlMjZlMmNlN2M5MzQyZDlmOGViODQ5ODI0NWMwNmYzODY4YTc2ZjdjOTNmNzhiYTk2YjVhNTE2NTRkODY)
+Workspace][slack_invite]
 is a great place to start! You can do so by clicking the invite link in the previous sentence,
 or in the badge at the top of this README. The Slack Workspace is a great place to ask general
 questions, join high-level design discussions, and hear about updates to pyQuil and the Forest SDK.
@@ -122,6 +122,7 @@ Thanks for contributing to pyQuil! 🙂
 [help]: https://github.com/rigetti/pyquil/labels/help%20wanted%20%3Awave%3A
 [fork]: https://github.com/rigetti/pyquil/fork
 [pr]: https://github.com/rigetti/pyquil/compare
+[slack_invite]: https://join.slack.com/t/rigetti-forest/shared_invite/enQtNTUyNTE1ODg3MzE2LWQwNzBlMjZlMmNlN2M5MzQyZDlmOGViODQ5ODI0NWMwNmYzODY4YTc2ZjdjOTNmNzhiYTk2YjVhNTE2NTRkODY
 
 Running on the QPU
 ------------------


### PR DESCRIPTION
Description
-----------

This PR updates the Rigetti-Forest Slack invitation link with one that has not expired. This fixes pyQuil issue #1040. 

Checklist
---------

- [x] The above description motivates these changes.
- [ ] ~There is a unit test that covers these changes.~ N/A
- [ ] ~All new and existing tests pass locally and on Semaphore.~ N/A
- [ ] ~Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).~ N/A
- [ ] ~Functions and classes have useful sphinx-style docstrings.~ N/A
- [ ] ~(New Feature) The docs have been updated accordingly.~ N/A
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
