### PR TITLE
Send local_forest_runtime stdout and stderr to DEVNULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Changelog
 
 ### Bugfixes
 
+-   Don't attach pipes to stdout/stderr when starting quilc and qvm processes in
+    `local_forest_runtime`. This prevents the pipe buffers from getting full and
+    causing hung quilc/qvm for long running processes (@appleby, gh-1122).
+
 [v2.15](https://github.com/rigetti/pyquil/compare/v2.14.0...v2.15.0) (December 20, 2019)
 ----------------------------------------------------------------------------------------
 

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -892,8 +892,8 @@ def local_forest_runtime(
     else:
         qvm_cmd = ['qvm', '-S', '--host', host, '-p', str(qvm_port)]
         qvm = subprocess.Popen(qvm_cmd,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
+                               stdout=subprocess.DEVNULL,
+                               stderr=subprocess.DEVNULL)
 
     if _port_used(host if host != '0.0.0.0' else '127.0.0.1', quilc_port):
         warning_msg = ("Unable to start quilc server, since the specified "
@@ -906,8 +906,8 @@ def local_forest_runtime(
             quilc_cmd += ['-P']
 
         quilc = subprocess.Popen(quilc_cmd,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
+                                 stdout=subprocess.DEVNULL,
+                                 stderr=subprocess.DEVNULL)
 
     # Return context
     try:

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -1,13 +1,12 @@
 import itertools
 import random
-import socket
 
 import networkx as nx
 import numpy as np
 import pytest
 
 from pyquil import Program, get_qc, list_quantum_computers
-from pyquil.api import ForestConnection, QVM, QuantumComputer, local_forest_runtime
+from pyquil.api import QVM, QuantumComputer, local_forest_runtime
 from pyquil.tests.utils import DummyCompiler
 from pyquil.api._quantum_computer import (_symmetrization, _flip_array_to_prog,
                                           _construct_orthogonal_array,
@@ -611,41 +610,3 @@ def test_orthogonal_array():
             oa = _construct_orthogonal_array(num_q, strength=strength)
             for _ in range(10):
                 check_random_columns(oa, strength)
-
-
-# The timeout is required here because the bug we are regression testing results in a hung process
-# when the buffers for stdout/stderr that quilc and qvm were previously logging to fill up. Without
-# the timeout, a failing test might hang indefinitely.
-@pytest.mark.timeout(5)
-def test_local_forest_runtime_multiple_requests():
-    # https://github.com/rigetti/pyquil/issues/1110
-
-    # Grab a pair of unused local ports to run quilc and qvm on. We want unused ports to ensure that
-    # local_forest_runtime actually starts new quilc and qvm processes, rather than just falling
-    # back to any pre-existing processes listening on the standard ports. There is a race here since
-    # something else might come along and grab the ports after we close the sockets but before we
-    # start up the local_forest_runtime, but it feels like an unlikely enough edge case that it's
-    # not worth worrying about or jumping through SO_REUSEPORT hoops.
-    qvm_port = quilc_port = None
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1:
-        s1.bind(('127.0.0.1', 0))
-        qvm_port = s1.getsockname()[1]
-
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s2:
-        s2.bind(('127.0.0.1', 0))
-        quilc_port = s2.getsockname()[1]
-
-    with local_forest_runtime(qvm_port=qvm_port, quilc_port=quilc_port):
-        fc = ForestConnection(sync_endpoint=f"http://127.0.0.1:{qvm_port}",
-                              compiler_endpoint=f"tcp://127.0.0.1:{quilc_port}")
-        device = NxDevice(nx.complete_graph(1))
-        qc_forest = QuantumComputer(
-            name='testy!',
-            qam=QVM(connection=fc),
-            device=device,
-            compiler=DummyCompiler()
-        )
-        p = Program(I(0), MEASURE(0, "ro"))
-        p.declare("ro")
-        for i in range(150):
-            assert np.array_equal(qc_forest.run(p), [[0]])


### PR DESCRIPTION
When sending quilc and qvm stdout and stderr to a `subprocess.PIPE`, it's possible for the pipe buffer to fill up and cause the processes to hang when attempting to log on stderr. Switch these to `subprocess.DEVNULL` instead. This means you can no longer read log messages from the handles, but has the advantage that it doesn't require user intervention to periodically drain the pipe buffer to prevent a hang.

Note that this is a backwards-incompatible change.

Closes #1110

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
