### PR TITLE
XY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog
     to `entrypoint.sh` (@karalekas, gh-1105).
 -   Added a `make typecheck` target to run mypy over a subset of the pyquil sources,
     and enabled typechecks in gitlab CI (@appleby, gh-1098).
+-   Added support for the `XY` gate family in `Program`s and in ISAs (@ecpeterson, gh-1096).
 
 ### Bugfixes
 

--- a/pyquil/device/_isa.py
+++ b/pyquil/device/_isa.py
@@ -180,9 +180,6 @@ def gates_in_isa(isa):
         if "ISWAP" in edge_type:
             gates.append(Gate("ISWAP", [], targets))
             gates.append(Gate("ISWAP", [], targets[::-1]))
-        if "XYhalves" in edge_type:
-            gates.append(Gate("XY", [np.pi/2], targets))
-            gates.append(Gate("XY", [np.pi/2], targets[::-1]))
         if "CPHASE" in edge_type:
             gates.append(Gate("CPHASE", [THETA], targets))
             gates.append(Gate("CPHASE", [THETA], targets[::-1]))

--- a/pyquil/device/_isa.py
+++ b/pyquil/device/_isa.py
@@ -177,20 +177,25 @@ def gates_in_isa(isa):
         if "CZ" in edge_type:
             gates.append(Gate("CZ", [], targets))
             gates.append(Gate("CZ", [], targets[::-1]))
+            continue
         if "ISWAP" in edge_type:
             gates.append(Gate("ISWAP", [], targets))
             gates.append(Gate("ISWAP", [], targets[::-1]))
+            continue
         if "CPHASE" in edge_type:
             gates.append(Gate("CPHASE", [THETA], targets))
             gates.append(Gate("CPHASE", [THETA], targets[::-1]))
+            continue
         if "XY" in edge_type:
             gates.append(Gate("XY", [THETA], targets))
             gates.append(Gate("XY", [THETA], targets[::-1]))
+            continue
         if "WILDCARD" in e.type:
             gates.append(Gate("_", "_", targets))
             gates.append(Gate("_", "_", targets[::-1]))
-        else:  # pragma no coverage
-            raise ValueError("Unknown edge type: {}".format(e.type))
+            continue
+
+        raise ValueError("Unknown edge type: {}".format(e.type))
     return gates
 
 

--- a/pyquil/device/_isa.py
+++ b/pyquil/device/_isa.py
@@ -153,7 +153,7 @@ def gates_in_isa(isa):
         if q.dead:
             # TODO: dead qubits may in the future lead to some implicit re-indexing
             continue
-        if q.type in ["Xhalves"]:
+        if q.type == "Xhalves":
             gates.extend([
                 Gate("I", [], [unpack_qubit(q.id)]),
                 Gate("RX", [np.pi / 2], [unpack_qubit(q.id)]),
@@ -162,6 +162,10 @@ def gates_in_isa(isa):
                 Gate("RX", [-np.pi], [unpack_qubit(q.id)]),
                 Gate("RZ", [THETA], [unpack_qubit(q.id)]),
             ])
+        elif q.type == "WILDCARD":
+            gates.extend([
+                Gate("_", "_", [unpack_qubit(q.id)])
+            ])
         else:  # pragma no coverage
             raise ValueError("Unknown qubit type: {}".format(q.type))
 
@@ -169,12 +173,25 @@ def gates_in_isa(isa):
         if e.dead:
             continue
         targets = [unpack_qubit(t) for t in e.targets]
-        if e.type in ["CZ", "ISWAP"]:
-            gates.append(Gate(e.type, [], targets))
-            gates.append(Gate(e.type, [], targets[::-1]))
-        elif e.type in ["CPHASE"]:
-            gates.append(Gate(e.type, [THETA], targets))
-            gates.append(Gate(e.type, [THETA], targets[::-1]))
+        edge_type = e.type if isinstance(e.type, list) else [e.type]
+        if "CZ" in edge_type:
+            gates.append(Gate("CZ", [], targets))
+            gates.append(Gate("CZ", [], targets[::-1]))
+        if "ISWAP" in edge_type:
+            gates.append(Gate("ISWAP", [], targets))
+            gates.append(Gate("ISWAP", [], targets[::-1]))
+        if "XYhalves" in edge_type:
+            gates.append(Gate("XY", [np.pi/2], targets))
+            gates.append(Gate("XY", [np.pi/2], targets[::-1]))
+        if "CPHASE" in edge_type:
+            gates.append(Gate("CPHASE", [THETA], targets))
+            gates.append(Gate("CPHASE", [THETA], targets[::-1]))
+        if "XY" in edge_type:
+            gates.append(Gate("XY", [THETA], targets))
+            gates.append(Gate("XY", [THETA], targets[::-1]))
+        if e.type in ["WILDCARD"]:
+            gates.append(Gate("_", "_", targets))
+            gates.append(Gate("_", "_", targets[::-1]))
         else:  # pragma no coverage
             raise ValueError("Unknown edge type: {}".format(e.type))
     return gates

--- a/pyquil/device/_isa.py
+++ b/pyquil/device/_isa.py
@@ -189,7 +189,7 @@ def gates_in_isa(isa):
         if "XY" in edge_type:
             gates.append(Gate("XY", [THETA], targets))
             gates.append(Gate("XY", [THETA], targets[::-1]))
-        if e.type in ["WILDCARD"]:
+        if "WILDCARD" in e.type:
             gates.append(Gate("_", "_", targets))
             gates.append(Gate("_", "_", targets[::-1]))
         else:  # pragma no coverage

--- a/pyquil/device/_main.py
+++ b/pyquil/device/_main.py
@@ -138,7 +138,7 @@ class Device(AbstractDevice):
                 return default
 
             array = getter()
-            if index < len(array):
+            if (isinstance(index, int) and index < len(array)) or index in array:
                 return array[index]
             else:
                 return default

--- a/pyquil/device/_main.py
+++ b/pyquil/device/_main.py
@@ -173,19 +173,15 @@ class Device(AbstractDevice):
             if e is not None and "ISWAP" in e.type:
                 gates += [GateInfo(operator="ISWAP", parameters=[], arguments=["_", "_"],
                                    duration=DEFAULT_ISWAP_DURATION,
-                                   fidelity=safely_get("fISWAPs", tuple(e.targets), DEFAULT_CZ_FIDELITY))]
-            if e is not None and "XYhalves" in e.type:
-                gates += [GateInfo(operator="XY", parameters=[np.pi/2], arguments=["_", "_"],
-                                   duration=DEFAULT_XY_DURATION,
-                                   fidelity=safely_get("fXYs", tuple(e.targets), DEFAULT_CZ_FIDELITY))]
+                                   fidelity=safely_get("fISWAPs", tuple(e.targets), DEFAULT_ISWAP_FIDELITY))]
             if e is not None and "CPHASE" in e.type:
                 gates += [GateInfo(operator="CPHASE", parameters=["theta"], arguments=["_", "_"],
                                    duration=DEFAULT_CPHASE_DURATION,
-                                   fidelity=safely_get("fCPHASEs", tuple(e.targets), DEFAULT_CZ_FIDELITY))]
+                                   fidelity=safely_get("fCPHASEs", tuple(e.targets), DEFAULT_CPHASE_FIDELITY))]
             if e is not None and "XY" in e.type:
                 gates += [GateInfo(operator="XY", parameters=["theta"], arguments=["_", "_"],
                                    duration=DEFAULT_XY_DURATION,
-                                   fidelity=safely_get("fXYs", tuple(e.targets), DEFAULT_CZ_FIDELITY))]
+                                   fidelity=safely_get("fXYs", tuple(e.targets), DEFAULT_XY_FIDELITY))]
             if e is not None and "WILDCARD" in e.type:
                 gates += [GateInfo(operator="_", parameters="_", arguments=["_", "_"],
                                    duration=PERFECT_DURATION, fidelity=PERFECT_FIDELITY)]

--- a/pyquil/device/_main.py
+++ b/pyquil/device/_main.py
@@ -188,7 +188,7 @@ class Device(AbstractDevice):
             return gates
 
         qubits = [Qubit(id=q.id, type=None, dead=q.dead, gates=qubit_type_to_gates(q))
-            for q in self._isa.qubits]
+                  for q in self._isa.qubits]
         edges = [Edge(targets=e.targets, type=None, dead=e.dead, gates=edge_type_to_gates(e))
                  for e in self._isa.edges]
         return ISA(qubits, edges)

--- a/pyquil/device/_specs.py
+++ b/pyquil/device/_specs.py
@@ -153,7 +153,7 @@ class Specs(_Specs):
         :return: A dictionary of XY/2 fidelities, normalized to unity.
         :rtype: Dict[tuple(int, int), float]
         """
-        return {tuple(es.targets): es.fXYs for es in self.edges_specs}
+        return {tuple(es.targets): es.fXY for es in self.edges_specs}
 
     def fCZ_std_errs(self):
         """
@@ -238,7 +238,9 @@ class Specs(_Specs):
                     'fBellState': es.fBellState,
                     'fCZ': es.fCZ,
                     'fCZ_std_err': es.fCZ_std_err,
-                    'fCPHASE': es.fCPHASE
+                    'fCPHASE': es.fCPHASE,
+                    'fXY': es.fXY,
+                    'fISWAP': es.fISWAP
                 } for es in self.edges_specs
             }
         }
@@ -269,7 +271,9 @@ class Specs(_Specs):
                                           fBellState=especs.get('fBellState'),
                                           fCZ=especs.get('fCZ'),
                                           fCZ_std_err=especs.get('fCZ_std_err'),
-                                          fCPHASE=especs.get('fCPHASE'))
+                                          fCPHASE=especs.get('fCPHASE'),
+                                          fXY=especs.get('fXY'),
+                                          fISWAP=especs.get('fISWAP'))
                                 for e, especs in d["2Q"].items()],
                                key=lambda edge_specs: edge_specs.targets)
         )

--- a/pyquil/device/_specs.py
+++ b/pyquil/device/_specs.py
@@ -22,7 +22,8 @@ QubitSpecs = namedtuple("_QubitSpecs", ["id", "fRO", "f1QRB", "f1QRB_std_err",
                                         "f1Q_simultaneous_RB", "f1Q_simultaneous_RB_std_err", "T1",
                                         "T2", "fActiveReset"])
 EdgeSpecs = namedtuple("_QubitQubitSpecs", ["targets", "fBellState", "fCZ", "fCZ_std_err",
-                                            "fCPHASE", "fXY", "fISWAP"])
+                                            "fCPHASE", "fCPHASE_std_err", "fXY", "fXY_std_err",
+                                            "fISWAP", "fISWAP_std_err"])
 _Specs = namedtuple("_Specs", ["qubits_specs", "edges_specs"])
 
 
@@ -145,6 +146,16 @@ class Specs(_Specs):
         """
         return {tuple(es.targets): es.fISWAP for es in self.edges_specs}
 
+    def fISWAP_std_errs(self):
+        """
+        Get a dictionary of the standard errors of the ISWAP fidelities from the specs,
+        keyed by targets (qubit-qubit pairs).
+
+        :return: A dictionary of ISWAP fidelities, normalized to unity.
+        :rtype: Dict[tuple(int, int), float]
+        """
+        return {tuple(es.targets): es.fISWAP_std_err for es in self.edges_specs}
+
     def fXYs(self):
         """
         Get a dictionary of XY(pi) fidelities (normalized to unity) from the specs,
@@ -154,6 +165,16 @@ class Specs(_Specs):
         :rtype: Dict[tuple(int, int), float]
         """
         return {tuple(es.targets): es.fXY for es in self.edges_specs}
+
+    def fXY_std_errs(self):
+        """
+        Get a dictionary of the standard errors of the XY fidelities from the specs,
+        keyed by targets (qubit-qubit pairs).
+
+        :return: A dictionary of XY fidelities, normalized to unity.
+        :rtype: Dict[tuple(int, int), float]
+        """
+        return {tuple(es.targets): es.fXY_std_err for es in self.edges_specs}
 
     def fCZ_std_errs(self):
         """
@@ -239,8 +260,11 @@ class Specs(_Specs):
                     'fCZ': es.fCZ,
                     'fCZ_std_err': es.fCZ_std_err,
                     'fCPHASE': es.fCPHASE,
+                    'fCPHASE_std_err': es.fCPHASE_std_err,
                     'fXY': es.fXY,
-                    'fISWAP': es.fISWAP
+                    'fXY_std_err': es.fXY_std_err,
+                    'fISWAP': es.fISWAP,
+                    'fISWAP_std_err': es.fISWAP_std_err
                 } for es in self.edges_specs
             }
         }
@@ -272,8 +296,11 @@ class Specs(_Specs):
                                           fCZ=especs.get('fCZ'),
                                           fCZ_std_err=especs.get('fCZ_std_err'),
                                           fCPHASE=especs.get('fCPHASE'),
+                                          fCPHASE_std_err=especs.get('fCPHASE_std_err'),
                                           fXY=especs.get('fXY'),
-                                          fISWAP=especs.get('fISWAP'))
+                                          fXY_std_err=especs.get('fXY_std_err'),
+                                          fISWAP=especs.get('fISWAP'),
+                                          fISWAP_std_err=especs.get('fISWAP_std_err'))
                                 for e, especs in d["2Q"].items()],
                                key=lambda edge_specs: edge_specs.targets)
         )

--- a/pyquil/device/_specs.py
+++ b/pyquil/device/_specs.py
@@ -22,7 +22,7 @@ QubitSpecs = namedtuple("_QubitSpecs", ["id", "fRO", "f1QRB", "f1QRB_std_err",
                                         "f1Q_simultaneous_RB", "f1Q_simultaneous_RB_std_err", "T1",
                                         "T2", "fActiveReset"])
 EdgeSpecs = namedtuple("_QubitQubitSpecs", ["targets", "fBellState", "fCZ", "fCZ_std_err",
-                                            "fCPHASE"])
+                                            "fCPHASE", "fXY", "fISWAP"])
 _Specs = namedtuple("_Specs", ["qubits_specs", "edges_specs"])
 
 
@@ -134,6 +134,26 @@ class Specs(_Specs):
         :rtype: Dict[tuple(int, int), float]
         """
         return {tuple(es.targets): es.fCZ for es in self.edges_specs}
+
+    def fISWAPs(self):
+        """
+        Get a dictionary of ISWAP fidelities (normalized to unity) from the specs,
+        keyed by targets (qubit-qubit pairs).
+
+        :return: A dictionary of ISWAP fidelities, normalized to unity.
+        :rtype: Dict[tuple(int, int), float]
+        """
+        return {tuple(es.targets): es.fISWAP for es in self.edges_specs}
+
+    def fXYs(self):
+        """
+        Get a dictionary of XY/2 fidelities (normalized to unity) from the specs,
+        keyed by targets (qubit-qubit pairs).
+
+        :return: A dictionary of XY/2 fidelities, normalized to unity.
+        :rtype: Dict[tuple(int, int), float]
+        """
+        return {tuple(es.targets): es.fXYs for es in self.edges_specs}
 
     def fCZ_std_errs(self):
         """

--- a/pyquil/device/_specs.py
+++ b/pyquil/device/_specs.py
@@ -147,7 +147,7 @@ class Specs(_Specs):
 
     def fXYs(self):
         """
-        Get a dictionary of XY/2 fidelities (normalized to unity) from the specs,
+        Get a dictionary of XY(pi) fidelities (normalized to unity) from the specs,
         keyed by targets (qubit-qubit pairs).
 
         :return: A dictionary of XY/2 fidelities, normalized to unity.

--- a/pyquil/device/tests/test_device.py
+++ b/pyquil/device/tests/test_device.py
@@ -65,10 +65,14 @@ def test_specs(specs_dict):
                        T1=18e-6, T2=11e-6, fActiveReset=None)
         ],
         edges_specs=[
-            EdgeSpecs(targets=[0, 1], fBellState=0.90, fCZ=0.89, fCZ_std_err=0.01, fCPHASE=0.88),
-            EdgeSpecs(targets=[0, 2], fBellState=0.92, fCZ=0.91, fCZ_std_err=0.20, fCPHASE=0.90),
-            EdgeSpecs(targets=[0, 3], fBellState=0.89, fCZ=0.88, fCZ_std_err=0.03, fCPHASE=0.87),
-            EdgeSpecs(targets=[1, 2], fBellState=0.91, fCZ=0.90, fCZ_std_err=0.12, fCPHASE=0.89),
+            EdgeSpecs(targets=[0, 1], fBellState=0.90, fCZ=0.89, fCZ_std_err=0.01, fCPHASE=0.88,
+                      fISWAP=None, fXY=None),
+            EdgeSpecs(targets=[0, 2], fBellState=0.92, fCZ=0.91, fCZ_std_err=0.20, fCPHASE=0.90,
+                      fISWAP=None, fXY=None),
+            EdgeSpecs(targets=[0, 3], fBellState=0.89, fCZ=0.88, fCZ_std_err=0.03, fCPHASE=0.87,
+                      fISWAP=None, fXY=None),
+            EdgeSpecs(targets=[1, 2], fBellState=0.91, fCZ=0.90, fCZ_std_err=0.12, fCPHASE=0.89,
+                      fISWAP=None, fXY=None),
         ])
 
     assert specs == Specs.from_dict(specs.to_dict())

--- a/pyquil/device/tests/test_device.py
+++ b/pyquil/device/tests/test_device.py
@@ -66,13 +66,13 @@ def test_specs(specs_dict):
         ],
         edges_specs=[
             EdgeSpecs(targets=[0, 1], fBellState=0.90, fCZ=0.89, fCZ_std_err=0.01, fCPHASE=0.88,
-                      fISWAP=None, fXY=None),
+                      fISWAP=None, fXY=None, fISWAP_std_err=None, fXY_std_err=None, fCPHASE_std_err=None),
             EdgeSpecs(targets=[0, 2], fBellState=0.92, fCZ=0.91, fCZ_std_err=0.20, fCPHASE=0.90,
-                      fISWAP=None, fXY=None),
+                      fISWAP=None, fXY=None, fISWAP_std_err=None, fXY_std_err=None, fCPHASE_std_err=None),
             EdgeSpecs(targets=[0, 3], fBellState=0.89, fCZ=0.88, fCZ_std_err=0.03, fCPHASE=0.87,
-                      fISWAP=None, fXY=None),
+                      fISWAP=None, fXY=None, fISWAP_std_err=None, fXY_std_err=None, fCPHASE_std_err=None),
             EdgeSpecs(targets=[1, 2], fBellState=0.91, fCZ=0.90, fCZ_std_err=0.12, fCPHASE=0.89,
-                      fISWAP=None, fXY=None),
+                      fISWAP=None, fXY=None, fISWAP_std_err=None, fXY_std_err=None, fCPHASE_std_err=None),
         ])
 
     assert specs == Specs.from_dict(specs.to_dict())

--- a/pyquil/gate_matrices.py
+++ b/pyquil/gate_matrices.py
@@ -228,7 +228,8 @@ QUANTUM_GATES = {
     'ISWAP': ISWAP,
     'PSWAP': PSWAP,
     'BARENCO': BARENCO,
-    'CZ': CZ
+    'CZ': CZ,
+    'XY': XY
 }
 
 

--- a/pyquil/gate_matrices.py
+++ b/pyquil/gate_matrices.py
@@ -186,8 +186,8 @@ def PSWAP(phi):
 
 def XY(phi):
     return np.array([[1, 0, 0, 0],
-                     [0, np.cos(phi/2), 1j*np.sin(phi/2), 0],
-                     [0, 1j*np.sin(phi/2), np.cos(phi/2), 0],
+                     [0, np.cos(phi / 2), 1j * np.sin(phi / 2), 0],
+                     [0, 1j * np.sin(phi / 2), np.cos(phi / 2), 0],
                      [0, 0, 0, 1]])
 
 

--- a/pyquil/gate_matrices.py
+++ b/pyquil/gate_matrices.py
@@ -70,6 +70,9 @@ Currently includes:
     PSWAP(:math:`\phi`) - phi-phase-swap
     :math:`\begin{pmatrix} 1&0&0&0 \\ 0&0&e^{i\phi}&0 \\ 0&e^{i\phi}&0&0 \\ 0&0&0&1 \end{pmatrix}`
 
+    XY(:math:`\phi`) - XY-interaction
+    :math:`\begin{pmatrix} 1&0&0&0 \\ 0&\cos(\phi/2)&i\sin(\phi/2)&0 \\ 0&i\sin(\phi/2)&\cos(\phi/2)&0 \\ 0&0&0&1 \end{pmatrix}`
+
 Specialized gates / internal utility gates:
     BARENCO(:math:`\alpha, \phi, \theta`) - Barenco gate
     :math:`\begin{pmatrix} 1&0&0&0 \\ 0&1&0&0 \\ 0&0&e^{i\phi} \cos\theta & -i e^{i(\alpha-\phi)}
@@ -178,6 +181,13 @@ def PSWAP(phi):
     return np.array([[1, 0, 0, 0],
                      [0, 0, np.exp(1j * phi), 0],
                      [0, np.exp(1j * phi), 0, 0],
+                     [0, 0, 0, 1]])
+
+
+def XY(phi):
+    return np.array([[1, 0, 0, 0],
+                     [0, np.cos(phi/2), 1j*np.sin(phi/2), 0],
+                     [0, 1j*np.sin(phi/2), np.cos(phi/2), 0],
                      [0, 0, 0, 1]])
 
 

--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -853,7 +853,8 @@ QUANTUM_GATES: Mapping[str, Callable[..., Gate]] = {
     'SWAP': SWAP,
     'CSWAP': CSWAP,
     'ISWAP': ISWAP,
-    'PSWAP': PSWAP}
+    'PSWAP': PSWAP,
+    'XY': XY}
 """
 Dictionary of quantum gate functions keyed by gate names.
 """

--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -442,6 +442,22 @@ def PSWAP(angle: ParameterDesignator, q1: QubitDesignator, q2: QubitDesignator) 
     return Gate(name="PSWAP", params=[angle], qubits=[unpack_qubit(q) for q in (q1, q2)])
 
 
+def XY(angle: ParameterDesignator, q1: QubitDesignator, q2: QubitDesignator) -> Gate:
+    """Produces a parameterized ISWAP gate::
+
+        XY(phi) = [[1,             0,             0, 0],
+                   [0,      cos(phi), 1j * sin(phi), 0],
+                   [0, 1j * sin(phi),      cos(phi), 0],
+                   [0,             0,             0, 1]
+
+    :param angle: The angle of the rotation to apply to the population 1 subspace.
+    :param q1: Qubit 1.
+    :param q2: Qubit 2.
+    :returns: A Gate object.
+    """
+    return Gate(name="XY", params=[angle], qubits=[unpack_qubit(q) for q in (q1, q2)])
+
+
 WAIT = Wait()
 """
 This instruction tells the quantum computation to halt. Typically these is used while classical memory is being

--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -445,10 +445,10 @@ def PSWAP(angle: ParameterDesignator, q1: QubitDesignator, q2: QubitDesignator) 
 def XY(angle: ParameterDesignator, q1: QubitDesignator, q2: QubitDesignator) -> Gate:
     """Produces a parameterized ISWAP gate::
 
-        XY(phi) = [[1,             0,             0, 0],
-                   [0,      cos(phi), 1j * sin(phi), 0],
-                   [0, 1j * sin(phi),      cos(phi), 0],
-                   [0,             0,             0, 1]
+        XY(phi) = [[1,               0,               0, 0],
+                   [0,      cos(phi/2), 1j * sin(phi/2), 0],
+                   [0, 1j * sin(phi/2),      cos(phi/2), 0],
+                   [0,               0,               0, 1]
 
     :param angle: The angle of the rotation to apply to the population 1 subspace.
     :param q1: Qubit 1.


### PR DESCRIPTION
Description
-----------

Update the handling of devices / ISAs / Specs objects to track the XY gate family.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
