### PR TITLE
Bump QVM docker image version to v1.13.1 for XY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # specify the dependency versions (can be overriden with --build-arg)
 ARG quilc_version=1.13.0
-ARG qvm_version=1.13.0
+ARG qvm_version=1.13.1
 ARG python_version=3.6
 
 # use multi-stage builds to independently pull dependency versions


### PR DESCRIPTION
Description
-----------

Self explanatory.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
