### PR TITLE
Practical output-transforming enhancements to qc.run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Changelog
     and it is now a keyword-only argument (@karalekas, gh-1071).
 -   The code in `device.py` as been reorganized into a new `device` subdirectory
     in a completely backwards-compatible fashion (@karalekas, gh-1066).
+-   The `run` method of the `QuantumComputer` supports two new keyword arguments:
+    `bitmask` for selectively flipping the resultant bitstrings, and `correlations`
+    for returning single- and multi-qubit correlations instead of the typical
+    bitstring outcomes (@karalekas, gh-1070).
     
 ### Bugfixes
 

--- a/docs/source/qvm.rst
+++ b/docs/source/qvm.rst
@@ -462,9 +462,9 @@ step in near-term algorithms like the variational quantum eigensolver (VQE).
      [1]
      [1]]
 
-We expect to get all 1s back because we're preparing the Bell state |00> + |11>, which means
+We expect to get all 1s back because we're preparing the Bell state ``|00> + |11>``, which means
 that the bitstring outcome will always be either "00" or "11". We can combine the two options,
-using the ``bitmask`` to feign the production of the (anti-correlated) Bell state |01> + |10>.
+using the ``bitmask`` to feign the production of the (anti-correlated) Bell state ``|01> + |10>``.
 
 .. code:: python
 

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -140,8 +140,8 @@ class QAM(ABC):
             out = []
             for c in correlations:
                 where = np.zeros(region_size, dtype=bool)
-                np.put(where, c, np.array([True]))
-                out.append(np.prod(output, axis=1, where=where))
+                where[c] = True
+                out.append(np.prod(output[:, where], axis=1))
             output = np.stack(out, axis=-1)
 
         return output

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -112,7 +112,8 @@ class QAM(ABC):
         :param region_name: The string naming the declared memory region.
         :param bitmask: A list representing a bitmask that is XOR'ed with the resultant bitstrings.
         :param correlations: A list or list of lists denoting which bitstring correlations to
-            return, instead of the regular bitstring results.
+            return, instead of the regular bitstring results. Maps the 0 state to its +1
+            expectation value, and the 1 state to its -1 expectation value.
         :return: A list of values of the appropriate type.
         """
         assert self.status == 'done'

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -94,7 +94,7 @@ class QAM(ABC):
         return self
 
     @_record_call
-    def read_memory(self, *, region_name: str):
+    def read_memory(self, *, region_name: str, expectation: bool = False):
         """
         Reads from a memory region named region_name on the QAM.
 
@@ -106,7 +106,15 @@ class QAM(ABC):
         """
         assert self.status == 'done'
 
-        return self._memory_results[region_name]
+        modify_output = any([expectation])
+        if not modify_output:
+            return self._memory_results[region_name]
+
+        bitstrings = self._memory_results[region_name].copy()
+        if expectation:
+            bitstrings[bitstrings == 1] = -1
+            bitstrings[bitstrings == 0] = 1
+        return bitstrings
 
     @_record_call
     def read_from_memory_region(self, *, region_name: str):

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -110,8 +110,9 @@ class QAM(ABC):
         "ro" of type ``BIT``.
 
         :param region_name: The string naming the declared memory region.
-        :param bitmask: The
-        :param region_name: The string naming the declared memory region.
+        :param bitmask: A list representing a bitmask that is XOR'ed with the resultant bitstrings.
+        :param correlations: A list or list of lists denoting which bitstring correlations to
+            return, instead of the regular bitstring results.
         :return: A list of values of the appropriate type.
         """
         assert self.status == 'done'

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -18,6 +18,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
 
+import numpy as np
 from rpcq.messages import ParameterAref
 
 from pyquil.api._error_reporting import _record_call
@@ -94,7 +95,13 @@ class QAM(ABC):
         return self
 
     @_record_call
-    def read_memory(self, *, region_name: str, expectation: bool = False):
+    def read_memory(
+            self,
+            *,
+            region_name: str,
+            expectation: bool = False,
+            mean: bool = False,
+    ) -> np.ndarray:
         """
         Reads from a memory region named region_name on the QAM.
 
@@ -106,7 +113,7 @@ class QAM(ABC):
         """
         assert self.status == 'done'
 
-        modify_output = any([expectation])
+        modify_output = any([expectation, mean])
         if not modify_output:
             return self._memory_results[region_name]
 
@@ -114,6 +121,8 @@ class QAM(ABC):
         if expectation:
             bitstrings[bitstrings == 1] = -1
             bitstrings[bitstrings == 0] = 1
+        if mean:
+            bitstrings = np.mean(bitstrings, axis=0)
         return bitstrings
 
     @_record_call

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -100,6 +100,7 @@ class QAM(ABC):
             self,
             *,
             region_name: str,
+            bitmask: List[int] = None,
             expectation: bool = False,
             correlation: Union[bool, List[bool], List[List[bool]]] = False,
             mean: bool = False,
@@ -115,11 +116,13 @@ class QAM(ABC):
         """
         assert self.status == 'done'
 
-        modify_output = any([expectation, correlation, mean])
+        modify_output = any([bitmask, expectation, correlation, mean])
         if not modify_output:
             return self._memory_results[region_name]
 
         bitstrings = self._memory_results[region_name].copy()
+        if bitmask is not None:
+            bitstrings = np.bitwise_xor(bitstrings, bitmask)
         if expectation:
             bitstrings[bitstrings == 1] = -1
             bitstrings[bitstrings == 0] = 1

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -102,7 +102,6 @@ class QAM(ABC):
             region_name: str,
             bitmask: Optional[List[int]] = None,
             expectations: Optional[Union[List[int], List[List[int]]]] = None,
-            statistics: bool = False,
     ) -> np.ndarray:
         """
         Reads from a memory region named region_name on the QAM.
@@ -115,7 +114,7 @@ class QAM(ABC):
         """
         assert self.status == 'done'
 
-        modify_output = any([bitmask, expectations, statistics])
+        modify_output = any([bitmask, expectations])
         if not modify_output:
             return self._memory_results[region_name]
 
@@ -140,12 +139,6 @@ class QAM(ABC):
                 np.put(where, e, np.array([True]))
                 bits.append(np.prod(output, axis=1, where=where))
             output = np.stack(bits, axis=-1)
-
-        # gather statistics (mean and standard error)
-        if statistics:
-            means = np.mean(output, axis=0)
-            standard_errors = np.std(output, axis=0, ddof=1) / np.sqrt(len(output))
-            output = np.stack((means, standard_errors), axis=-1)
 
         return output
 

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -101,7 +101,7 @@ class QAM(ABC):
             *,
             region_name: str,
             bitmask: Optional[List[int]] = None,
-            expectations: Optional[Union[List[int], List[List[int]]]] = None,
+            correlations: Optional[Union[List[int], List[List[int]]]] = None,
     ) -> np.ndarray:
         """
         Reads from a memory region named region_name on the QAM.
@@ -114,7 +114,7 @@ class QAM(ABC):
         """
         assert self.status == 'done'
 
-        modify_output = any([bitmask, expectations])
+        modify_output = any([bitmask, correlations])
         if not modify_output:
             return self._memory_results[region_name]
 
@@ -124,21 +124,21 @@ class QAM(ABC):
         if bitmask is not None:
             output = np.bitwise_xor(output, bitmask)
 
-        # compute single-qubit and joint expectation values
-        if expectations is not None:
+        # compute single- and multi-qubit correlations
+        if correlations is not None:
             output[output == 1] = -1
             output[output == 0] = 1
 
             region_size = len(output[0])
-            if isinstance(expectations, list) and isinstance(expectations[0], int):
-                expectations = [expectations]
+            if isinstance(correlations, list) and isinstance(correlations[0], int):
+                correlations = [correlations]
 
-            bits = []
-            for e in expectations:
+            out = []
+            for c in correlations:
                 where = np.zeros(region_size, dtype=bool)
-                np.put(where, e, np.array([True]))
-                bits.append(np.prod(output, axis=1, where=where))
-            output = np.stack(bits, axis=-1)
+                np.put(where, c, np.array([True]))
+                out.append(np.prod(output, axis=1, where=where))
+            output = np.stack(out, axis=-1)
 
         return output
 

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -110,6 +110,8 @@ class QAM(ABC):
         "ro" of type ``BIT``.
 
         :param region_name: The string naming the declared memory region.
+        :param bitmask: The
+        :param region_name: The string naming the declared memory region.
         :return: A list of values of the appropriate type.
         """
         assert self.status == 'done'

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -17,6 +17,7 @@ import warnings
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from typing import List, Union
 
 import numpy as np
 from rpcq.messages import ParameterAref
@@ -100,6 +101,7 @@ class QAM(ABC):
             *,
             region_name: str,
             expectation: bool = False,
+            correllation: Union[bool, List[bool]] = False,
             mean: bool = False,
     ) -> np.ndarray:
         """
@@ -113,7 +115,7 @@ class QAM(ABC):
         """
         assert self.status == 'done'
 
-        modify_output = any([expectation, mean])
+        modify_output = any([expectation, correllation, mean])
         if not modify_output:
             return self._memory_results[region_name]
 
@@ -121,6 +123,11 @@ class QAM(ABC):
         if expectation:
             bitstrings[bitstrings == 1] = -1
             bitstrings[bitstrings == 0] = 1
+        if correllation is True:
+            region_size = len(bitstrings[0])
+            bitstrings = np.prod(bitstrings, axis=1, where=[True] * region_size)
+        elif isinstance(correllation, list):
+            bitstrings = np.prod(bitstrings, axis=1, where=correllation)
         if mean:
             bitstrings = np.mean(bitstrings, axis=0)
         return bitstrings

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -114,7 +114,7 @@ class QuantumComputer:
             bitmask: Optional[List[int]] = None,
             expectation: bool = False,
             correlation: Optional[Union[List[int], List[List[int]]]] = None,
-            mean: bool = False) -> np.ndarray:
+            statistics: bool = False) -> np.ndarray:
         """
         Run a quil executable. If the executable contains declared parameters, then a memory
         map must be provided, which defines the runtime values of these parameters.
@@ -136,7 +136,7 @@ class QuantumComputer:
                          bitmask=bitmask,
                          expectation=expectation,
                          correlation=correlation,
-                         mean=mean)
+                         statistics=statistics)
 
     @_record_call
     def run_symmetrized_readout(self,

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -112,8 +112,7 @@ class QuantumComputer:
             memory_map: Dict[str, List[Union[int, float]]] = None,
             *,
             bitmask: Optional[List[int]] = None,
-            expectations: Optional[Union[List[int], List[List[int]]]] = None,
-            statistics: bool = False) -> np.ndarray:
+            expectations: Optional[Union[List[int], List[List[int]]]] = None) -> np.ndarray:
         """
         Run a quil executable. If the executable contains declared parameters, then a memory
         map must be provided, which defines the runtime values of these parameters.
@@ -133,8 +132,7 @@ class QuantumComputer:
             .wait() \
             .read_memory(region_name='ro',
                          bitmask=bitmask,
-                         expectations=expectations,
-                         statistics=statistics)
+                         expectations=expectations)
 
     @_record_call
     def run_symmetrized_readout(self,

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -107,8 +107,11 @@ class QuantumComputer:
         return self.device.get_isa(oneq_type=oneq_type, twoq_type=twoq_type)
 
     @_record_call
-    def run(self, executable: Executable,
-            memory_map: Dict[str, List[Union[int, float]]] = None) -> np.ndarray:
+    def run(self,
+            executable: Executable,
+            memory_map: Dict[str, List[Union[int, float]]] = None,
+            *,
+            expectation: bool = False) -> np.ndarray:
         """
         Run a quil executable. If the executable contains declared parameters, then a memory
         map must be provided, which defines the runtime values of these parameters.
@@ -126,10 +129,11 @@ class QuantumComputer:
                     self.qam.write_memory(region_name=region_name, offset=offset, value=value)
         return self.qam.run() \
             .wait() \
-            .read_memory(region_name='ro')
+            .read_memory(region_name='ro', expectation=expectation)
 
     @_record_call
-    def run_symmetrized_readout(self, program: Program, trials: int, symm_type: int = 3,
+    def run_symmetrized_readout(
+            self, program: Program, trials: int, symm_type: int = 3,
                                     meas_qubits: List[int] = None) -> np.ndarray:
         r"""
         Run a quil program in such a way that the readout error is made symmetric. Enforcing

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -112,7 +112,7 @@ class QuantumComputer:
             memory_map: Dict[str, List[Union[int, float]]] = None,
             *,
             bitmask: Optional[List[int]] = None,
-            expectations: Optional[Union[List[int], List[List[int]]]] = None) -> np.ndarray:
+            correlations: Optional[Union[List[int], List[List[int]]]] = None) -> np.ndarray:
         """
         Run a quil executable. If the executable contains declared parameters, then a memory
         map must be provided, which defines the runtime values of these parameters.
@@ -132,7 +132,7 @@ class QuantumComputer:
             .wait() \
             .read_memory(region_name='ro',
                          bitmask=bitmask,
-                         expectations=expectations)
+                         correlations=correlations)
 
     @_record_call
     def run_symmetrized_readout(self,

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -112,8 +112,7 @@ class QuantumComputer:
             memory_map: Dict[str, List[Union[int, float]]] = None,
             *,
             bitmask: Optional[List[int]] = None,
-            expectation: bool = False,
-            correlation: Optional[Union[List[int], List[List[int]]]] = None,
+            expectations: Optional[Union[List[int], List[List[int]]]] = None,
             statistics: bool = False) -> np.ndarray:
         """
         Run a quil executable. If the executable contains declared parameters, then a memory
@@ -134,8 +133,7 @@ class QuantumComputer:
             .wait() \
             .read_memory(region_name='ro',
                          bitmask=bitmask,
-                         expectation=expectation,
-                         correlation=correlation,
+                         expectations=expectations,
                          statistics=statistics)
 
     @_record_call

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -111,6 +111,7 @@ class QuantumComputer:
             executable: Executable,
             memory_map: Dict[str, List[Union[int, float]]] = None,
             *,
+            bitmask: List[int] = None,
             expectation: bool = False,
             correlation: Union[bool, List[bool], List[List[bool]]] = False,
             mean: bool = False) -> np.ndarray:
@@ -132,6 +133,7 @@ class QuantumComputer:
         return self.qam.run() \
             .wait() \
             .read_memory(region_name='ro',
+                         bitmask=bitmask,
                          expectation=expectation,
                          correlation=correlation,
                          mean=mean)

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -112,6 +112,7 @@ class QuantumComputer:
             memory_map: Dict[str, List[Union[int, float]]] = None,
             *,
             expectation: bool = False,
+            correllation: Union[bool, List[bool]] = False,
             mean: bool = False) -> np.ndarray:
         """
         Run a quil executable. If the executable contains declared parameters, then a memory
@@ -130,7 +131,10 @@ class QuantumComputer:
                     self.qam.write_memory(region_name=region_name, offset=offset, value=value)
         return self.qam.run() \
             .wait() \
-            .read_memory(region_name='ro', expectation=expectation, mean=mean)
+            .read_memory(region_name='ro',
+                         expectation=expectation,
+                         correllation=correllation,
+                         mean=mean)
 
     @_record_call
     def run_symmetrized_readout(

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -111,7 +111,8 @@ class QuantumComputer:
             executable: Executable,
             memory_map: Dict[str, List[Union[int, float]]] = None,
             *,
-            expectation: bool = False) -> np.ndarray:
+            expectation: bool = False,
+            mean: bool = False) -> np.ndarray:
         """
         Run a quil executable. If the executable contains declared parameters, then a memory
         map must be provided, which defines the runtime values of these parameters.
@@ -129,7 +130,7 @@ class QuantumComputer:
                     self.qam.write_memory(region_name=region_name, offset=offset, value=value)
         return self.qam.run() \
             .wait() \
-            .read_memory(region_name='ro', expectation=expectation)
+            .read_memory(region_name='ro', expectation=expectation, mean=mean)
 
     @_record_call
     def run_symmetrized_readout(

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -120,6 +120,11 @@ class QuantumComputer:
         :param executable: The program to run. You are responsible for compiling this first.
         :param memory_map: The mapping of declared parameters to their values. The values
             are a list of floats or integers.
+        :param bitmask: A list representing a bitmask that is XOR'ed with the resultant bitstrings.
+            Useful shorthand for running with readout symmetrization.
+        :param correlations: A list or list of lists denoting which bitstring correlations to
+            return, instead of the regular bitstring results. Useful shorthand for practical
+            applications which involve estimating a collection of observables.
         :return: A numpy array of shape (trials, len(ro-register)) that contains 0s and 1s.
         """
         self.qam.load(executable)

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -17,7 +17,7 @@ import re
 import socket
 import warnings
 from math import pi, log
-from typing import List, Dict, Tuple, Iterator, Union
+from typing import List, Dict, Tuple, Iterator, Optional, Union
 import itertools
 
 import subprocess
@@ -111,9 +111,9 @@ class QuantumComputer:
             executable: Executable,
             memory_map: Dict[str, List[Union[int, float]]] = None,
             *,
-            bitmask: List[int] = None,
+            bitmask: Optional[List[int]] = None,
             expectation: bool = False,
-            correlation: Union[bool, List[bool], List[List[bool]]] = False,
+            correlation: Optional[Union[List[int], List[List[int]]]] = None,
             mean: bool = False) -> np.ndarray:
         """
         Run a quil executable. If the executable contains declared parameters, then a memory

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -112,7 +112,7 @@ class QuantumComputer:
             memory_map: Dict[str, List[Union[int, float]]] = None,
             *,
             expectation: bool = False,
-            correllation: Union[bool, List[bool]] = False,
+            correlation: Union[bool, List[bool], List[List[bool]]] = False,
             mean: bool = False) -> np.ndarray:
         """
         Run a quil executable. If the executable contains declared parameters, then a memory
@@ -133,7 +133,7 @@ class QuantumComputer:
             .wait() \
             .read_memory(region_name='ro',
                          expectation=expectation,
-                         correllation=correllation,
+                         correlation=correlation,
                          mean=mean)
 
     @_record_call

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -139,9 +139,11 @@ class QuantumComputer:
                          mean=mean)
 
     @_record_call
-    def run_symmetrized_readout(
-            self, program: Program, trials: int, symm_type: int = 3,
-                                    meas_qubits: List[int] = None) -> np.ndarray:
+    def run_symmetrized_readout(self,
+                                program: Program,
+                                trials: int,
+                                symm_type: int = 3,
+                                meas_qubits: List[int] = None) -> np.ndarray:
         r"""
         Run a quil program in such a way that the readout error is made symmetric. Enforcing
         symmetric readout error is useful in simplifying the assumptions in some near

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -123,8 +123,9 @@ class QuantumComputer:
         :param bitmask: A list representing a bitmask that is XOR'ed with the resultant bitstrings.
             Useful shorthand for running with readout symmetrization.
         :param correlations: A list or list of lists denoting which bitstring correlations to
-            return, instead of the regular bitstring results. Useful shorthand for practical
-            applications which involve estimating a collection of observables.
+            return, instead of the regular bitstring results. Maps the 0 state to its +1
+            expectation value, and the 1 state to its -1 expectation value. Useful shorthand
+            for practical applications which involve estimating a collection of observables.
         :return: A numpy array of shape (trials, len(ro-register)) that contains 0s and 1s.
         """
         self.qam.load(executable)

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -250,12 +250,12 @@ class PyQVM(QAM):
             *,
             region_name: str,
             bitmask: Optional[List[int]] = None,
-            expectations: Optional[Union[List[int], List[List[int]]]] = None,
+            correlations: Optional[Union[List[int], List[List[int]]]] = None,
             statistics: bool = False,
     ) -> np.ndarray:
         return np.asarray(super().read_memory(region_name=region_name,
                                               bitmask=bitmask,
-                                              expectations=expectations,
+                                              correlations=correlations,
                                               statistics=statistics))
 
     def find_label(self, label: Label):

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -16,7 +16,7 @@
 import warnings
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Type, Dict, Tuple, Union, List, Sequence
+from typing import Type, Dict, Tuple, Union, List, Sequence, Optional
 
 import numpy as np
 from numpy.random.mtrand import RandomState
@@ -249,16 +249,14 @@ class PyQVM(QAM):
             self,
             *,
             region_name: str,
-            bitmask: List[int] = None,
-            expectation: bool = False,
-            correlation: Union[bool, List[bool], List[List[bool]]] = False,
-            mean: bool = False,
+            bitmask: Optional[List[int]] = None,
+            expectations: Optional[Union[List[int], List[List[int]]]] = None,
+            statistics: bool = False,
     ) -> np.ndarray:
         return np.asarray(super().read_memory(region_name=region_name,
                                               bitmask=bitmask,
-                                              expectation=expectation,
-                                              correlation=correlation,
-                                              mean=mean))
+                                              expectations=expectations,
+                                              statistics=statistics))
 
     def find_label(self, label: Label):
         """

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -251,12 +251,10 @@ class PyQVM(QAM):
             region_name: str,
             bitmask: Optional[List[int]] = None,
             correlations: Optional[Union[List[int], List[List[int]]]] = None,
-            statistics: bool = False,
     ) -> np.ndarray:
         return np.asarray(super().read_memory(region_name=region_name,
                                               bitmask=bitmask,
-                                              correlations=correlations,
-                                              statistics=statistics))
+                                              correlations=correlations))
 
     def find_label(self, label: Label):
         """

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -245,8 +245,20 @@ class PyQVM(QAM):
         self.status = 'done'
         return self
 
-    def read_memory(self, *, region_name: str):
-        return np.asarray(self._memory_results[region_name])
+    def read_memory(
+            self,
+            *,
+            region_name: str,
+            bitmask: List[int] = None,
+            expectation: bool = False,
+            correlation: Union[bool, List[bool], List[List[bool]]] = False,
+            mean: bool = False,
+    ) -> np.ndarray:
+        return np.asarray(super().read_memory(region_name=region_name,
+                                              bitmask=bitmask,
+                                              expectation=expectation,
+                                              correlation=correlation,
+                                              mean=mean))
 
     def find_label(self, label: Label):
         """

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -432,6 +432,34 @@ def test_qc_run(qvm, compiler):
         assert bits.shape == (3,)
 
 
+def test_qc_run_bitmask(qvm, compiler):
+    qc = get_qc('9q-square-qvm')
+    p = Program()
+    p += X(0)
+    p += X(1)
+    ro = p.declare('ro', 'BIT', 2)
+    p += MEASURE(0, ro[0])
+    p += MEASURE(1, ro[1])
+    p.wrap_in_numshots_loop(1)
+    b = qc.compile(p)
+    assert np.allclose(qc.run(b, bitmask=[0, 0]), np.array([1, 1]))
+    assert np.allclose(qc.run(b, bitmask=[1, 0]), np.array([0, 1]))
+    assert np.allclose(qc.run(b, bitmask=[0, 1]), np.array([1, 0]))
+    assert np.allclose(qc.run(b, bitmask=[1, 1]), np.array([0, 0]))
+
+def test_qc_run_correlations(qvm, compiler):
+    qc = get_qc('9q-square-qvm')
+    p = Program()
+    p += H(0)
+    p += CNOT(0, 1)
+    ro = p.declare('ro', 'BIT', 2)
+    p += MEASURE(0, ro[0])
+    p += MEASURE(1, ro[1])
+    p.wrap_in_numshots_loop(1)
+    b = qc.compile(p)
+    assert qc.run(b, correlations=[0, 1]) == np.array([1])
+    assert qc.run(b, bitmask=[1, 0], correlations=[0, 1]) == np.array([-1])
+
 def test_nq_qvm_qc():
     for n_qubits in [2, 4, 7, 19]:
         qc = get_qc(f'{n_qubits}q-qvm')

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -447,6 +447,7 @@ def test_qc_run_bitmask(qvm, compiler):
     assert np.allclose(qc.run(b, bitmask=[0, 1]), np.array([1, 0]))
     assert np.allclose(qc.run(b, bitmask=[1, 1]), np.array([0, 0]))
 
+
 def test_qc_run_correlations(qvm, compiler):
     qc = get_qc('9q-square-qvm')
     p = Program()
@@ -459,6 +460,7 @@ def test_qc_run_correlations(qvm, compiler):
     b = qc.compile(p)
     assert qc.run(b, correlations=[0, 1]) == np.array([1])
     assert qc.run(b, bitmask=[1, 0], correlations=[0, 1]) == np.array([-1])
+
 
 def test_nq_qvm_qc():
     for n_qubits in [2, 4, 7, 19]:


### PR DESCRIPTION
Description
-----------

I'm toying around with adding some practical enhancements to the `run` method of the `QuantumComputer` object for typical transformations of bitstring outcomes.

For practical applications of quantum computers, we often want to just compute an expectation value or a collection of simultaneously measureable expectation values from the long list of bits we get out of the QPU. The new keyword argument `correlations` enables that:

```python
In [1]: from pyquil import get_qc, Program
   ...: from pyquil.gates import H, CNOT, MEASURE
   ...:
   ...: qvm = get_qc('2q-qvm')
   ...:
   ...: p = Program()
   ...: p += H(0)
   ...: p += CNOT(0 ,1)
   ...: ro = p.declare('ro', 'BIT', 2)
   ...: p += MEASURE(0, ro[0])
   ...: p += MEASURE(1, ro[1])
   ...: p.wrap_in_numshots_loop(10)
Out[1]: <pyquil.quil.Program at 0x116a0e908>

In [2]: qvm.run(p, correlations=[[1], [0]])
Out[2]:
array([[ 1,  1],
       [-1, -1],
       [-1, -1],
       [-1, -1],
       [ 1,  1],
       [-1, -1],
       [ 1,  1],
       [ 1,  1],
       [-1, -1],
       [-1, -1]])

In [3]: qvm.run(p, correlations=[0, 1])
Out[3]:
array([[1],
       [1],
       [1],
       [1],
       [1],
       [1],
       [1],
       [1],
       [1],
       [1]])

In [4]: np.mean(qvm.run(p, correlations=[0, 1]), axis=0)
Out[4]: array([[1.]])
```

In the above example, I'm essentially asking for the quantum computer to give me back just my estimate of the `ZZ` observable and nothing else.

We can get even more clever, and compute `ZZ`, `ZI`, and `IZ` all from the same set of bitstrings:

```python
In [5]: zz, zi, iz = np.mean(qvm.run(p, correlations=[[0, 1], [1], [0]]), axis=0)

In [6]: (zz, zi, iz)
Out[6]: (1.0, 0.2, 0.2)
```

Because we are preparing the bell state `|00> + |11>`, we expect `(1, 0, 0)`, but there is some error in `ZI` and `IZ` due to undersampling.

Finally, when performing readout symmetrization, we want to flip our qubit states before measurement, and then flip the resulting bits back accordingly. The `bitmask` parameter accomplishes the latter task:

```python
In [7]: zz, zi, iz = np.mean(qvm.run(p,
                             bitmask=[1, 0],
                             correlations=[[0, 1], [1], [0]]),
                             axis=0)

In [8]: (zz, zi, iz)
Out[8]: (-1.0, 0.2, -0.2)
```

Now our estimate for `ZZ` is -1 because we flipped the output of qubit 1, making it look like we prepared the state `|10> + |01>`.

**NOTE**: It is important to note that some or all of this functionality can eventually be subsumed by improvements to the QPU compilation & execution stack (e.g. support for classical operations). However, I think these are reasonable near-term additions to greatly simplify the common use cases for running on the QPU. 

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
