### PR TITLE
Fix control line offset in LaTeX for controlled gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog
 
 ### Bugfixes
 
+- Fixed a bug in the LaTeX output of controlled unitary operations (@kilimanjaro, gh-1103).
+
 [v2.13](https://github.com/rigetti/pyquil/compare/v2.12.0...v2.13.0) (November 7, 2019)
 ---------------------------------------------------------------------------------------
 

--- a/pyquil/latex/_diagram.py
+++ b/pyquil/latex/_diagram.py
@@ -465,10 +465,11 @@ class DiagramBuilder:
                              f"qubits.")
 
         for q in control_qubits:
-            self.diagram.append(q, TIKZ_CONTROL(q, target_qubits[0]))
+            offset = target_qubits[0] - q
+            self.diagram.append(q, TIKZ_CONTROL(q, offset))
 
         # we put the gate on the first target line, and nop on the others
-        self.diagram.append(target_qubits[0], TIKZ_GATE(instr.name, size=len(qubits),
+        self.diagram.append(target_qubits[0], TIKZ_GATE(instr.name, size=len(target_qubits),
                                                         params=instr.params, dagger=dagger))
         for q in target_qubits[1:]:
             self.diagram.append(q, TIKZ_NOP())

--- a/pyquil/latex/tests/test_latex.py
+++ b/pyquil/latex/tests/test_latex.py
@@ -109,3 +109,18 @@ def test_unsupported_ops():
         prog = base_prog + op
         with pytest.raises(ValueError):
             _ = to_latex(prog)
+
+
+def test_controlled_gate():
+    prog = Program(H(2).controlled(3))
+    # This is hardcoded, but better than nothing
+    expected = r"""
+    \begin{tikzcd}
+    \lstick{\ket{q_{2}}} & \gate{H} &  \qw \\
+    \lstick{\ket{q_{3}}} & \ctrl{-1} & \qw
+    \end{tikzcd}
+    """.strip().split()
+
+    actual = to_latex(prog).split()
+    start_idx = actual.index('\\begin{tikzcd}')
+    assert expected == actual[start_idx:start_idx + len(expected)]


### PR DESCRIPTION
Description
-----------

This fixes a bug in printing of controlled unitaries. The control line is specified with a placement and offset. The previous version computed the offset incorrectly. I added a test to check this. This bug did not affect gates such as `CNOT`, which were handled by a separate code path.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
