### PR TITLE
updates typos in example programs

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -501,11 +501,11 @@ Let's take a look at how we could use a ``CNOT`` gate in pyQuil.
 
     CNOT|10> =  (1+0j)|10>
     With outcome probabilities
-     {'00': 0.0, '01': 0.0, '10': 1.0, '11': 0.0}
+     {'00': 0.0, '01': 1.0, '10': 0.0, '11': 0.0} #changed the prob it should be '01' if q[0] is control bit
 
     CNOT|11> =  (1+0j)|01>
     With outcome probabilities
-     {'00': 0.0, '01': 1.0, '10': 0.0, '11': 0.0}
+     {'00': 0.0, '01': 0.0, '10': 1.0, '11': 0.0} #changed the prob it should be "10" at 1.0 
 
 
 The ``CNOT`` gate does what its name implies: the state of the second qubit is flipped
@@ -540,7 +540,7 @@ and :math:`|10\rangle` states:
 
     SWAP|01> =  (1+0j)|10>
     With outcome probabilities
-     {'00': 0.0, '01': 0.0, '10': 1.0, '11': 0.0}
+     {'00': 0.0, '01': 1.0, '10': 0.0, '11': 0.0} #changed the prob it should be '01' 1.0
 
 In summary, quantum computing operations are composed of a series of
 complex matrices applied to complex vectors. These matrices must be unitary (meaning that


### PR DESCRIPTION
Description
-----------
 I don't think my typo changes are on level of needing unit tests...I changed the prob. outcomes of the CNOT gates on the last 2 examples and the SWAP
Insert your PR description here. Thanks for contributing to pyQuil! 🙂

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
