### PR TITLE
pin mypy to 0.740

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pytest-timeout
 pytest-rerunfailures
 requests-mock
 flake8
-mypy
+mypy==0.740
 
 # docs
 sphinx


### PR DESCRIPTION
Description
-----------

Seems that the upgrade from mypy 0.740 to 0.750 broke `make typecheck`. Pinning to 0.740 solves the issue.

Following suggestion of @appleby 

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
