### PR TITLE
use qcs quth credentials in forest server requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,9 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+### VSCODE ###
+.vscode/
+
 ### PyCharm Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog
 
 ### Improvements and Changes
 
+-   Update authentication mechanism to Forest server. Preferentially use
+    credentials found at `~/.qcs/user_auth_credentials` and fallback to
+    `~/.qcs/qmi_auth_credentials`. (@erichulburd, gh-1117)
+
 ### Bugfixes
 
 [v2.14](https://github.com/rigetti/pyquil/compare/v2.13.0...v2.14.0) (November 25, 2019)
@@ -185,8 +189,8 @@ Changelog
     the underlying `QVM`/`QPU` and `QVMCompiler`/`QPUCompiler` objects,
     which should resolve bugs that arise due to stale clients/connections
     (@karalekas, gh-872).
--   In addition to the simultaneous 1Q RB fidelities contained in device 
-    specs prior to this release, there are now 1Q RB fidelities for 
+-   In addition to the simultaneous 1Q RB fidelities contained in device
+    specs prior to this release, there are now 1Q RB fidelities for
     non-simultaneous gate operation. The names of these fields have been
     changed for clarity, and standard errors for both fidelities have been
     added as well. Finally, deprecation warnings have been added regarding

--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -14,10 +14,14 @@ PyQuil Configuration Files
 Network endpoints for the Rigetti Forest infrastructure and information pertaining to QPU access are
 stored in a pair of configuration files. These files are located by default at ``~/.qcs_config`` and ``~/.forest_config``.
 The location can be changed by setting the environment variables ``QCS_CONFIG`` or ``FOREST_CONFIG`` to point to the new
-location.
+location. When running on a QMI, the configuration files are automatically managed so as to
+point to the correct endpoints.
 
-When running on a QMI, the values in these configuration files are automatically managed so as to
-point to the correct endpoints. When running locally, configuration files are not necessary. Thus, the average
+Authentication credentials for Forest server are read from ``~/.qcs/user_auth_token``. You may download
+user auth credentials at https://qcs.rigetti.com/auth/token. When running on a QMI, authentication credentials
+are read from ``~/.qcs/qmi_auth_token``.
+
+When running locally, configuration files are not necessary. Thus, the average
 user will not have to do any work to get their configuration files set up.
 
 If for some reason you want to use an atypical configuration, you may need to modify these files.
@@ -31,7 +35,6 @@ The default QCS config file on any QMI looks similar to the following:
     # .qcs_config
     [Rigetti Forest]
     url = https://forest-server.qcs.rigetti.com
-    key = 4fd12391-11eb-52ec-35c2-262765ae4c4f
     user_id = 4fd12391-11eb-52ec-35c2-262765ae4c4f
 
     [QPU]
@@ -40,7 +43,6 @@ The default QCS config file on any QMI looks similar to the following:
 where
 
  -  ``url`` is the endpoint that pyQuil hits for device information and for the 2.0 endpoints,
- -  ``key`` stores the Forest 1.X API key,
  -  ``user_id`` stores a Forest 2.0 user ID, and
  -  ``exec_on_engage`` specifies the shell command that the QMI will launch when the QMI becomes QPU-engaged. It
     would have no effect if you are running locally, but is important if you are running on the QMI. By default, it runs the

--- a/pyquil/api/_benchmark.py
+++ b/pyquil/api/_benchmark.py
@@ -18,7 +18,7 @@ from rpcq import Client
 from rpcq.messages import (RandomizedBenchmarkingRequest, RandomizedBenchmarkingResponse,
                            ConjugateByCliffordRequest, ConjugateByCliffordResponse)
 
-from pyquil.api._base_connection import get_session, post_json
+from pyquil.api._base_connection import post_json
 from pyquil.api._config import PyquilConfig
 from pyquil.api._error_reporting import _record_call
 from pyquil.api._qac import AbstractBenchmarker

--- a/pyquil/api/_config.py
+++ b/pyquil/api/_config.py
@@ -19,6 +19,11 @@ Module for reading configuration information about api keys and user ids.
 from configparser import ConfigParser, NoSectionError, NoOptionError
 from os.path import expanduser, abspath
 from os import environ
+import json
+import logging
+from typing import List, Dict
+
+_log = logging.getLogger(__name__)
 
 # `.qcs_config` is for content (mostly) related to QCS: the QCS front end stacks endpoint (`url`)
 # for querying all QCS data: devices, reservations, etc. etc., and the `exec_on_engage` that the
@@ -40,14 +45,6 @@ class PyquilConfig(object):
         "default": "https://forest-server.qcs.rigetti.com"
     }
 
-    API_KEY = {
-        "env": "FOREST_API_KEY",
-        "file": QCS_CONFIG,
-        "section": "Rigetti Forest",
-        "name": "key",
-        "default": None
-    }
-
     USER_ID = {
         "env": "FOREST_USER_ID",
         "file": QCS_CONFIG,
@@ -62,6 +59,22 @@ class PyquilConfig(object):
         "section": "QPU",
         "name": "exec_on_engage",
         "default": ""
+    }
+
+    QMI_AUTH_TOKEN_PATH = {
+        "env": "QMI_AUTH_TOKEN_PATH",
+        "file": QCS_CONFIG,
+        "section": "Rigetti Forest",
+        "name": "qmi_auth_token_path",
+        "default": "~/.qcs/qmi_auth_token"
+    }
+
+    USER_AUTH_TOKEN_PATH = {
+        "env": "USER_AUTH_TOKEN_PATH",
+        "file": QCS_CONFIG,
+        "section": "Rigetti Forest",
+        "name": "user_auth_token_path",
+        "default": "~/.qcs/user_auth_token"
     }
 
     QPU_URL = {
@@ -96,15 +109,21 @@ class PyquilConfig(object):
         "default": None
     }
 
-    def __init__(self):
+    def __init__(self, config_paths: Dict[str, str] = CONFIG_PATHS):
         self.configparsers = {}
-        for env_name, default_path in CONFIG_PATHS.items():
+        for env_name, default_path in config_paths.items():
             default_path = expanduser(default_path)
             path = environ.get(env_name, default_path)
 
             cp = ConfigParser()
             cp.read(abspath(path))
+            print(env_name, abspath(path))
             self.configparsers[env_name] = cp
+        self._parse_auth_tokens()
+
+    def _parse_auth_tokens(self):
+        self.user_auth_token = _parse_auth_token(self.user_auth_token_path, ['access_token', 'refresh_token', 'scope'])
+        self.qmi_auth_token = _parse_auth_token(self.qmi_auth_token_path, ['access_token', 'refresh_token'])
 
     def _env_or_config_or_default(self, env=None, file=None, section=None, name=None, default=None):
         """
@@ -125,12 +144,35 @@ class PyquilConfig(object):
             return default
 
     @property
-    def api_key(self):
-        return self._env_or_config_or_default(**self.API_KEY)
-
-    @property
     def user_id(self):
         return self._env_or_config_or_default(**self.USER_ID)
+
+    @property
+    def qmi_auth_token_path(self):
+        return self._env_or_config_or_default(**self.QMI_AUTH_TOKEN_PATH)
+
+    def update_qmi_auth_token(self, qmi_auth_token):
+        self.qmi_auth_token = qmi_auth_token
+        with open(self.qmi_auth_token_path, 'w') as f:
+            json.dump(qmi_auth_token, f)
+
+    @property
+    def user_auth_token_path(self):
+        return self._env_or_config_or_default(**self.USER_AUTH_TOKEN_PATH)
+
+    def update_user_auth_token(self, user_auth_token):
+        self.user_auth_token = user_auth_token
+        with open(self.user_auth_token_path, 'w') as f:
+            json.dump(user_auth_token, f)
+
+    @property
+    def qcs_auth_headers(self):
+        if self.user_auth_token is not None:
+            return {'Authorization': 'Bearer %s' % self.user_auth_token['access_token']}
+        if self.qmi_auth_token is not None:
+            return {'X-QMI-AUTH-TOKEN': self.qmi_auth_token['access_token']}
+        # WARN: This authentication mechanism is deprecated.
+        return {'X-User-Id': self.user_id}
 
     @property
     def forest_url(self):
@@ -155,3 +197,37 @@ class PyquilConfig(object):
     @property
     def qpu_compiler_url(self):
         return self._env_or_config_or_default(**self.QPU_COMPILER_URL)
+
+    @property
+    def qcs_url(self):
+        return self.forest_url.replace('forest-server.', '')
+
+    def assert_valid_auth_credential(self):
+        """
+        assert_valid_auth_credential will check to make sure the user has a valid
+        auth credential configured. This assertion is made lazily - it is called
+        only after the user has received a 401 or 403 from forest server. See
+        _base_connection.py::ForestSession#_refresh_auth_token.
+        """
+        if self.user_auth_token is None and self.qmi_auth_token is None:
+            raise ValueError(f'Your configuration does not have valid authentication credentials. \
+Please visit {self.qcs_url}/auth/token to download credentials \
+and save to {self.user_auth_token_path}.')
+
+
+def _parse_auth_token(path, required_keys: List[str]):
+    try:
+        with open(abspath(path), 'r') as f:
+            token = json.load(f)
+            invalid_values = [k for k in required_keys if token.get(k).__class__ != str]
+            if len(invalid_values) != 0:
+                _log.warning(f'Failed to parse auth token at {path}.')
+                _log.warning(f'Invalid {invalid_values}.')
+                return None
+            return token
+    except json.decoder.JSONDecodeError:
+        _log.warning(f'Failed to parse auth token at {path}. Invalid JSON.')
+        return None
+    except FileNotFoundError:
+        _log.debug(f'Auth token at {path} not found.')
+        return None

--- a/pyquil/api/_devices.py
+++ b/pyquil/api/_devices.py
@@ -79,14 +79,13 @@ def list_lattices(device_name: str = None, num_qubits: int = None,
           accessible soon, but in the meanwhile, you'll have to use default QVM configurations and
           to use `list_quantum_computers` with `qpus = False`.
 
-        * You do have user authentication information, but it is missing or modified.  You can find
-          this either in the environment variables FOREST_API_KEY and FOREST_USER_ID or in the
-          config file (stored by default at ~/.qcs_config, but with location settable through the
-          environment variable QCS_CONFIG), which contains the subsection
+        * You do have user authentication credentials, but it is invalid. You can visit
+          https://qcs.rigetti.com/auth/token and save to ~/.qcs/user_auth_token to update your
+          authentication credentials. Alternatively, you may provide the path to your credentials in
+          your config file or  with the USER_AUTH_TOKEN_PATH environment variable.
 
           [Rigetti Forest]
-          user_id = your_user_id
-          key = your_api_key
+          user_auth_token_path = ~/.qcs/my_auth_credentials
 
         * You're missing an address for the Forest 2.0 server endpoint, or the address is invalid.
           This too can be set through the environment variable FOREST_URL or by changing the

--- a/pyquil/tests/data/qmi_auth_token_invalid.json
+++ b/pyquil/tests/data/qmi_auth_token_invalid.json
@@ -1,0 +1,4 @@
+{
+  "access_token": "ok",
+  "refreshish_token": "notwhatwe'relookingfor"
+}

--- a/pyquil/tests/data/qmi_auth_token_valid.json
+++ b/pyquil/tests/data/qmi_auth_token_valid.json
@@ -1,0 +1,4 @@
+{
+  "access_token": "ok",
+  "refresh_token": "supersecret"
+}

--- a/pyquil/tests/data/user_auth_token_invalid.json
+++ b/pyquil/tests/data/user_auth_token_invalid.json
@@ -1,0 +1,5 @@
+{
+  "access_token": "ok",
+  "refresh_token": "ok",
+  "scopish": "notwhatwe'relookingfor"
+}

--- a/pyquil/tests/data/user_auth_token_valid.json
+++ b/pyquil/tests/data/user_auth_token_valid.json
@@ -1,0 +1,1 @@
+{"access_token": "secret", "refresh_token": "supersecret", "scope": "openid offline_access profile"}

--- a/pyquil/tests/test_base_connection.py
+++ b/pyquil/tests/test_base_connection.py
@@ -1,0 +1,148 @@
+import pytest
+import os
+import requests_mock
+from configparser import ConfigParser
+from pyquil.api._base_connection import ForestSession
+from pyquil.api._config import PyquilConfig
+import urllib.parse
+
+
+def fixture_path(path: str) -> str:
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    return os.path.join(dir_path, 'data', path)
+
+
+test_config_paths = {
+    'QCS_CONFIG': fixture_path('qcs_config.test'),
+    'FOREST_CONFIG': fixture_path('forest_config.test'),
+}
+
+
+def test_forest_session_request_authenticated_with_user_token():
+    config = PyquilConfig(test_config_paths)
+    config.configparsers['QCS_CONFIG'].set('Rigetti Forest', 'qmi_auth_token_path', fixture_path('qmi_auth_token_invalid.json'))
+    config.configparsers['QCS_CONFIG'].set('Rigetti Forest', 'user_auth_token_path', fixture_path('user_auth_token_valid.json'))
+    config.configparsers['QCS_CONFIG'].set('Rigetti Forest', 'url', 'mock://forest')
+    config._parse_auth_tokens()
+
+    session = ForestSession(config)
+    mock_adapter = requests_mock.Adapter()
+    session.mount('mock', mock_adapter)
+
+    url = '%s/devices' % config.forest_url
+    headers = {
+        # access token from ./data/user_auth_token_valid.json.
+        'Authorization': 'Bearer secret'
+    }
+    mock_adapter.register_uri('GET', url, status_code=200, json=[{'id': 0}], headers=headers)
+
+    devices = session.get(url).json()
+    assert len(devices) == 1
+    assert devices[0]['id'] == 0
+
+
+def test_forest_session_request_authenticated_with_qmi_auth():
+    config = PyquilConfig(test_config_paths)
+    config.configparsers['QCS_CONFIG'].set(
+        'Rigetti Forest', 'qmi_auth_token_path',
+        fixture_path('qmi_auth_token_valid.json'))
+    config.configparsers['QCS_CONFIG'].set(
+        'Rigetti Forest', 'user_auth_token_path',
+        fixture_path('user_auth_token_invalid.json'))
+    config.configparsers['QCS_CONFIG'].set('Rigetti Forest', 'url', 'mock://forest')
+    config._parse_auth_tokens()
+
+    session = ForestSession(config)
+    mock_adapter = requests_mock.Adapter()
+    session.mount('mock', mock_adapter)
+
+    url = '%s/devices' % config.forest_url
+    headers = {
+        # access token from ./data/qmi_auth_token_valid.json.
+        'X-QMI-AUTH-TOKEN': 'secret'
+    }
+    mock_adapter.register_uri('GET', url, status_code=200, json=[{'id': 0}], headers=headers)
+
+    devices = session.get(url).json()
+    assert len(devices) == 1
+    assert devices[0]['id'] == 0
+
+
+def test_forest_session_request_refresh_user_auth_token():
+    config = PyquilConfig(test_config_paths)
+    config.configparsers['QCS_CONFIG'].set(
+        'Rigetti Forest', 'qmi_auth_token_path',
+        fixture_path('qmi_auth_token_invalid.json'))
+    config.configparsers['QCS_CONFIG'].set(
+        'Rigetti Forest', 'user_auth_token_path',
+        fixture_path('user_auth_token_valid.json'))
+    config.configparsers['QCS_CONFIG'].set('Rigetti Forest', 'url', 'mock://forest')
+    config._parse_auth_tokens()
+
+    session = ForestSession(config)
+    mock_adapter = requests_mock.Adapter()
+    session.mount('mock', mock_adapter)
+
+    url = '%s/devices' % config.forest_url
+    response_list = [
+        # access token from ./data/user_auth_token_valid.json.
+        {'status_code': 401, 'json': {'error': 'user_unauthorized'}, 'headers': {'Authorization': 'Bearer secret'}},
+        # access token from new_user_auth_token.
+        {'status_code': 200, 'json': [{'id': 0}], 'headers': {'Authorization': 'Bearer secret2'}},
+    ]
+    mock_adapter.register_uri('GET', url, response_list=response_list)
+
+    refresh_url = '%s/auth/idp/oauth2/v1/token' % config.forest_url
+
+    def refresh_matcher(request):
+        body = dict(urllib.parse.parse_qsl(request.text))
+        return (body['refresh_token'] == 'supersecret') and (body['grant_type'] == 'refresh_token')
+    new_user_auth_token = {'access_token': 'secret2', 'refresh_token': 'supersecret2', 'scope': 'openid offline_access profile'}
+    mock_adapter.register_uri('POST', refresh_url, status_code=200, json=new_user_auth_token, additional_matcher=refresh_matcher)
+
+    # refresh will write the new auth tokens to file. Do not over-write text fixture data.
+    config.configparsers['QCS_CONFIG'].set('Rigetti Forest', 'qmi_auth_token_path', '/tmp/qmi_auth_token_invalid.json')
+    config.configparsers['QCS_CONFIG'].set('Rigetti Forest', 'user_auth_token_path', '/tmp/user_auth_token_valid.json')
+    devices = session.get(url).json()
+    assert len(devices) == 1
+    assert devices[0]['id'] == 0
+
+
+def test_forest_session_request_refresh_qmi_auth_token():
+    config = PyquilConfig(test_config_paths)
+    config.configparsers['QCS_CONFIG'].set(
+        'Rigetti Forest', 'qmi_auth_token_path',
+        fixture_path('qmi_auth_token_valid.json'))
+    config.configparsers['QCS_CONFIG'].set(
+        'Rigetti Forest', 'user_auth_token_path',
+        fixture_path('user_auth_token_invalid.json'))
+    config.configparsers['QCS_CONFIG'].set('Rigetti Forest', 'url', 'mock://forest')
+    config._parse_auth_tokens()
+
+    session = ForestSession(config)
+    mock_adapter = requests_mock.Adapter()
+    session.mount('mock', mock_adapter)
+
+    url = '%s/devices' % config.forest_url
+    response_list = [
+        # access token from ./data/user_auth_token_valid.json.
+        {'status_code': 401, 'json': {'error': 'user_unauthorized'}, 'headers': {'X-QMI-AUTH-TOKEN': 'ok'}},
+        # access token from new_user_auth_token.
+        {'status_code': 200, 'json': [{'id': 0}], 'headers': {'X-QMI-AUTH-TOKEN': 'ok'}},
+    ]
+    mock_adapter.register_uri('GET', url, response_list=response_list)
+
+    refresh_url = '%s/auth/qmi/refresh' % config.forest_url
+
+    def refresh_matcher(request):
+        body = request.json()
+        return (body['refresh_token'] == 'supersecret') and (body['access_token'] == 'ok')
+    new_user_auth_token = {'access_token': 'secret2', 'refresh_token': 'supersecret2'}
+    mock_adapter.register_uri('POST', refresh_url, status_code=200, json=new_user_auth_token, additional_matcher=refresh_matcher)
+
+    # refresh will write the new auth tokens to file. Do not over-write text fixture data.
+    config.configparsers['QCS_CONFIG'].set('Rigetti Forest', 'qmi_auth_token_path', '/tmp/qmi_auth_token_invalid.json')
+    config.configparsers['QCS_CONFIG'].set('Rigetti Forest', 'user_auth_token_path', '/tmp/user_auth_token_valid.json')
+    devices = session.get(url).json()
+    assert len(devices) == 1
+    assert devices[0]['id'] == 0

--- a/pyquil/tests/test_config.py
+++ b/pyquil/tests/test_config.py
@@ -1,0 +1,64 @@
+import pytest
+import os
+import requests_mock
+from pyquil.api._config import PyquilConfig
+
+
+def fixture_path(path: str) -> str:
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    return os.path.join(dir_path, 'data', path)
+
+
+test_config_paths = {
+    'QCS_CONFIG': fixture_path('qcs_config.test'),
+    'FOREST_CONFIG': fixture_path('forest_config.test'),
+}
+
+
+def test_config_qcs_auth_headers_valid_user_token():
+    config = PyquilConfig(test_config_paths)
+    config.user_auth_token = {
+        'access_token': 'secret',
+        'refresh_token': 'supersecret',
+        'scope': 'openid profile'}
+    config.qmi_auth_token = None
+    assert 'Authorization' in config.qcs_auth_headers
+    assert 'X-QMI-AUTH-TOKEN' not in config.qcs_auth_headers
+    assert config.qcs_auth_headers['Authorization'] == 'Bearer secret'
+
+
+def test_config_qcs_auth_headers_valid_qmi_token():
+    config = PyquilConfig(test_config_paths)
+    config.user_auth_token = None
+    config.qmi_auth_token = {
+        'access_token': 'secret',
+        'refresh_token': 'supersecret'}
+    assert 'Authorization' not in config.qcs_auth_headers
+    assert 'X-QMI-AUTH-TOKEN' in config.qcs_auth_headers
+    assert config.qcs_auth_headers['X-QMI-AUTH-TOKEN'] == 'secret'
+
+
+def test_config_assert_valid_auth_credential():
+    config = PyquilConfig(test_config_paths)
+    config.configparsers['QCS_CONFIG'].set(
+        'Rigetti Forest', 'qmi_auth_token_path',
+        fixture_path('qmi_auth_token_invalid.json'))
+    config.configparsers['QCS_CONFIG'].set(
+        'Rigetti Forest', 'user_auth_token_path',
+        fixture_path('user_auth_token_invalid.json'))
+    config._parse_auth_tokens()
+    assert config.user_auth_token is None
+    assert config.qmi_auth_token is None
+    with pytest.raises(ValueError) as excinfo:
+        config.assert_valid_auth_credential()
+
+    config.configparsers['QCS_CONFIG'].set(
+        'Rigetti Forest', 'qmi_auth_token_path',
+        fixture_path('qmi_auth_token_valid.json'))
+    config.configparsers['QCS_CONFIG'].set(
+        'Rigetti Forest', 'user_auth_token_path',
+        fixture_path('user_auth_token_valid.json'))
+    config._parse_auth_tokens()
+    assert config.user_auth_token is not None
+    assert config.qmi_auth_token is not None
+    config.assert_valid_auth_credential()


### PR DESCRIPTION
Description
-----------

Insert your PR description here. Thanks for contributing to pyQuil! 🙂

Use Okta or QMI auth token when authenticating to Forest server.

* Subclass `requests.Session` and override `#request` method to catch authn/z responses (ie 401 and 403).
* On 401/403 make the relevant call to refresh the the auth credentials.
* Re-write the auth credentials to file upon successful refresh.
* Retry request with updated auth credential.

Checklist
---------

- [X] The above description motivates these changes.
- [X] There is a unit test that covers these changes.
- [] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [X] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
