### PR TITLE
Typo

### DIFF
--- a/docs/source/migration.ipynb
+++ b/docs/source/migration.ipynb
@@ -150,9 +150,9 @@
     "And we wish to measure the following quantum observables $O$\n",
     " - the expected value of the 0th bit $O=(1-Z_0)/2$\n",
     " - the expected value of the 1st bit $O=(1-Z_1)/2$\n",
-    " - the expected value of the exclusive or (XOR) between the two qubits $O=(1-ZZ)/2$\n",
+    " - the expected value of the exclusive or (XOR) between the two qubits $O=(1-Z_0Z_1)/2$\n",
     " \n",
-    "**Exercise for the reader:** convince yourself that $(1-ZZ)/2$ is the XOR function"
+    "**Exercise for the reader:** convince yourself that $(1-Z_0Z_1)/2$ is the XOR function"
    ]
   },
   {


### PR DESCRIPTION
Index on Z's dropped. Added them.

Description
-----------

No index on Z's in expectation value of XOR function

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).