### PR TITLE
Remove unused code for talking to quilc over HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Changelog
 -   Updated `examples/meyer_penny_game.py` with the correct path to the Meyer Penny
     game exercise in `docs/source/exercises.rst` (@appleby, gh-1045).
 -   Fixed the Slack Workspace invite link in the README (@amyfbrown, gh-1042).
+-   Remove some stale code for pulling quilc version info (@notmgsk, gh-1089).
 
 [v2.12](https://github.com/rigetti/pyquil/compare/v2.11.0...v2.12.0) (September 28, 2019)
 ----------------------------------------------------------------------------------------

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -392,11 +392,3 @@ class ForestConnection:
         response = post_json(self.session, self.sync_endpoint + "/", payload)
         unpacked_response = response.json()
         return unpacked_response
-
-    def _quilc_get_version_info(self) -> dict:
-        """
-        Return version information for quilc.
-
-        :return: Dictionary with version information
-        """
-        return get_json(self.session, self.sync_endpoint + '/version')

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -260,26 +260,6 @@ def qvm_run_payload(quil_program, classical_addresses, trials,
     return payload
 
 
-def quilc_compile_payload(quil_program, isa, specs):
-    """REST payload for :py:func:`ForestConnection._quilc_compile`"""
-    if not quil_program:
-        raise ValueError("You have attempted to compile an empty program."
-                         " Please provide an actual program.")
-    if not isinstance(quil_program, Program):
-        raise TypeError("quil_program must be a Program object.")
-    if not isinstance(isa, ISA):
-        raise TypeError("isa must be an ISA object.")
-    if not isinstance(specs, Specs):
-        raise TypeError("specs must be a Specs object.")
-
-    payload = {"uncompiled-quil": quil_program.out(),
-               "target-device": {
-                   "isa": isa.to_dict(),
-                   "specs": specs.to_dict()}}
-
-    return payload
-
-
 class ForestConnection:
     @_record_call
     def __init__(self, sync_endpoint=None, compiler_endpoint=None, forest_cloud_endpoint=None):
@@ -380,15 +360,3 @@ class ForestConnection:
         except ValueError:
             raise TypeError(f'Malformed version string returned by the QVM: {response.text}')
         return qvm_version
-
-    def _quilc_compile(self, quil_program, isa, specs):
-        """
-        Sends a quilc job to Forest.
-
-        Users should use :py:func:`LocalCompiler.quil_to_native_quil` instead of calling this
-        directly.
-        """
-        payload = quilc_compile_payload(quil_program, isa, specs)
-        response = post_json(self.session, self.sync_endpoint + "/", payload)
-        unpacked_response = response.json()
-        return unpacked_response


### PR DESCRIPTION
Since removing HTTP from `quilc`, the `ForestConnection._quilc_get_version_info()` function has been broken. Thankfully nothing uses it.
