### PR TITLE
Correct path to exercises.rst in meyer_penny_game.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Changelog
 
 ### Bugfixes
 
+- Updated `examples/meyer_penny_game.py` with the correct path to the Meyer Penny game exercise in
+  `docs/source/exercises.rst` (@appleby, gh-1045).
+
 [v2.12](https://github.com/rigetti/pyquil/compare/v2.11.0...v2.12.0) (September 28, 2019)
 ----------------------------------------------------------------------------------------
 

--- a/examples/meyer_penny_game.py
+++ b/examples/meyer_penny_game.py
@@ -26,7 +26,7 @@ import numpy as np
 def meyer_penny_program():
     """
     Returns the program to simulate the Meyer-Penny Game
-    The full description is available in docs/source/examples.rst
+    The full description is available in ../docs/source/exercises.rst
 
     :return: pyQuil Program
     """


### PR DESCRIPTION
Fixes #1044

Description
-----------

A docstring comment in `meyer_penny_game.py` was referencing a non-existent `examples.rst` file. It appears the referenced content can now be found in `exercises.rst`.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
