### PR TITLE
Use TomographyExperiment for measure_observables args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Changelog
 -   `PauliTerm` and `PauliSum` now have `__repr__` methods (@karalekas, gh-1080).
 -   The experiment-schema-related code in `operator_estimation.py` has been moved
     into a new `experiment` subdirectory (@karalekas, gh-1084).
+-   The keyword arguments to `measure_observables` are now captured as part of
+    the `TomographyExperiment` class (@karalekas, gh-1090).
     
 ### Bugfixes
 

--- a/pyquil/experiment/__init__.py
+++ b/pyquil/experiment/__init__.py
@@ -24,13 +24,14 @@ import logging
 import warnings
 from json import JSONEncoder
 from enum import IntEnum
-from typing import List, Union
+from typing import List, Union, Optional
 
 from pyquil import Program
 from pyquil.experiment._result import ExperimentResult
 from pyquil.experiment._setting import (_OneQState, _pauli_to_product_state, ExperimentSetting,
                                         SIC0, SIC1, SIC2, SIC3, TensorProductState, minusX, minusY,
                                         minusZ, plusX, plusY, plusZ, zeros_state)
+from pyquil.quilbase import Reset
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ def _abbrev_program(program: Program, max_len=10):
         program_lines = (program_lines[:first_n] + [f'... {excluded} instrs not shown ...']
                          + program_lines[-last_n:])
 
-    return '; '.join(program_lines)
+    return '   ' + '\n   '.join(program_lines)
 
 
 class TomographyExperiment:
@@ -85,12 +86,37 @@ class TomographyExperiment:
     This class will not group settings for you. Please see :py:func:`group_experiments` for
     a function that will automatically process a TomographyExperiment to group Experiments sharing
     a TPB.
+
+    :ivar settings: The collection of ExperimentSetting objects that define this experiment.
+    :ivar program: The main program body of this experiment. Also determines the ``shots``
+        and ``reset`` instance variables. The ``shots`` instance variable is the number of
+        shots to take per ExperimentSetting. The ``reset`` instance variable is whether to
+        actively reset qubits instead of waiting several times the coherence length for qubits
+        to decay to ``|0>`` naturally. Setting this to True is much faster but there is a ~1%
+        error per qubit in the reset operation. Thermal noise from "traditional" reset is not
+        routinely characterized but is of the same order.
+    :ivar symmetrization: the level of readout symmetrization to perform for the estimation
+        and optional calibration of each observable. The following integer levels, encapsulated in
+        the ``SymmetrizationLevel`` integer enum, are currently supported:
+
+        * -1 -- exhaustive symmetrization uses every possible combination of flips
+        * 0 -- no symmetrization
+        * 1 -- symmetrization using an orthogonal array (OA) with strength 1
+        * 2 -- symmetrization using an orthogonal array (OA) with strength 2
+        * 3 -- symmetrization using an orthogonal array (OA) with strength 3
+
+        Note that (default) exhaustive symmetrization requires a number of QPU calls exponential in
+        the number of qubits in the union of the support of the observables in any group of settings
+        in ``tomo_experiment``; the number of shots may need to be increased to accommodate this.
+        see :func:`run_symmetrized_readout` in api._quantum_computer for more information.
     """
 
     def __init__(self,
                  settings: Union[List[ExperimentSetting], List[List[ExperimentSetting]]],
                  program: Program,
-                 qubits: List[int] = None):
+                 qubits: Optional[List[int]] = None,
+                 *,
+                 symmetrization: int = SymmetrizationLevel.EXHAUSTIVE):
         if len(settings) == 0:
             settings = []
         else:
@@ -104,6 +130,15 @@ class TomographyExperiment:
             warnings.warn("The 'qubits' parameter has been deprecated and will be removed"
                           "in a future release of pyquil")
         self.qubits = qubits
+        self.symmetrization = SymmetrizationLevel(symmetrization)
+        self.shots = self.program.num_shots
+
+        if 'RESET' in self.program.out():
+            self.reset = True
+            # trim the RESET from the program because in measure_observables it is re-added
+            self.program = Program([inst for inst in self.program if not isinstance(inst, Reset)])
+        else:
+            self.reset = False
 
     def __len__(self):
         return len(self._settings)
@@ -166,13 +201,20 @@ class TomographyExperiment:
             first_n = abbrev_after // 2
             last_n = abbrev_after - first_n
             excluded = len(setting_strs) - abbrev_after
-            setting_strs = (setting_strs[:first_n] + [f'... {excluded} not shown ...',
-                                                      '... use e.settings_string() for all ...']
+            setting_strs = (setting_strs[:first_n] + [f'... {excluded} settings not shown ...']
                             + setting_strs[-last_n:])
-        return '\n'.join(setting_strs)
+        return '   ' + '\n   '.join(setting_strs)
 
-    def __str__(self):
-        return _abbrev_program(self.program) + '\n' + self.settings_string(abbrev_after=20)
+    def __repr__(self):
+        string = f'shots: {self.shots}\n'
+        if self.reset:
+            string += f'active reset: enabled\n'
+        else:
+            string += f'active reset: disabled\n'
+        string += f'symmetrization: {self.symmetrization} ({self.symmetrization.name.lower()})\n'
+        string += f'program:\n{_abbrev_program(self.program)}\n'
+        string += f'settings:\n{self.settings_string(abbrev_after=20)}'
+        return string
 
     def serializable(self):
         return {

--- a/pyquil/experiment/tests/test_experiment.py
+++ b/pyquil/experiment/tests/test_experiment.py
@@ -5,10 +5,11 @@ import numpy as np
 import pytest
 
 from pyquil import Program
-from pyquil.experiment import (ExperimentSetting, SIC0, SIC1, SIC2, SIC3, TensorProductState,
-                               TomographyExperiment, plusX, minusX, plusY, minusY, plusZ, minusZ,
-                               read_json, to_json, zeros_state, ExperimentResult)
-from pyquil.gates import X, Y
+from pyquil.experiment import (_remove_reset_from_program, ExperimentSetting, SIC0, SIC1, SIC2,
+                               SIC3, TensorProductState, TomographyExperiment, plusX, minusX,
+                               plusY, minusY, plusZ, minusZ, read_json, to_json, zeros_state,
+                               ExperimentResult)
+from pyquil.gates import RESET, X, Y
 from pyquil.paulis import sI, sX, sY, sZ
 
 
@@ -155,3 +156,25 @@ def test_experiment_result():
         total_counts=100,
     )
     assert str(er) == 'X0_0→(1+0j)*Z0: 0.9 +- 0.05'
+
+
+DEFGATE_X = """
+DEFGATE XGATE:
+    0, 1
+    1, 0
+"""
+
+TRIMMED_PROG = """
+DEFGATE XGATE:
+    0, 1
+    1, 0
+
+X 0
+"""
+
+def test_remove_reset_from_program():
+    p = Program(DEFGATE_X)
+    p += RESET()
+    p += X(0)
+    new_p = _remove_reset_from_program(p)
+    assert '\n' + new_p.out() == TRIMMED_PROG

--- a/pyquil/experiment/tests/test_experiment.py
+++ b/pyquil/experiment/tests/test_experiment.py
@@ -101,8 +101,10 @@ def test_tomo_experiment():
 
 def test_tomo_experiment_pre_grouped():
     expts = [
-        [ExperimentSetting(TensorProductState(), sX(0) * sI(1)), ExperimentSetting(TensorProductState(), sI(0) * sX(1))],
-        [ExperimentSetting(TensorProductState(), sZ(0) * sI(1)), ExperimentSetting(TensorProductState(), sI(0) * sZ(1))],
+        [ExperimentSetting(TensorProductState(), sX(0) * sI(1)),
+         ExperimentSetting(TensorProductState(), sI(0) * sX(1))],
+        [ExperimentSetting(TensorProductState(), sZ(0) * sI(1)),
+         ExperimentSetting(TensorProductState(), sI(0) * sZ(1))],
     ]
 
     suite = TomographyExperiment(
@@ -125,8 +127,10 @@ def test_tomo_experiment_empty():
 
 def test_experiment_deser(tmpdir):
     expts = [
-        [ExperimentSetting(TensorProductState(), sX(0) * sI(1)), ExperimentSetting(TensorProductState(), sI(0) * sX(1))],
-        [ExperimentSetting(TensorProductState(), sZ(0) * sI(1)), ExperimentSetting(TensorProductState(), sI(0) * sZ(1))],
+        [ExperimentSetting(TensorProductState(), sX(0) * sI(1)),
+         ExperimentSetting(TensorProductState(), sI(0) * sX(1))],
+        [ExperimentSetting(TensorProductState(), sZ(0) * sI(1)),
+         ExperimentSetting(TensorProductState(), sI(0) * sZ(1))],
     ]
 
     suite = TomographyExperiment(
@@ -164,6 +168,7 @@ DEFGATE XGATE:
     1, 0
 """
 
+
 TRIMMED_PROG = """
 DEFGATE XGATE:
     0, 1
@@ -171,6 +176,7 @@ DEFGATE XGATE:
 
 X 0
 """
+
 
 def test_remove_reset_from_program():
     p = Program(DEFGATE_X)

--- a/pyquil/experiment/tests/test_experiment.py
+++ b/pyquil/experiment/tests/test_experiment.py
@@ -12,6 +12,16 @@ from pyquil.gates import X, Y
 from pyquil.paulis import sI, sX, sY, sZ
 
 
+EXPERIMENT_REPR = """
+shots: 1
+active reset: disabled
+symmetrization: -1 (exhaustive)
+program:
+   X 0
+   Y 1
+"""
+
+
 def _generate_random_states(n_qubits, n_terms):
     oneq_states = [SIC0, SIC1, SIC2, SIC3, plusX, minusX, plusY, minusY, plusZ, minusZ]
     all_s_inds = np.random.randint(len(oneq_states), size=(n_terms, n_qubits))
@@ -84,8 +94,8 @@ def test_tomo_experiment():
         assert len(e2) == 1
         e2 = e2[0]
         assert e1 == e2
-    prog_str = str(suite).splitlines()[0]
-    assert prog_str == 'X 0; Y 1'
+    prog_str = str(suite).splitlines()[3:5]
+    assert prog_str == EXPERIMENT_REPR.splitlines()[4:6]
 
 
 def test_tomo_experiment_pre_grouped():
@@ -102,8 +112,8 @@ def test_tomo_experiment_pre_grouped():
     for es1, es2 in zip(expts, suite):
         for e1, e2 in zip(es1, es2):
             assert e1 == e2
-    prog_str = str(suite).splitlines()[0]
-    assert prog_str == 'X 0; Y 1'
+    prog_str = str(suite).splitlines()[3:5]
+    assert prog_str == EXPERIMENT_REPR.splitlines()[4:6]
 
 
 def test_tomo_experiment_empty():

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -380,11 +380,12 @@ def _generate_experiment_programs(
     return programs, meas_qubits
 
 
-def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperiment,
-                        n_shots: int = 10000,
+def measure_observables(qc: QuantumComputer,
+                        tomo_experiment: TomographyExperiment,
+                        n_shots: Optional[int] = None,
                         progress_callback: Optional[Callable[[int, int], None]] = None,
-                        active_reset: bool = False,
-                        symmetrize_readout: int = SymmetrizationLevel.EXHAUSTIVE,
+                        active_reset: Optional[bool] = None,
+                        symmetrize_readout: Optional[Union[int, str]] = 'None',
                         calibrate_readout: Optional[str] = 'plus-eig',
                         readout_symmetrize: Optional[str] = None):
     """
@@ -392,59 +393,79 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
 
     :param qc: A QuantumComputer which can run quantum programs
     :param tomo_experiment: A suite of tomographic observables to measure
-    :param n_shots: The number of shots to take per ExperimentSetting
     :param progress_callback: If not None, this function is called each time a group of
         settings is run with arguments ``f(i, len(tomo_experiment)`` such that the progress
         is ``i / len(tomo_experiment)``.
-    :param active_reset: Whether to actively reset qubits instead of waiting several
-        times the coherence length for qubits to decay to ``|0>`` naturally. Setting this
-        to True is much faster but there is a ~1% error per qubit in the reset operation.
-        Thermal noise from "traditional" reset is not routinely characterized but is of the same
-        order.
-    :param symmetrize_readout: the level of readout symmetrization to perform for the estimation
-        and optional calibration of each observable. The following integer levels, encapsulated in
-        the ``SymmetrizationLevel`` integer enum, are currently supported:
-
-        * -1 -- exhaustive symmetrization uses every possible combination of flips
-        * 0 -- no symmetrization
-        * 1 -- symmetrization using an orthogonal array (OA) with strength 1
-        * 2 -- symmetrization using an orthogonal array (OA) with strength 2
-        * 3 -- symmetrization using an orthogonal array (OA) with strength 3
-
-        Note that (default) exhaustive symmetrization requires a number of QPU calls exponential in
-        the number of qubits in the union of the support of the observables in any group of settings
-        in ``tomo_experiment``; the number of shots may need to be increased to accommodate this.
-        see :func:`run_symmetrized_readout` in api._quantum_computer for more information.
     :param calibrate_readout: Method used to calibrate the readout results. Currently, the only
         method supported is normalizing against the operator's expectation value in its +1
         eigenstate, which can be specified by setting this variable to 'plus-eig' (default value).
         The preceding symmetrization and this step together yield a more accurate estimation of
         the observable. Set to `None` if no calibration is desired.
     """
-    if readout_symmetrize is not None:
-        warnings.warn("'readout_symmetrize' has been renamed to 'symmetrize_readout'",
-                      DeprecationWarning)
-        symmetrize_readout = readout_symmetrize
+    shots = tomo_experiment.shots
+    symmetrization = tomo_experiment.symmetrization
+    reset = tomo_experiment.reset
 
-    if symmetrize_readout is None:
-        symmetrize_readout = SymmetrizationLevel.NONE
-        warnings.warn("'symmetrize_readout' should now be an int, 0 instead of None.",
-                      DeprecationWarning)
-    elif symmetrize_readout == 'exhaustive':
-        symmetrize_readout = SymmetrizationLevel.EXHAUSTIVE
-        warnings.warn("'symmetrize_readout' should now be an int, -1 instead of 'exhaustive'.",
-                      DeprecationWarning)
-    elif symmetrize_readout not in list(SymmetrizationLevel):
-        raise Exception(f'The symmetrize_readout argument must be one of the following ints '
-                        f'{list(SymmetrizationLevel)}')
+    if n_shots is not None:
+        warnings.warn("'n_shots' has been deprecated; if you want to set the number of shots "
+                      "for this run of measure_observables please provide the number to "
+                      "Program.wrap_in_numshots_loop() for the Quil program that you provide "
+                      "when creating your TomographyExperiment object. For now, this value will "
+                      "override that in the TomographyExperiment, but eventually this keyword "
+                      "argument will be removed.",
+                      FutureWarning)
+        shots = n_shots
+    else:
+        if shots == 1:
+            warnings.warn("'n_shots' has been deprecated; if you want to set the number of shots "
+                          "for this run of measure_observables please provide the number to "
+                          "Program.wrap_in_numshots_loop() for the Quil program that you provide "
+                          "when creating your TomographyExperiment object. It looks like your "
+                          "TomographyExperiment object has shots = 1, so for now we will change "
+                          "that to 10000, which was the previous default value.",
+                          FutureWarning)
+            shots = 10000
+
+    if active_reset is not None:
+        warnings.warn("'active_reset' has been deprecated; if you want to enable active qubit "
+                      "reset please provide a Quil program that has a RESET instruction in it when "
+                      "creating your TomographyExperiment object. For now, this value will "
+                      "override that in the TomographyExperiment, but eventually this keyword "
+                      "argument will be removed.",
+                      FutureWarning)
+        reset = active_reset
+
+    if readout_symmetrize is not None and symmetrize_readout != 'None':
+        raise ValueError("'readout_symmetrize' and 'symmetrize_readout' are conflicting keyword "
+                         "arguments -- please provide only one.")
+
+    if readout_symmetrize is not None:
+        warnings.warn("'readout_symmetrize' has been deprecated; please provide the symmetrization "
+                      "level when creating your TomographyExperiment object. For now, this value "
+                      "will override that in the TomographyExperiment, but eventually this keyword "
+                      "argument will be removed.",
+                      FutureWarning)
+        symmetrization = SymmetrizationLevel(readout_symmetrize)
+
+    if symmetrize_readout != 'None':
+        warnings.warn("'symmetrize_readout' has been deprecated; please provide the symmetrization "
+                      "level when creating your TomographyExperiment object. For now, this value "
+                      "will override that in the TomographyExperiment, but eventually this keyword "
+                      "argument will be removed.",
+                      FutureWarning)
+        if symmetrize_readout is None:
+            symmetrize_readout = SymmetrizationLevel.NONE
+        elif symmetrize_readout == 'exhaustive':
+            symmetrize_readout = SymmetrizationLevel.EXHAUSTIVE
+        symmetrization = SymmetrizationLevel(symmetrize_readout)
 
     # calibration readout only works with symmetrization turned on
-    if calibrate_readout is not None and symmetrize_readout != SymmetrizationLevel.EXHAUSTIVE:
+    if calibrate_readout is not None and symmetrization != SymmetrizationLevel.EXHAUSTIVE:
         raise ValueError("Readout calibration only currently works with exhaustive readout "
                          "symmetrization turned on.")
 
     # generate programs for each group of simultaneous settings.
-    programs, meas_qubits = _generate_experiment_programs(tomo_experiment, active_reset)
+    programs, meas_qubits = _generate_experiment_programs(tomo_experiment, reset)
 
     for i, (prog, qubits, settings) in enumerate(zip(programs, meas_qubits, tomo_experiment)):
         log.info(f"Collecting bitstrings for the {len(settings)} settings: {settings}")
@@ -453,7 +474,7 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
         # identity, i.e. weight=0. We handle this specially below.
         if len(qubits) > 0:
             # obtain (optionally symmetrized) bitstring results for all of the qubits
-            bitstrings = qc.run_symmetrized_readout(prog, n_shots, symmetrize_readout, qubits)
+            bitstrings = qc.run_symmetrized_readout(prog, shots, symmetrization, qubits)
 
         if progress_callback is not None:
             progress_callback(i, len(tomo_experiment))
@@ -461,7 +482,7 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
         # Post-process
         # Inner loop over the grouped settings. They only differ in which qubits' measurements
         # we include in the post-processing. For example, if `settings` is Z1, Z2, Z1Z2 and we
-        # measure (n_shots, n_qubits=2) obs_strings then the full operator value involves selecting
+        # measure (shots, n_qubits=2) obs_strings then the full operator value involves selecting
         # either the first column, second column, or both and multiplying along the row.
         for setting in settings:
             # Get the term's coefficient so we can multiply it in later.
@@ -477,14 +498,14 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                     setting=setting,
                     expectation=coeff,
                     std_err=0.0,
-                    total_counts=n_shots,
+                    total_counts=shots,
                 )
                 continue
 
             # Obtain statistics from result of experiment
             obs_mean, obs_var = _stats_from_measurements(bitstrings,
                                                          {q: idx for idx, q in enumerate(qubits)},
-                                                         setting, n_shots, coeff)
+                                                         setting, shots, coeff)
 
             if calibrate_readout == 'plus-eig':
                 # Readout calibration
@@ -494,12 +515,15 @@ def measure_observables(qc: QuantumComputer, tomo_experiment: TomographyExperime
                 calibr_qub_dict = {q: idx for idx, q in enumerate(calibr_qubs)}
 
                 # Perform symmetrization on the calibration program
-                calibr_results = qc.run_symmetrized_readout(calibr_prog, n_shots, -1, calibr_qubs)
+                calibr_results = qc.run_symmetrized_readout(calibr_prog,
+                                                            shots,
+                                                            SymmetrizationLevel.EXHAUSTIVE,
+                                                            calibr_qubs)
 
                 # Obtain statistics from the measurement process
                 obs_calibr_mean, obs_calibr_var = _stats_from_measurements(calibr_results,
                                                                            calibr_qub_dict,
-                                                                           setting, n_shots)
+                                                                           setting, shots)
                 # Calibrate the readout results
                 corrected_mean = obs_mean / obs_calibr_mean
                 corrected_var = ratio_variance(obs_mean, obs_var, obs_calibr_mean, obs_calibr_var)


### PR DESCRIPTION
Description
-----------

Rather than having a proliferation of keyword args in `measure_observables`, we can use the `TomographyExperiment` to capture everything we want to do. There's some really ugly deprecation code, but I did what I had to do to make it completely backwards compatible. This change enables future work on parametric-compilation-enabled observable estimation.

Printing out a `TomographyExperiment` now gives you something like this:
```yaml
shots: 1000
active reset: enabled
symmetrization: -1 (exhaustive)
program:
   H 1
   CNOT 2 1
   DAGGER T 1
   CNOT 0 1
   T 1
   ... 12 instrs not shown ...
   T 0
   S 2
   MEASURE 0
   MEASURE 1
   MEASURE 2
settings:
   0: Z0_0 * Z0_1→(1+0j)*X0X1
   1: Z0_0 * Z0_1→(1+0j)*X0X1
   2: Z0_0 * Z0_1→(1+0j)*X0X1
   3: Z0_0 * Z0_1→(1+0j)*X0X1
   4: Z0_0 * Z0_1→(1+0j)*X0X1
   5: Z0_0 * Z0_1→(1+0j)*X0X1
   6: Z0_0 * Z0_1→(1+0j)*X0X1
   7: Z0_0 * Z0_1→(1+0j)*X0X1
   8: Z0_0 * Z0_1→(1+0j)*X0X1
   9: Z0_0 * Z0_1→(1+0j)*X0X1
   ... 80 settings not shown ...
   90: Z0_0 * Z0_1→(1+0j)*X0X1
   91: Z0_0 * Z0_1→(1+0j)*X0X1
   92: Z0_0 * Z0_1→(1+0j)*X0X1
   93: Z0_0 * Z0_1→(1+0j)*X0X1
   94: Z0_0 * Z0_1→(1+0j)*X0X1
   95: Z0_0 * Z0_1→(1+0j)*X0X1
   96: Z0_0 * Z0_1→(1+0j)*X0X1
   97: Z0_0 * Z0_1→(1+0j)*X0X1
   98: Z0_0 * Z0_1→(1+0j)*X0X1
   99: Z0_0 * Z0_1→(1+0j)*X0X1
```

I'll finish squashing all the warnings in `test_operator_estimation.py`.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
