### PR TITLE
Bump quilc / qvm parent Docker images to v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Changelog
 
 ### Bugfixes
 
+-   Pinned the `mypy` version to work around issue with nested types causing the
+    `make typecheck` CI job to fail (@erichulburd, gh-1119).
 -   Minor fixes for `examples/1.3_vqe_demo.py` and `examples/quantum_walk.ipynb`
     (@appleby, gh-1116).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changelog
     the cause is well known. (@kalzoo, gh-1123)
 -   Connection to the QPU compiler now supports both ZeroMQ and HTTP(S)
     (@kalzoo, gh-1127).
+-   Bump quilc / qvm parent Docker images to v1.15.1 (@karalekas, gh-1128).
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,25 +10,26 @@ Changelog
     by requesting an `Engagement` from Forest Dispatch, which includes the keys
     necessary for encryption along with the endpoints to use. This workflow is
     managed by the new `ForestSession` class, and in the general case is
-    transparent to the user. (@kalzoo, gh-1123)
+    transparent to the user (@kalzoo, gh-1123).
 
 ### Improvements and Changes
 
--   Broadened the scope of `flake8` compliance to the include the `examples` and
-    `docs` directories, and thus the whole repository (@tommy-moffat, gh-1113).
 -   LaTeX circuit output now ignores `RESET` instructions by default, rendering
     instead the (equivalent) program with `RESET` omitted (@kilimanjaro, gh-1118)
--   Add unit test for validating Trotterization order (@jmbr, gh-1120).
--   Update authentication mechanism to Forest server. Preferentially use
-    credentials found at `~/.qcs/user_auth_credentials` and fallback to
-    `~/.qcs/qmi_auth_credentials`. (@erichulburd, gh-1123)
--   The log level can now be controlled with the `LOG_LEVEL` environment variable.
-    Set to `LOG_LEVEL=DEBUG` to help diagnose problems. (@kalzoo, gh-1123)
--   Certain errors will no longer print their entire stack trace outside of `DEBUG`
-    mode, for a cleaner console and better user experience. This is only true for 
-    errors where the cause is well known. (@kalzoo, gh-1123)
+-   Broadened the scope of `flake8` compliance to the include the `examples` and
+    `docs` directories, and thus the whole repository (@tommy-moffat, gh-1113).
 -   `DEFGATE ... AS PAULI-SUM` is now supported (@ecpeterson, gh-1125).
--   Connection to the QPU compiler supports both ZeroMQ and HTTP(S) (@kalzoo, gh-1127).
+-   Add unit test for validating Trotterization order (@jmbr, gh-1120).
+-   Updated the authentication mechanism to Forest server. Preferentially use
+    credentials found at `~/.qcs/user_auth_credentials` and fall back to
+    `~/.qcs/qmi_auth_credentials` (@erichulburd, gh-1123).
+-   The log level can now be controlled with the `LOG_LEVEL` environment variable,
+    set to `LOG_LEVEL=DEBUG` to help diagnose problems. In addition, certain errors
+    will no longer print their entire stack trace outside of `DEBUG` mode, for a
+    cleaner console and better user experience. This is only true for errors where
+    the cause is well known. (@kalzoo, gh-1123)
+-   Connection to the QPU compiler now supports both ZeroMQ and HTTP(S)
+    (@kalzoo, gh-1127).
 
 ### Bugfixes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# specify the dependency versions (can be overriden with --build-arg)
-ARG quilc_version=1.13.0
-ARG qvm_version=1.13.1
+# specify the dependency versions (can be overriden with --build_arg)
+ARG quilc_version=1.15.1
+ARG qvm_version=1.15.1
 ARG python_version=3.6
 
 # use multi-stage builds to independently pull dependency versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ FROM rigetti/quilc:$quilc_version as quilc
 FROM rigetti/qvm:$qvm_version as qvm
 FROM python:$python_version
 
-# copy over the pre-built quilc binary and tweedledum library from the first build stage
-COPY --from=quilc /usr/local/lib/libtweedledum.so /usr/local/lib/libtweedledum.so
+# copy over the pre-built quilc binary from the first build stage
 COPY --from=quilc /src/quilc/quilc /src/quilc/quilc
 
 # copy over the pre-built qvm binary from the second build stage
@@ -18,7 +17,7 @@ COPY --from=qvm /src/qvm/qvm /src/qvm/qvm
 # install the missing apt packages that aren't copied over
 RUN apt-get update && apt-get -yq dist-upgrade && \
     apt-get install --no-install-recommends -yq \
-    clang-7 git libblas-dev libffi-dev liblapack-dev libzmq3-dev && \
+    git libblas-dev libffi-dev liblapack-dev libzmq3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # install ipython


### PR DESCRIPTION
Description
-----------

Title is self-explanatory.

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
