### PR TITLE
Correctly declare the size of the ro register in qc.run example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog
 
 ### Bugfixes
 
+-   Fixed an example of using the `qc.run` method in the docs to correctly declare the size of a memory register (@appleby, gh-1099).
+
 [v2.13](https://github.com/rigetti/pyquil/compare/v2.12.0...v2.13.0) (November 7, 2019)
 ---------------------------------------------------------------------------------------
 

--- a/docs/source/qvm.rst
+++ b/docs/source/qvm.rst
@@ -354,7 +354,7 @@ The above program would be written in this way to execute with ``run``:
     qc = get_qc("8q-qvm")
 
     p = Program()
-    ro = p.declare('ro', 'BIT', 1)
+    ro = p.declare('ro', 'BIT', 2)
     p += X(0)
     p += MEASURE(0, ro[0])
     p += MEASURE(1, ro[1])


### PR DESCRIPTION
Description
-----------

Correctly declare the size of the ro register in qc.run example.

Fixes #1097

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
