### PR TITLE
Discardable ancilla qubits when pretty printing wavefunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Changelog
     value (@tommy-moffat, gh-1114).
 -   Added type hints for all remaining top-level files (@karalekas, gh-1150).
 -   Added type annotations to the whole `pyquil.api` module (@karalekas, gh-1157).
--   Added the functionality to discard unwanted ancillia qubits from
+-   Added the functionality to discard unwanted ancilla qubits from
     pretty-printed bitstrings (@tommy-moffat, gh-1083).
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ Changelog
     and in `ISA`s (@ecpeterson, gh-1096, gh-1107, gh-1111).
 -   Removed the `tox.ini` and `readthedocs.yml` files (@karalekas, gh-1108).
 -   Type hints have been added to the `PauliSum` class (@rht, gh-1104).
+-   Added the functionality to discard unwanted ancilliary qubits from pretty-printed
+    bitstrings (@tommy-moffat, gh-1083).
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Changelog
     value (@tommy-moffat, gh-1114).
 -   Added type hints for all remaining top-level files (@karalekas, gh-1150).
 -   Added type annotations to the whole `pyquil.api` module (@karalekas, gh-1157).
+-   Added the functionality to discard unwanted ancillia qubits from
+    pretty-printed bitstrings (@tommy-moffat, gh-1083).
 
 ### Bugfixes
 
@@ -129,8 +131,6 @@ Changelog
     and in `ISA`s (@ecpeterson, gh-1096, gh-1107, gh-1111).
 -   Removed the `tox.ini` and `readthedocs.yml` files (@karalekas, gh-1108).
 -   Type hints have been added to the `PauliSum` class (@rht, gh-1104).
--   Added the functionality to discard unwanted ancilliary qubits from pretty-printed
-    bitstrings (@tommy-moffat, gh-1083).
 
 ### Bugfixes
 

--- a/pyquil/tests/test_wavefunction.py
+++ b/pyquil/tests/test_wavefunction.py
@@ -71,3 +71,20 @@ def test_sample(wvf):
     bitstrings = wvf.sample_bitstrings(n_samples=100)
     assert bitstrings.shape == (100, 2)
     assert [0, 0] in bitstrings
+
+
+def test_discardable_ancillae():
+    ro1 = "(0.71+0j)|0> + (0.71+0j)|1>"
+    ro2 = "(0.5+0j)|00> + (0.5+0j)|01> + (0.71+0j)|11>"
+    assert Wavefunction(1 / np.sqrt(2) * np.array(
+        [1., 1., 0., 0.]
+    )).pretty_print(ancillas=[1]) == ro1
+    assert Wavefunction(1 / np.sqrt(2) * np.array(
+        [1., 0., 1., 0.]
+    )).pretty_print(ancillas=[0]) == ro1
+    assert Wavefunction(1 / np.sqrt(2) * np.array(
+        [1., 0., 1., 0., 0., 0., 0., 0.]
+    )).pretty_print(ancillas=[0, 2]) == ro1
+    assert Wavefunction(1 / np.sqrt(2) * np.array(
+        [1 / np.sqrt(2), 1 / np.sqrt(2), 0., 0., 0., 1., 0., 0.]
+    )).pretty_print(ancillas=[1]) == ro2

--- a/pyquil/tests/test_wavefunction.py
+++ b/pyquil/tests/test_wavefunction.py
@@ -86,4 +86,5 @@ def test_discardable_ancillae():
     assert Wavefunction(1 / np.sqrt(2) * np.array(tests[0])).pretty_print(ancillae=[1]) == ro1
     assert Wavefunction(1 / np.sqrt(2) * np.array(tests[1])).pretty_print(ancillae=[0]) == ro1
     assert Wavefunction(1 / np.sqrt(2) * np.array(tests[2])).pretty_print(ancillae=[0, 2]) == ro1
+    assert Wavefunction(1 / np.sqrt(2) * np.array(tests[2])).pretty_print(ancillae=[2, 0]) == ro1
     assert Wavefunction(1 / np.sqrt(2) * np.array(tests[3])).pretty_print(ancillae=[1]) == ro2

--- a/pyquil/tests/test_wavefunction.py
+++ b/pyquil/tests/test_wavefunction.py
@@ -76,25 +76,14 @@ def test_sample(wvf):
 def test_discardable_ancillae():
     ro1 = "(0.71+0j)|0> + (0.71+0j)|1>"
     ro2 = "(0.5+0j)|00> + (0.5+0j)|01> + (0.71+0j)|11>"
-    assert (
-        Wavefunction(1 / np.sqrt(2) * np.array([1.0, 1.0, 0.0, 0.0])).pretty_print(ancillae=[1])
-        == ro1
-    )
-    assert (
-        Wavefunction(1 / np.sqrt(2) * np.array([1.0, 0.0, 1.0, 0.0])).pretty_print(ancillae=[0])
-        == ro1
-    )
-    assert (
-        Wavefunction(
-            1 / np.sqrt(2) * np.array([1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-        ).pretty_print(ancillae=[0, 2])
-        == ro1
-    )
-    assert (
-        Wavefunction(
-            1
-            / np.sqrt(2)
-            * np.array([1 / np.sqrt(2), 1 / np.sqrt(2), 0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
-        ).pretty_print(ancillae=[1])
-        == ro2
-    )
+    tests = [
+        [1.0, 1.0, 0.0, 0.0],
+        [1.0, 0.0, 1.0, 0.0],
+        [1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [1 / np.sqrt(2), 1 / np.sqrt(2), 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+    ]
+
+    assert Wavefunction(1 / np.sqrt(2) * np.array(tests[0])).pretty_print(ancillae=[1]) == ro1
+    assert Wavefunction(1 / np.sqrt(2) * np.array(tests[1])).pretty_print(ancillae=[0]) == ro1
+    assert Wavefunction(1 / np.sqrt(2) * np.array(tests[2])).pretty_print(ancillae=[0, 2]) == ro1
+    assert Wavefunction(1 / np.sqrt(2) * np.array(tests[3])).pretty_print(ancillae=[1]) == ro2

--- a/pyquil/tests/test_wavefunction.py
+++ b/pyquil/tests/test_wavefunction.py
@@ -76,15 +76,25 @@ def test_sample(wvf):
 def test_discardable_ancillae():
     ro1 = "(0.71+0j)|0> + (0.71+0j)|1>"
     ro2 = "(0.5+0j)|00> + (0.5+0j)|01> + (0.71+0j)|11>"
-    assert Wavefunction(1 / np.sqrt(2) * np.array(
-        [1., 1., 0., 0.]
-    )).pretty_print(ancillas=[1]) == ro1
-    assert Wavefunction(1 / np.sqrt(2) * np.array(
-        [1., 0., 1., 0.]
-    )).pretty_print(ancillas=[0]) == ro1
-    assert Wavefunction(1 / np.sqrt(2) * np.array(
-        [1., 0., 1., 0., 0., 0., 0., 0.]
-    )).pretty_print(ancillas=[0, 2]) == ro1
-    assert Wavefunction(1 / np.sqrt(2) * np.array(
-        [1 / np.sqrt(2), 1 / np.sqrt(2), 0., 0., 0., 1., 0., 0.]
-    )).pretty_print(ancillas=[1]) == ro2
+    assert (
+        Wavefunction(1 / np.sqrt(2) * np.array([1.0, 1.0, 0.0, 0.0])).pretty_print(ancillas=[1])
+        == ro1
+    )
+    assert (
+        Wavefunction(1 / np.sqrt(2) * np.array([1.0, 0.0, 1.0, 0.0])).pretty_print(ancillas=[0])
+        == ro1
+    )
+    assert (
+        Wavefunction(
+            1 / np.sqrt(2) * np.array([1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        ).pretty_print(ancillas=[0, 2])
+        == ro1
+    )
+    assert (
+        Wavefunction(
+            1
+            / np.sqrt(2)
+            * np.array([1 / np.sqrt(2), 1 / np.sqrt(2), 0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+        ).pretty_print(ancillas=[1])
+        == ro2
+    )

--- a/pyquil/tests/test_wavefunction.py
+++ b/pyquil/tests/test_wavefunction.py
@@ -77,17 +77,17 @@ def test_discardable_ancillae():
     ro1 = "(0.71+0j)|0> + (0.71+0j)|1>"
     ro2 = "(0.5+0j)|00> + (0.5+0j)|01> + (0.71+0j)|11>"
     assert (
-        Wavefunction(1 / np.sqrt(2) * np.array([1.0, 1.0, 0.0, 0.0])).pretty_print(ancillas=[1])
+        Wavefunction(1 / np.sqrt(2) * np.array([1.0, 1.0, 0.0, 0.0])).pretty_print(ancillae=[1])
         == ro1
     )
     assert (
-        Wavefunction(1 / np.sqrt(2) * np.array([1.0, 0.0, 1.0, 0.0])).pretty_print(ancillas=[0])
+        Wavefunction(1 / np.sqrt(2) * np.array([1.0, 0.0, 1.0, 0.0])).pretty_print(ancillae=[0])
         == ro1
     )
     assert (
         Wavefunction(
             1 / np.sqrt(2) * np.array([1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-        ).pretty_print(ancillas=[0, 2])
+        ).pretty_print(ancillae=[0, 2])
         == ro1
     )
     assert (
@@ -95,6 +95,6 @@ def test_discardable_ancillae():
             1
             / np.sqrt(2)
             * np.array([1 / np.sqrt(2), 1 / np.sqrt(2), 0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
-        ).pretty_print(ancillas=[1])
+        ).pretty_print(ancillae=[1])
         == ro2
     )

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -170,8 +170,6 @@ class Wavefunction(object):
         qubit_num = len(self)
         pp_string = ""
         for index, amplitude in enumerate(self.amplitudes):
-            if index & mask != 0 and not np.isclose(amplitude, 0):
-                raise ValueError("Specified ancilla was found to have non-zero amplitude.")
             outcome = get_bitstring_from_index(index, qubit_num)
             for ancilla in ancillae:
                 outcome = outcome[0 : qubit_num - ancilla - 1] + outcome[qubit_num - ancilla :]

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -158,7 +158,6 @@ class Wavefunction(object):
         :param int decimal_digits: The number of digits to truncate to.
         :param ancillae: The list of indices for ancilla qubits to omit.
         :return: A dict with outcomes as keys and complex amplitudes as values.
-        :rtype: str
         """
 
         if ancillae is None:

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -147,20 +147,17 @@ class Wavefunction(object):
                 outcome_dict[outcome] = prob
         return outcome_dict
 
-    def pretty_print(self, decimal_digits: int = 2, ancillae: Optional[Sequence[int]] = None) -> str:
+    def pretty_print(
+        self, decimal_digits: int = 2, ancillae: Optional[Sequence[int]] = None
+    ) -> str:
         """
         Returns a string repr of the wavefunction, ignoring all outcomes with approximately zero
         amplitude (up to a certain number of decimal digits) and rounding the amplitudes to
         decimal_digits.
 
         :param int decimal_digits: The number of digits to truncate to.
-<<<<<<< HEAD
-        :param ancillae: The list of indices for ancillary qubits to omit.
-        :return: A string representation of the wavefunction.
-=======
         :param ancillae: The list of indices for ancilla qubits to omit.
         :return: A dict with outcomes as keys and complex amplitudes as values.
->>>>>>> Typos and formatting
         :rtype: str
         """
 

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -154,23 +154,26 @@ class Wavefunction(object):
         decimal_digits.
 
         :param int decimal_digits: The number of digits to truncate to.
+<<<<<<< HEAD
         :param ancillae: The list of indices for ancillary qubits to omit.
         :return: A string representation of the wavefunction.
+=======
+        :param ancillae: The list of indices for ancilla qubits to omit.
+        :return: A dict with outcomes as keys and complex amplitudes as values.
+>>>>>>> Typos and formatting
         :rtype: str
         """
 
-        # Initialize bitmask as 1's complement of ancilla spec
         if ancillae is None:
             ancillae = []
-        mask = 0
-        for ancilla in ancillae:
-            mask |= 1 << ancilla
 
         outcome_dict = {}
         qubit_num = len(self)
         pp_string = ""
         for index, amplitude in enumerate(self.amplitudes):
             outcome = get_bitstring_from_index(index, qubit_num)
+
+            # Remove each ancilla qubit from the outcome bitstring
             for ancilla in ancillae:
                 outcome = outcome[0 : qubit_num - ancilla - 1] + outcome[qubit_num - ancilla :]
             amplitude = (

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -168,11 +168,10 @@ class Wavefunction(object):
         qubit_num = len(self)
         pp_string = ""
         for index, amplitude in enumerate(self.amplitudes):
-            outcome = get_bitstring_from_index(index, qubit_num)
-
-            # Remove each ancilla qubit from the outcome bitstring
-            for ancilla in ancillae:
-                outcome = outcome[0 : qubit_num - ancilla - 1] + outcome[qubit_num - ancilla :]
+            outcome = ""
+            for (i, c) in enumerate(get_bitstring_from_index(index, qubit_num)):
+                if qubit_num - i - 1 not in ancillae:  # don't include ancilla qubits
+                    outcome += c
             amplitude = (
                 round(amplitude.real, decimal_digits) + round(amplitude.imag, decimal_digits) * 1.0j
             )

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -164,20 +164,21 @@ class Wavefunction(object):
             ancillae = []
         mask = 0
         for ancilla in ancillae:
-            mask |= (1 << ancilla)
+            mask |= 1 << ancilla
 
         outcome_dict = {}
         qubit_num = len(self)
         pp_string = ""
         for index, amplitude in enumerate(self.amplitudes):
             if index & mask != 0 and not np.isclose(amplitude, 0):
-                raise ValueError('Specified ancilla was found to have non-zero amplitude.')
+                raise ValueError("Specified ancilla was found to have non-zero amplitude.")
             outcome = get_bitstring_from_index(index, qubit_num)
             for ancilla in ancillae:
-                outcome = outcome[0:qubit_num - ancilla - 1] + outcome[qubit_num - ancilla:]
-            amplitude = round(amplitude.real, decimal_digits) + \
-                round(amplitude.imag, decimal_digits) * 1.j
-            if amplitude != 0.:
+                outcome = outcome[0 : qubit_num - ancilla - 1] + outcome[qubit_num - ancilla :]
+            amplitude = (
+                round(amplitude.real, decimal_digits) + round(amplitude.imag, decimal_digits) * 1.0j
+            )
+            if amplitude != 0.0:
                 outcome_dict[outcome] = amplitude
                 pp_string += str(amplitude) + "|{}> + ".format(outcome)
         if len(pp_string) >= 3:


### PR DESCRIPTION
Description
-----------

Added the functionality to discard unwanted ancilliary qubits from pretty-printed bitstrings. Fixes issue #186 

To be reviewed by @stylewarning 

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
