### PR TITLE
Likely typo

### DIFF
--- a/docs/source/migration3-declare.ipynb
+++ b/docs/source/migration3-declare.ipynb
@@ -1,4 +1,4 @@
-{
+p{
  "cells": [
   {
    "cell_type": "markdown",
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Do an optimization (the old way)\n",
+    "## Do an optimization (the new way)\n",
     "\n",
     "Instead of doing a full grid search, we will employ a classical optimizer to find the best parameter values. Here we use scipy to find the theta that results in sampling the most `1`s in our resultant bitstrings."
    ]


### PR DESCRIPTION
Two methods described as 'the old way'

Description
-----------

Two methods described as 'the old way'

Later method corrected to 'the new way'

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
