### PR TITLE
Add "make typecheck" target and run it during gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,15 @@ style:
     - make requirements
     - make style
 
+typecheck:
+  image: python:3.6
+  tags:
+    - github
+  script:
+    - make install
+    - make requirements
+    - make typecheck
+
 docs:
   image: python:3.6
   tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 
 ### Improvements and Changes
 
+-   Added a `make typecheck` target to run mypy over a subset of the pyquil sources,
+    and enabled typechecks in gitlab CI (@appleby, gh-1098).
+
 ### Bugfixes
 
 [v2.13](https://github.com/rigetti/pyquil/compare/v2.12.0...v2.13.0) (November 7, 2019)
@@ -56,7 +59,7 @@ Changelog
 -   Type hints have been added to the `pyquil.gates`, `pyquil.quilatom`, and
     `pyquil.quilbase` modules (@appleby, gh-999).
 -   We now support Python 3.8 and it is tested in the CI (@karalekas, gh-1093).
-    
+
 ### Bugfixes
 
 -   Updated `examples/meyer_penny_game.py` with the correct path to the Meyer Penny

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ style:
 test:
 	pytest -v --runslow --cov=pyquil
 
+# The dream is to one day run mypy on the whole tree. For now, limit
+# checks to known-good files.
+.PHONY: typecheck
+typecheck:
+	mypy pyquil/quilatom.py pyquil/quilbase.py pyquil/gates.py
+
 .PHONY: upload
 upload:
 	twine upload --repository-url https://test.pypi.org/legacy/ dist/*

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,24 @@
+[mypy]
+# We'd like to leave follow_imports and ignore_missing_imports at
+# their default values, but there are too many errors to fix for now.
+follow_imports = silent
+ignore_missing_imports = True
+
+# Enable options equivalent to the --strict command line arg
+warn_unused_configs = True
+disallow_subclassing_any = True
+disallow_any_generics = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
+# Ignore errors in generated parser files
+[mypy-pyquil._parser.gen3.*]
+ignore_errors = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ pytest-timeout
 pytest-rerunfailures
 requests-mock
 flake8
+mypy
 tox
 
 # docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, docs, flake8
+envlist = py36, py37, docs, flake8, mypy
 
 [testenv]
 recreate=
@@ -20,3 +20,7 @@ commands = flake8 pyquil
 [flake8]
 ignore = E501,E999,E741,E126,E127,F401,F403,F405,F811,F841,E743,W503
 exclude = gen3,external
+
+[testenv:mypy]
+# The dream is to one day run mypy on the whole tree. For now, limit checks to known-good files.
+commands = mypy pyquil/quilatom.py pyquil/quilbase.py pyquil/gates.py


### PR DESCRIPTION
Description
-----------

Add "make typecheck" target and run it during gitlab CI.

- Add mypy to requirements.txt
- Add mypy.ini
- Add testenv:mypy to tox.ini
- Add a make typecheck target
- Add a typecheck section to .gitlab-ci.yml

Closes #1006

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
