### PR TITLE
Support instead providing a list of values to write_memory()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 -   Type hints have been added to the `quil.py` file (@rht, gh-1115, gh-1134).
 -   Use [Black](https://black.readthedocs.io/en/stable/index.html) for code style
     and enforce it (along with a line length of 100) via the `style` (`flake8`)
@@ -40,7 +41,7 @@ Changelog
 -   Use `dataclasses` instead of `namedtuples` in the `pyquil/device` module, and
     add type annotations to the entire module (@karalekas, gh-1149).
 -   `QAM.write_memory` now accepts either a `Sequence` of values or a single
-    value. (@tommy-moffat, gh-658)
+    value (@tommy-moffat, gh-1114).
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 ### Improvements and Changes
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 -   Type hints have been added to the `quil.py` file (@rht, gh-1115, gh-1134).
 -   Use [Black](https://black.readthedocs.io/en/stable/index.html) for code style
     and enforce it (along with a line length of 100) via the `style` (`flake8`)
@@ -38,7 +39,7 @@ Changelog
     `check-types` CI job (@karalekas, gh-1146).
 -   Use `dataclasses` instead of `namedtuples` in the `pyquil/device` module, and
     add type annotations to the entire module (@karalekas, gh-1149).
--   `QAM.write_memory` now accepts either a Sequence of values or a single
+-   `QAM.write_memory` now accepts either a `Sequence` of values or a single
     value. (@tommy-moffat, gh-658)
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 
 ### Improvements and Changes
 
+<<<<<<< HEAD
 -   Type hints have been added to the `quil.py` file (@rht, gh-1115, gh-1134).
 -   Use [Black](https://black.readthedocs.io/en/stable/index.html) for code style
     and enforce it (along with a line length of 100) via the `style` (`flake8`)
@@ -37,6 +38,8 @@ Changelog
     `check-types` CI job (@karalekas, gh-1146).
 -   Use `dataclasses` instead of `namedtuples` in the `pyquil/device` module, and
     add type annotations to the entire module (@karalekas, gh-1149).
+-   `QAM.write_memory` now accepts either a Sequence of values or a single
+    value. (@tommy-moffat, gh-658)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ Changelog
 
 ### Improvements and Changes
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 -   Type hints have been added to the `quil.py` file (@rht, gh-1115, gh-1134).
 -   Use [Black](https://black.readthedocs.io/en/stable/index.html) for code style
     and enforce it (along with a line length of 100) via the `style` (`flake8`)

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -64,7 +64,7 @@ class QAM(ABC):
     def write_memory(self, *, region_name: str, offset: Optional[int] = None,
                      value: Optional[Union[int, float, Sequence[int], Sequence[float]]] = None):
         """
-        Writes a value or chronologically unwraps a list of values into a memory region on
+        Writes a value or unwraps a list of values into a memory region on
         the QAM at a specified offset.
 
         :param region_name: Name of the declared memory region on the QAM.

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -17,6 +17,7 @@ import warnings
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from typing import Sequence, Union, Optional
 
 from rpcq.messages import ParameterAref
 
@@ -60,18 +61,26 @@ class QAM(ABC):
         return self
 
     @_record_call
-    def write_memory(self, *, region_name: str, offset: int = 0, value=None):
-        """
-        Writes a value into a memory region on the QAM at a specified offset.
+    def write_memory(self, *, region_name: str, offset: int = None,
+                     value: Optional[Union[int, float, Sequence[int], Sequence[float]]] = None):        """
+        Writes a value or chronologically unwraps a list of values into a memory region on
+        the QAM at a specified offset.
 
         :param region_name: Name of the declared memory region on the QAM.
         :param offset: Integer offset into the memory region to write to.
-        :param value: Value to store at the indicated location.
+        :param value: Value(s) to store at the indicated location.
         """
         assert self.status in ["loaded", "done"]
 
-        aref = ParameterAref(name=region_name, index=offset)
-        self._variables_shim[aref] = value
+        if isinstance(value, Sequence):
+            if offset != None:
+                warnings.warn("offset should be None when value is a Sequence")
+            for index, v in enumerate(value):
+                aref = ParameterAref(name=region_name, index=offset + index)
+                self._variables_shim[aref] = v
+        else:
+            aref = ParameterAref(name=region_name, index=offset)
+            self._variables_shim[aref] = value
 
         return self
 

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -62,7 +62,8 @@ class QAM(ABC):
 
     @_record_call
     def write_memory(self, *, region_name: str, offset: Optional[int] = None,
-                     value: Optional[Union[int, float, Sequence[int], Sequence[float]]] = None):
+                     value: Optional[Union[int, float, Sequence[int],
+                                           Sequence[float]]] = None):
         """
         Writes a value or unwraps a list of values into a memory region on
         the QAM at a specified offset.
@@ -79,7 +80,10 @@ class QAM(ABC):
             warnings.warn("offset should be None when value is a Sequence")
 
         if isinstance(value, Sequence):
-            if region_name in self._variables_shim.keys() and len(value) > len(self._variables_shim[region_name]) - offset:
+            assert all(isinstance(v, type(value[0])) for v in value), \
+                "Element of 'value' must be of uniform type"
+            if region_name in self._variables_shim.keys() and len(value) > \
+                    len(self._variables_shim[region_name]) - offset:
                 raise ValueError('Value sequence exceeds memory region size')
 
             for index, v in enumerate(value):

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -62,7 +62,8 @@ class QAM(ABC):
 
     @_record_call
     def write_memory(self, *, region_name: str, offset: int = None,
-                     value: Optional[Union[int, float, Sequence[int], Sequence[float]]] = None):        """
+                     value: Optional[Union[int, float, Sequence[int], Sequence[float]]] = None):
+        """
         Writes a value or chronologically unwraps a list of values into a memory region on
         the QAM at a specified offset.
 

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -61,9 +61,13 @@ class QAM(ABC):
         return self
 
     @_record_call
-    def write_memory(self, *, region_name: str, offset: Optional[int] = None,
-                     value: Optional[Union[int, float, Sequence[int],
-                                           Sequence[float]]] = None):
+    def write_memory(
+        self,
+        *,
+        region_name: str,
+        offset: Optional[int] = None,
+        value: Optional[Union[int, float, Sequence[int], Sequence[float]]] = None,
+    ):
         """
         Writes a value or unwraps a list of values into a memory region on
         the QAM at a specified offset.
@@ -80,15 +84,18 @@ class QAM(ABC):
             warnings.warn("offset should be None when value is a Sequence")
 
         if isinstance(value, Sequence):
-            assert all(isinstance(v, type(value[0])) for v in value), \
-                "Element of 'value' must be of uniform type"
-            if region_name in self._variables_shim.keys() and len(value) > \
-                    len(self._variables_shim[region_name]) - offset:
-                raise ValueError('Value sequence exceeds memory region size')
+            assert all(
+                isinstance(v, type(value[0])) for v in value
+            ), "Element of 'value' must be of uniform type"
+            if (
+                region_name in self._variables_shim.keys()
+                and len(value) > len(self._variables_shim[region_name]) - offset
+            ):
+                raise ValueError("Value sequence exceeds memory region size")
 
             for index, v in enumerate(value):
                 if not isinstance(v, type(value[0])):
-                    raise TypeError('Value sequence is not of uniform type')
+                    raise TypeError("Value sequence is not of uniform type")
 
                 aref = ParameterAref(name=region_name, index=offset + index)
                 self._variables_shim[aref] = v

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -133,10 +133,10 @@ class QuantumComputer:
         self.qam.load(executable)
         if memory_map:
             for region_name, values_list in memory_map.items():
-                for offset, value in enumerate(values_list):
-                    # TODO gh-658: have write_memory take a list rather than value + offset
-                    self.qam.write_memory(region_name=region_name, offset=offset, value=value)
-        return self.qam.run().wait().read_memory(region_name="ro")
+                self.qam.write_memory(region_name=region_name, value=values_list)
+        return self.qam.run() \
+            .wait() \
+            .read_memory(region_name='ro')
 
     @_record_call
     def experiment(

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -134,9 +134,7 @@ class QuantumComputer:
         if memory_map:
             for region_name, values_list in memory_map.items():
                 self.qam.write_memory(region_name=region_name, value=values_list)
-        return self.qam.run() \
-            .wait() \
-            .read_memory(region_name='ro')
+        return self.qam.run().wait().read_memory(region_name="ro")
 
     @_record_call
     def experiment(


### PR DESCRIPTION
Description
-----------

Modified write_memory() for accepting lists in addition to values + offsets when writing to classical memory registers. Closes #658.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
