### PR TITLE
Deprecate positional usage of protoquil compilation arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Changelog
     function (@kylegulshen, gh-1043).
 -   All uses of `__future__` and `six` have been dropped (@karalekas, gh-1060).
 -   The `conftest.py` has been moved to the project root dir (@karalekas, gh-1064).
+-   Using `protoquil` as a positional argument to `qc.compile` has been deprecated,
+    and it is now a keyword-only argument (@karalekas, gh-1071).
     
 ### Bugfixes
 

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -78,7 +78,7 @@ The compiler connection is also available directly via the property ``qc.compile
 precise class of this object changes based on context (e.g., ``QPUCompiler``,
 ``QVMCompiler``), but it always conforms to the interface laid out by ``pyquil.api._qac``:
 
-* ``compiler.quil_to_native_quil(program, protoquil)``: This method converts a Quil program into
+* ``compiler.quil_to_native_quil(program, *, protoquil)``: This method converts a Quil program into
   native Quil, according to the ISA that the compiler is initialized with.  The input parameter is
   specified as a :py:class:`~pyquil.quil.Program` object. The optional ``protoquil`` keyword
   argument instructs the compiler to restrict both its input and output to protoquil (Quil code that

--- a/pyquil/api/_qac.py
+++ b/pyquil/api/_qac.py
@@ -33,7 +33,7 @@ class AbstractCompiler(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def quil_to_native_quil(self, program: Program, protoquil=None) -> Program:
+    def quil_to_native_quil(self, program: Program, *, protoquil=None) -> Program:
         """
         Compile an arbitrary quil program according to the ISA of target_device.
 

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -253,10 +253,15 @@ class QuantumComputer:
         return bitstring_dict
 
     @_record_call
-    def compile(self, program: Program,
-                to_native_gates: bool = True,
-                optimize: bool = True,
-                protoquil: bool = None) -> Union[BinaryExecutableResponse, PyQuilExecutableResponse]:
+    def compile(
+            self,
+            program: Program,
+            to_native_gates: bool = True,
+            optimize: bool = True,
+            protoquil_positional: bool = None,
+            *,
+            protoquil: bool = None,
+    ) -> Union[BinaryExecutableResponse, PyQuilExecutableResponse]:
         """
         A high-level interface to program compilation.
 
@@ -278,6 +283,17 @@ class QuantumComputer:
             to protoquil (executable on QPU). A value of ``None`` means defer to server.
         :return: An executable binary suitable for passing to :py:func:`QuantumComputer.run`.
         """
+        if protoquil_positional is not None:
+            warnings.warn('Setting "protoquil" via a positional argument has been deprecated and '
+                          'will be removed in a future release. Please set it as a keyword arg.',
+                          category=FutureWarning)
+            if protoquil is not None:
+                warnings.warn('You have set "protoquil" via both a positional and keyword argument.'
+                              'Continuing with the value of the keyword argument.',
+                              category=FutureWarning)
+            else:
+                protoquil = protoquil_positional
+
         if isinstance(self.qam, QPU):
             self.reset()
 

--- a/pyquil/tests/utils.py
+++ b/pyquil/tests/utils.py
@@ -13,7 +13,7 @@ class DummyCompiler(AbstractCompiler):
     def get_version_info(self):
         return {}
 
-    def quil_to_native_quil(self, program: Program, protoquil=None):
+    def quil_to_native_quil(self, program: Program, *, protoquil=None):
         return program
 
     def native_quil_to_executable(self, nq_program: Program):


### PR DESCRIPTION
Description
-----------

Slipped through my review of #940 (see https://github.com/rigetti/pyquil/pull/940#discussion_r305418586).

Checklist
---------

- [x] The above description motivates these changes.
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
