### PR TITLE
Specify file encoding to guard against ascii locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Changelog
     gh-1103).
 -   Fixed an example of using the `qc.run` method in the docs to correctly declare
     the size of a memory register (@appleby, gh-1099).
+-   Specify UTF-8 encoding when opening files that might contain non-ascii characters,
+    such as when reading the pyquil README.md file in setup.py or when serializing /
+    deserializing pyquil.experiment objects to/from JSON (@appleby, gh-1102).
 
 [v2.13](https://github.com/rigetti/pyquil/compare/v2.12.0...v2.13.0) (November 7, 2019)
 ---------------------------------------------------------------------------------------

--- a/pyquil/experiment/_main.py
+++ b/pyquil/experiment/_main.py
@@ -266,7 +266,8 @@ def to_json(fn, obj):
 
     See :py:func:`read_json`.
     """
-    with open(fn, 'w') as f:
+    # Specify UTF-8 to guard against systems that default to an ASCII locale.
+    with open(fn, 'w', encoding='utf-8') as f:
         json.dump(obj, f, cls=OperatorEncoder, indent=2, ensure_ascii=False)
     return fn
 
@@ -291,5 +292,6 @@ def read_json(fn):
 
     See :py:func:`to_json`.
     """
-    with open(fn) as f:
+    # Specify UTF-8 to guard against systems that default to an ASCII locale.
+    with open(fn, encoding='utf-8') as f:
         return json.load(f, object_hook=_operator_object_hook)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ if sys.version_info < (3, 6):
 with open('VERSION.txt', 'r') as f:
     __version__ = f.read().strip()
 
-with open('README.md', 'r') as f:
+# Specify UTF-8 to guard against systems that default to an ASCII locale.
+with open('README.md', 'r', encoding='utf-8') as f:
     long_description = f.read()
 
 # save the source code in version.py


### PR DESCRIPTION
Description
-----------

If you don't explicitly specify the encoding you want when opening a file, [Python defaults to the platform-dependent LC_CTYPE](https://docs.python.org/3.6/library/functions.html#open). On platforms where this is set to an ascii or "C" locale, this prevents installing pyquil, since `setup.py` tries to read `README.md` and chokes on the `U+1F642 SLIGHTLY SMILING FACE`.

Likewise `test_experiment_deser` fails in `pyquil.experiment.to_json` when it encounters a `U+2192 RIGHTWARDS ARROW` in the str representation of an `ExperimentSetting`.

I noticed this while attempting to install pyquil on CentOS 7, which apparently defaults to an ascii locale.

To reproduce and/or verify the fix, you can 

```
cd /path/to/pyquil
export LC_ALL=C
pip install -e .
pytest pyquil/experiment/tests/test_experiment.py
```

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
