### PR TITLE
Test for presence of π in _expression_to_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Changelog
 -   Updated `examples/meyer_penny_game.py` with the correct path to the Meyer Penny
     game exercise in `docs/source/exercises.rst` (@appleby, gh-1045).
 -   Fixed the Slack Workspace invite link in the README (@amyfbrown, gh-1042).
+-   Fixed pretty printing of parameter expressions where π is involved
+    (@notmgsk, gh-1076).
 
 [v2.12](https://github.com/rigetti/pyquil/compare/v2.11.0...v2.12.0) (September 28, 2019)
 ----------------------------------------------------------------------------------------

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -502,6 +502,12 @@ def _expression_to_string(expression):
                 or expression.precedence == expression.op2.precedence
                 and expression.associates in ('right', 'both')):
             right = '(' + right + ')'
+        # If op2 is a float, it will maybe represented as a multiple
+        # of pi in right. If that is the case, then we need to take
+        # extra care to insert parens. See gh-943.
+        elif isinstance(expression.op2, float) and (
+                ("pi" in right and right != "pi")):
+            right = '(' + right + ')'
 
         return left + expression.operator + right
     elif isinstance(expression, Function):

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -1298,3 +1298,24 @@ def test_placeholders_preserves_modifiers():
     a = address_qubits(p)
 
     assert a[0].modifiers == g.modifiers
+
+
+def _eval_as_np_pi(exp):
+    eval(exp.replace('pi', repr(np.pi)).replace('theta[0]', "1"))
+
+
+def test_params_pi_and_precedence():
+    trivial_pi = "3 * theta[0] / (2 * pi)"
+    prog = Program(f"RX({trivial_pi}) 0")
+    exp = str(prog[0].params[0])
+    assert(_eval_as_np_pi(trivial_pi) == _eval_as_np_pi(exp))
+
+    less_trivial_pi = "3 * theta[0] * 2 / (pi)"
+    prog = Program(f"RX({trivial_pi}) 0")
+    exp = str(prog[0].params[0])
+    assert(_eval_as_np_pi(trivial_pi) == _eval_as_np_pi(exp))
+
+    more_less_trivial_pi = "3 / (theta[0] / (pi + 1)) / pi"
+    prog = Program(f"RX({trivial_pi}) 0")
+    exp = str(prog[0].params[0])
+    assert(_eval_as_np_pi(trivial_pi) == _eval_as_np_pi(exp))


### PR DESCRIPTION
Description
-----------

See #993 for details. This is a much simpler fix than I previously suggested.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [🤷‍♂] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [🤷‍♂] Functions and classes have useful sphinx-style docstrings.
- [🤷‍♂] (New Feature) The docs have been updated accordingly.
- [🤷‍♂] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
