### PR TITLE
Add __repr__ magic methods for PauliSum and PauliTerm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changelog
 -   `PauliSum` objects are now hashable (@ecpeterson, gh-1073).
 -   The code in `device.py` as been reorganized into a new `device` subdirectory
     in a completely backwards-compatible fashion (@karalekas, gh-1066).
+-   `PauliTerm` and `PauliSum` now have `__repr__` methods (@karalekas, gh-1080).
     
 ### Bugfixes
 

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -296,7 +296,7 @@ class PauliTerm(object):
         """
         return other + -1. * self
 
-    def __str__(self):
+    def __repr__(self):
         term_strs = []
         for index in self._ops.keys():
             term_strs.append("%s%s" % (self[index], index))
@@ -305,9 +305,6 @@ class PauliTerm(object):
             term_strs.append("I")
         out = "%s*%s" % (self.coefficient, '*'.join(term_strs))
         return out
-
-    def __repr__(self):
-        return str(self)
 
     def compact_str(self):
         """A string representation of the Pauli term that is more compact than ``str(term)``
@@ -537,11 +534,8 @@ class PauliSum(object):
     def __hash__(self):
         return hash(frozenset(self.terms))
 
-    def __str__(self):
-        return " + ".join([str(term) for term in self.terms])
-
     def __repr__(self):
-        return str(self)
+        return " + ".join([str(term) for term in self.terms])
 
     def __len__(self):
         """

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -306,6 +306,9 @@ class PauliTerm(object):
         out = "%s*%s" % (self.coefficient, '*'.join(term_strs))
         return out
 
+    def __repr__(self):
+        return str(self)
+
     def compact_str(self):
         """A string representation of the Pauli term that is more compact than ``str(term)``
 
@@ -536,6 +539,9 @@ class PauliSum(object):
 
     def __str__(self):
         return " + ".join([str(term) for term in self.terms])
+
+    def __repr__(self):
+        return str(self)
 
     def __len__(self):
         """


### PR DESCRIPTION
Description
-----------

Just uses the `__str__` magic method. Not sure if there is a reason for us to support both the `__str__` and the `compact_str` of a `PauliTerm`  -- maybe they should be merged?

```python
In [1]: from pyquil.paulis import sX

In [2]: sX(1)
Out[2]: (1+0j)*X1

In [3]: sX(1) * sX(2) + sX(1) * sX(2)
Out[3]: (2+0j)*X1*X2
```

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
