### PR TITLE
Add support for QPU compilation over http(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Changelog
     mode, for a cleaner console and better user experience. This is only true for 
     errors where the cause is well known. (@kalzoo, gh-1123)
 -   `DEFGATE ... AS PAULI-SUM` is now supported (@ecpeterson, gh-1125).
+-   Connection to the QPU compiler supports both ZeroMQ and HTTP(S) (@kalzoo, gh-1127).
 
 ### Bugfixes
 

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -14,15 +14,19 @@
 #    limitations under the License.
 ##############################################################################
 import logging
+import sys
 import warnings
+from requests.exceptions import RequestException
 from typing import Dict, Any, List, Optional, Tuple
 from collections import Counter
 
 from rpcq import Client
+from rpcq._base import Message, to_json, from_json
 from rpcq.messages import (BinaryExecutableRequest, BinaryExecutableResponse,
                            NativeQuilRequest, TargetDevice,
                            PyQuilExecutableResponse, ParameterSpec,
                            RewriteArithmeticRequest)
+from urllib.parse import urljoin
 
 from pyquil import __version__
 from pyquil.api._base_connection import ForestSession, get_session
@@ -32,6 +36,11 @@ from pyquil.api._errors import UserMessageError
 from pyquil.device import AbstractDevice
 from pyquil.parser import parse_program
 from pyquil.quil import Program, Measurement, Declare
+
+if sys.version_info < (3, 7):
+    from pyquil.external.dataclasses import dataclass
+else:
+    from dataclasses import dataclass
 
 
 _log = logging.getLogger(__name__)
@@ -196,6 +205,7 @@ class QPUCompiler(AbstractCompiler):
         self.qpu_compiler_endpoint = qpu_compiler_endpoint
         self._qpu_compiler_client = None
 
+        self._device = device
         self.target_device = TargetDevice(isa=device.get_isa().to_dict(), specs=None)
         self.name = name
 
@@ -211,7 +221,22 @@ class QPUCompiler(AbstractCompiler):
         if not self._qpu_compiler_client:
             endpoint = self.qpu_compiler_endpoint or self.session.config.qpu_compiler_url
             if endpoint is not None:
-                self._qpu_compiler_client = Client(endpoint, timeout=self.timeout)
+                if endpoint.startswith(('http://', 'https://')):
+                    device_endpoint = urljoin(
+                        endpoint,
+                        f'devices/{self._device._raw["device_name"]}/'
+                    )
+                    self._qpu_compiler_client = HTTPCompilerClient(
+                        endpoint=device_endpoint,
+                        session=self.session
+                    )
+                elif endpoint.startswith('tcp://'):
+                    self._qpu_compiler_client = Client(endpoint, timeout=self.timeout)
+                else:
+                    raise UserMessageError(
+                        'Invalid endpoint provided to QPUCompiler. Expected protocol in [http://, '
+                        f'https://, tcp://], but received endpoint {endpoint}'
+                    )
         return self._qpu_compiler_client
 
     def connect(self) -> None:
@@ -352,3 +377,71 @@ class QVMCompiler(AbstractCompiler):
         timeout = self.client.timeout
         self.client.close()
         self.client = Client(self.endpoint, timeout=timeout)
+
+
+@dataclass
+class HTTPCompilerClient:
+    """
+    A class which partially implements the interface of rpcq.Client, to allow the QPUCompiler to
+    send compilation requests over HTTP(S) rather than ZeroMQ.
+
+    :param endpoint: The base url to which rpcq methods will be appended.
+    :param session: The ForestSession object which manages headers and authentication.
+    """
+
+    endpoint: str
+    session: ForestSession
+
+    def call(self,
+             method: str,
+             payload: Optional[Message] = None,
+             *,
+             rpc_timeout: int = 30) -> Message:
+        """
+        A partially-compatible implementation of rpcq.Client#call, which allows calling rpcq
+        methods over HTTP following the scheme:
+
+            POST <endpoint>/<method>
+            body: json-serialized <payload>
+
+        This implementation is meant for use only with the QPUCompiler and is not intended to be
+        a fully-compatible port of rpcq from ZeroMQ to HTTP.
+
+        If the request succeeds (per HTTP response code), the body of the response is parsed into
+        an RPCQ Message.
+
+        If the request fails, the response body should be a JSON object with a ``message`` field
+        indicating the cause of the failure. If present, that message is delivered to the user.
+
+        :param payload: The rpcq message body.
+        :param rpc_timeout: The number of seconds to wait to read data back from the service
+            after connection.
+            @see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+        """
+        url = urljoin(self.endpoint, method)
+
+        if payload:
+            body = to_json(payload)
+        else:
+            body = None
+
+        response = self.session.post(url, json=body, timeout=(1, rpc_timeout))
+
+        try:
+            response.raise_for_status()
+        except RequestException as e:
+            message = f'QPU Compiler {method} failed: '
+
+            try:
+                contents = response.json()
+            except Exception:
+                contents = None
+
+            if contents and contents.get('message'):
+                message += contents.get('message')
+            else:
+                message += 'please try again or contact support.'
+
+            raise UserMessageError(message) from e
+
+        return from_json(response.text)

--- a/pyquil/api/tests/test_compiler.py
+++ b/pyquil/api/tests/test_compiler.py
@@ -1,0 +1,145 @@
+import math
+import pytest
+import requests_mock
+
+from rpcq.core_messages import BinaryExecutableResponse
+
+from pyquil import Program
+from pyquil.api._base_connection import get_session
+from pyquil.api._compiler import QPUCompiler
+from pyquil.api._config import PyquilConfig
+from pyquil.api._errors import UserMessageError
+from pyquil.device import Device
+from pyquil.gates import RX, MEASURE
+from pyquil.tests.utils import api_fixture_path
+
+
+def simple_program():
+    program = Program()
+    readout = program.declare('ro', 'BIT', 3)
+    program += RX(math.pi / 2, 0)
+    program += MEASURE(0, readout[0])
+    return program
+
+
+SIMPLE_RESPONSE = {
+    "program": "bAsE64==",
+    "memory_descriptors": {},
+    "ro_sources": [],
+    "_type": "BinaryExecutableResponse"
+}
+
+DUMMY_ISA_DICT = {"1Q": {"0": {}, "1": {}}, "2Q": {"0-1": {}}}
+
+TEST_CONFIG_PATHS = {
+    'QCS_CONFIG': api_fixture_path('qcs_config.ini'),
+    'FOREST_CONFIG': api_fixture_path('forest_config.ini'),
+}
+
+
+def test_http_compilation(compiler):
+    device_name = 'test_device'
+    mock_url = 'http://mock-qpu-compiler'
+
+    config = PyquilConfig(TEST_CONFIG_PATHS)
+    session = get_session(config=config)
+    mock_adapter = requests_mock.Adapter()
+    session.mount('http://', mock_adapter)
+
+    headers = {
+        # access token from ./data/user_auth_token_valid.json.
+        'Authorization': 'Bearer secret'
+    }
+    mock_adapter.register_uri('POST',
+                              f'{mock_url}/devices/{device_name}/get_version_info',
+                              status_code=200,
+                              json={},
+                              headers=headers)
+
+    mock_adapter.register_uri('POST',
+                              f'{mock_url}/devices/{device_name}/native_quil_to_binary',
+                              status_code=200,
+                              json=SIMPLE_RESPONSE,
+                              headers=headers)
+
+    device = Device(name='not_actually_device_name',
+                    raw={
+                        'device_name': device_name,
+                        'isa': DUMMY_ISA_DICT
+                    })
+    compiler = QPUCompiler(quilc_endpoint=session.config.quilc_url,
+                           qpu_compiler_endpoint=mock_url,
+                           device=device,
+                           session=session)
+
+    compilation_result = compiler.native_quil_to_executable(
+        compiler.quil_to_native_quil(simple_program()))
+
+    assert isinstance(compilation_result, BinaryExecutableResponse)
+    assert compilation_result.program == SIMPLE_RESPONSE['program']
+
+
+def test_http_compilation_failure(compiler):
+    device_name = 'test_device'
+    mock_url = 'http://mock-qpu-compiler'
+
+    config = PyquilConfig(TEST_CONFIG_PATHS)
+    session = get_session(config=config)
+    mock_adapter = requests_mock.Adapter()
+    session.mount('http://', mock_adapter)
+
+    headers = {
+        # access token from ./data/user_auth_token_valid.json.
+        'Authorization': 'Bearer secret'
+    }
+
+    mock_adapter.register_uri('POST',
+                              f'{mock_url}/devices/{device_name}/get_version_info',
+                              status_code=200,
+                              json={},
+                              headers=headers)
+
+    mock_adapter.register_uri('POST',
+                              f'{mock_url}/devices/{device_name}/native_quil_to_binary',
+                              status_code=500,
+                              json={'message': 'test compilation failed'},
+                              headers=headers)
+
+    device = Device(name='not_actually_device_name',
+                    raw={
+                        'device_name': device_name,
+                        'isa': DUMMY_ISA_DICT
+                    })
+
+    compiler = QPUCompiler(quilc_endpoint=session.config.quilc_url,
+                           qpu_compiler_endpoint=mock_url,
+                           device=device,
+                           session=session)
+
+    native_quil = compiler.quil_to_native_quil(simple_program())
+
+    with pytest.raises(UserMessageError) as excinfo:
+        compiler.native_quil_to_executable(native_quil)
+
+    assert 'test compilation failed' in str(excinfo.value)
+
+
+def test_invalid_protocol():
+    device_name = 'test_device'
+    mock_url = 'not-http-or-tcp://mock-qpu-compiler'
+
+    config = PyquilConfig(TEST_CONFIG_PATHS)
+    session = get_session(config=config)
+    mock_adapter = requests_mock.Adapter()
+    session.mount('', mock_adapter)
+    device = Device(name='not_actually_device_name',
+                    raw={
+                        'device_name': device_name,
+                        'isa': DUMMY_ISA_DICT
+                    })
+
+    with pytest.raises(UserMessageError):
+        QPUCompiler(quilc_endpoint=session.config.quilc_url,
+                    qpu_compiler_endpoint=mock_url,
+                    device=device,
+                    session=session)


### PR DESCRIPTION
Description
-----------

Continues the discussion from https://github.com/kalzoo/pyquil/pull/1.

This small change allows compilation to take place over http(s) as well as zeromq, enabling architectural changes within the Rigetti QPU Compiler service.

This should be merged into master once `feature/qpu-authorization` is merged.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
