### PR TITLE
Run flake8 on the docs and examples directories as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ Changelog
 ### Announcements
 
 ### Improvements and Changes
--   Broadened the scope of flake8 compliance to the entire repo (including examples, docs, etc.) (@tommy-moffat, gh-1113)
+
+-   Broadened the scope of flake8 compliance to the entire repo (including examples,
+    docs, etc.) (@tommy-moffat, gh-1113)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changelog
     and in `ISA`s (@ecpeterson, gh-1096, gh-1107, gh-1111).
 -   Removed the `tox.ini` and `readthedocs.yml` files (@karalekas, gh-1108).
 -   Type hints have been added to the `PauliSum` class (@rht, gh-1104).
+-   Broadened the scope of flake8 compliance to the entire repo (including examples, docs, etc.) (@tommy-moffat, gh-1113)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 ### Announcements
 
 ### Improvements and Changes
+-   Broadened the scope of flake8 compliance to the entire repo (including examples, docs, etc.) (@tommy-moffat, gh-1113)
 
 ### Bugfixes
 
@@ -37,7 +38,6 @@ Changelog
     and in `ISA`s (@ecpeterson, gh-1096, gh-1107, gh-1111).
 -   Removed the `tox.ini` and `readthedocs.yml` files (@karalekas, gh-1108).
 -   Type hints have been added to the `PauliSum` class (@rht, gh-1104).
--   Broadened the scope of flake8 compliance to the entire repo (including examples, docs, etc.) (@tommy-moffat, gh-1113)
 
 ### Bugfixes
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ requirements: requirements.txt
 
 .PHONY: style
 style:
-	flake8 pyquil
+	flake8
 
 .PHONY: test
 test:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,12 @@
 #
 # needs_sphinx = '1.0'
 
+import sphinx_rtd_theme
+from pyquil import __version__
+
+import subprocess
+import os
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
@@ -45,9 +51,6 @@ extensions = [
 
 autosummary_generate = True
 autoclass_content = "both"
-
-import sphinx_rtd_theme
-from pyquil import __version__
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -375,9 +378,6 @@ mathjax_config = {
 }
 
 # fun little hack to always build the rst changelog from the markdown
-
-import subprocess
-import os
 
 dirname = os.path.dirname(__file__)
 

--- a/examples/1.3_vqe_demo.py
+++ b/examples/1.3_vqe_demo.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
         # generate the spin-adapted classical coupled-cluster amplitude to use as the input for the
         # circuit
         packed_amps = uccsd_singlet_get_packed_amplitudes(molecule.ccsd_single_amps, molecule.ccsd_double_amps,
-                                                     molecule.n_qubits, molecule.n_electrons)
+                                                          molecule.n_qubits, molecule.n_electrons)
         theta = packed_amps[-1]  # always take the doubles amplitude
 
         # now that we're done setting up the Hamiltonian and grabbing initial opt parameters
@@ -123,12 +123,11 @@ if __name__ == "__main__":
         observable = objective_fun(theta, hamiltonian=bk_mat, quantum_resource=qvm)
 
         result = minimize(objective_fun, x0=theta, args=(bk_mat, qvm), method='CG',
-                          options={'disp':True})
+                          options={'disp': True})
         ucc_energy.append(result.fun)
         fci_energy.append(molecule.fci_energy)
         hf_energy.append(molecule.hf_energy)
         print(w[0], molecule.fci_energy, tenergy, result.fun)
-
 
     plt.plot(bond_length, hf_energy, 'C1o-', label='HF')
     plt.plot(bond_length, ucc_energy, 'C0o-', label='UCC-VQE')

--- a/examples/quantum_die.py
+++ b/examples/quantum_die.py
@@ -58,7 +58,7 @@ def process_results(results):
     raw_results = results[0]
     processing_result = 0
     for each_qubit_measurement in raw_results:
-        processing_result = 2*processing_result + each_qubit_measurement
+        processing_result = 2 * processing_result + each_qubit_measurement
     # Convert from 0 indexed to 1 indexed
     die_value = processing_result + 1
     return die_value
@@ -76,5 +76,6 @@ if __name__ == '__main__':
     number_of_sides = int(input("Please enter number of sides: "))
     qvm = get_qvm(number_of_sides)
     die_value = roll_die(qvm, number_of_sides)
-    while die_value > number_of_sides: die_value = roll_die(qvm, number_of_sides)
+    while die_value > number_of_sides:
+        die_value = roll_die(qvm, number_of_sides)
     print(f"The result is: {die_value}")


### PR DESCRIPTION
Description
-----------

Broadened the scope of flake8 compliance to the entire repo (including examples, docs, etc.)

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
