### PR TITLE
Allow RESET instructions to silently fall through the latex generation process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog
 
 ### Improvements and Changes
 
+- LaTeX circuit output now ignores `RESET` instructions by default, rendering
+  instead the (equivalent) program with `RESET` omitted. (@kilimanjaro,
+  gh-1118).
+
 ### Bugfixes
 
 [v2.14](https://github.com/rigetti/pyquil/compare/v2.13.0...v2.14.0) (November 25, 2019)

--- a/pyquil/latex/_diagram.py
+++ b/pyquil/latex/_diagram.py
@@ -86,7 +86,7 @@ PRAGMA_BEGIN_GROUP = 'LATEX_GATE_GROUP'
 PRAGMA_END_GROUP = 'END_LATEX_GATE_GROUP'
 
 UNSUPPORTED_INSTRUCTION_CLASSES = (
-    Wait, Reset, ResetQubit,
+    Wait,
     JumpConditional, JumpWhen, JumpUnless, Jump,
     UnaryClassicalInstruction, LogicalBinaryOp, ArithmeticBinaryOp,
     ClassicalMove, ClassicalExchange, ClassicalConvert,

--- a/pyquil/latex/tests/test_latex.py
+++ b/pyquil/latex/tests/test_latex.py
@@ -98,8 +98,7 @@ def test_unsupported_ops():
         JumpTarget(target),
         CNOT(0, 1))
 
-    bad_ops = [RESET(0),
-               WAIT,
+    bad_ops = [WAIT,
                Jump(target),
                MOVE(MemoryReference('reg1'), MemoryReference('reg2'))]
 


### PR DESCRIPTION
Description
-----------

As it currently stands, programs with RESET operations are not semantically different (in an ideal world) to those without them. Actual drawing of the detailed operation of RESET (which involves a measurement and some small amount of feedback control) is a significant scope creep to this latex code. Thus I propose simply ignoring RESET instructions for the purpose of rendering circuits.