### PR TITLE
Only request engagement from dispatch when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Changelog
     `make typecheck` CI job to fail (@erichulburd, gh-1119).
 -   Minor fixes for `examples/1.3_vqe_demo.py` and `examples/quantum_walk.ipynb`
     (@appleby, gh-1116).
+-   Only request engagement from Forest Dispatch when QPU and QPU Compiler addresses
+    are not provided by other configuration sources (@kalzoo, gh-1130).
 
 [v2.14](https://github.com/rigetti/pyquil/compare/v2.13.0...v2.14.0) (November 25, 2019)
 ----------------------------------------------------------------------------------------

--- a/pyquil/api/_config.py
+++ b/pyquil/api/_config.py
@@ -154,6 +154,9 @@ class PyquilConfig(object):
         # The engagement callback can be added by config consumers after construction
         self.get_engagement = lambda: None
 
+        # Whether engagement has been requested in order to provide any config values
+        self._engagement_requested = False
+
         self.config_parsers = {}
         for env_name, default_path in config_paths.items():
             default_path = expanduser(default_path)
@@ -205,6 +208,7 @@ class PyquilConfig(object):
         """
         try:
             if engagement_key is not None and self.get_engagement() is not None:
+                self._engagement_requested = True
                 return getattr(self.get_engagement(), engagement_key)
         except AttributeError:
             pass
@@ -225,6 +229,16 @@ class PyquilConfig(object):
     @property
     def engage_cmd(self) -> str:
         return self._env_or_config_or_default(**self.ENGAGE_CMD)
+
+    @property
+    def engagement(self) -> Optional['Engagement']:
+        """
+        An Engagement should only be made available to consumers if it was used to retrieve a
+        configuration value.
+        """
+        if not self._engagement_requested:
+            return
+        return self.get_engagement()
 
     @property
     def forest_url(self) -> str:

--- a/pyquil/api/tests/test_config.py
+++ b/pyquil/api/tests/test_config.py
@@ -57,3 +57,16 @@ def test_config_assert_valid_auth_credential():
     assert config.user_auth_token is not None
     assert config.qmi_auth_token is not None
     config.assert_valid_auth_credential()
+
+
+def test_engagement_not_requested_when_unnecessary():
+    config = PyquilConfig(TEST_CONFIG_PATHS)
+    config.config_parsers['FOREST_CONFIG'].set('Rigetti Forest',
+                                               'qpu_compiler_address',
+                                               'tcp://fake_compiler:5555')
+    config.config_parsers['FOREST_CONFIG'].set('Rigetti Forest',
+                                               'qpu_endpoint_address',
+                                               'tcp://fake_qpu:5555')
+    assert config.qpu_compiler_url == 'tcp://fake_compiler:5555'
+    assert config.qpu_url == 'tcp://fake_qpu:5555'
+    assert config.engagement is None


### PR DESCRIPTION
Description
-----------

This PR fixes an issue arising on the QMI when a `.forest_config` file is also present and includes `qpu_endpoint_address` and `qpu_compiler_address`. In that case, PyQuil still requested engagement and obtained a keypair, but then attempted to connect to the unencrypted endpoint specified in the `.forest_config`, which hangs.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
