### PR TITLE
Finish the rest of the type annotations for quil.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Changelog
 
 ### Improvements and Changes
 
--   Type hints have been added to the `Program` class (@rht, gh-1115, gh-1134)
+-   Some of the type hints have been added to the `quil.py` file
+    (@rht, gh-1115, gh-1134).
 -   Use [Black](https://black.readthedocs.io/en/stable/index.html) for code style
     and enforce it (along with a line length of 100) via the `style` (`flake8`)
     and `formatcheck` (`black --check`) CI jobs (@karalekas, gh-1132).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changelog
 
 ### Improvements and Changes
 
--   Added some type hints to the `Program` class (@rht, gh-1115).
+-   Type hints have been added to the `Program` class (@rht, gh-1115, gh-1134)
 -   Use [Black](https://black.readthedocs.io/en/stable/index.html) for code style
     and enforce it (along with a line length of 100) via the `style` (`flake8`)
     and `formatcheck` (`black --check`) CI jobs (@karalekas, gh-1132).

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ check-format:
 # The dream is to one day run mypy on the whole tree. For now, limit checks to known-good files.
 .PHONY: check-types
 check-types:
-	mypy pyquil/quilatom.py pyquil/quilbase.py pyquil/gates.py pyquil/noise.py
+	mypy pyquil/quilatom.py pyquil/quilbase.py pyquil/gates.py \
+		pyquil/noise.py pyquil/quil.py
 
 .PHONY: check-style
 check-style:

--- a/pyquil/noise.py
+++ b/pyquil/noise.py
@@ -200,7 +200,7 @@ def _check_kraus_ops(n: int, kraus_ops: Sequence[np.ndarray]) -> None:
 
 
 def _create_kraus_pragmas(
-    name: str, qubit_indices: Sequence[Any], kraus_ops: Sequence[np.ndarray]
+    name: str, qubit_indices: Sequence[int], kraus_ops: Sequence[np.ndarray]
 ) -> List[Pragma]:
     """
     Generate the pragmas to define a Kraus map for a specific gate on some qubits.
@@ -214,7 +214,7 @@ def _create_kraus_pragmas(
     pragmas = [
         Pragma(
             "ADD-KRAUS",
-            [name] + list(qubit_indices),
+            (name,) + tuple(qubit_indices),
             "({})".format(" ".join(map(format_parameter, np.ravel(k)))),
         )
         for k in kraus_ops

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -20,7 +20,19 @@ import itertools
 import types
 import warnings
 from collections import OrderedDict, defaultdict
-from typing import Any, Dict, Generator, List, Iterable, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    List,
+    Iterable,
+    Iterator,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 from rpcq.messages import NativeQuilMetadata
@@ -657,7 +669,7 @@ class Program(object):
         p.inst(other)
         return p
 
-    def __iadd__(self, other: "Program") -> "Program":
+    def __iadd__(self, other: object) -> "Program":
         """
         Concatenate two programs together using +=, returning a new one.
 
@@ -679,7 +691,7 @@ class Program(object):
             else self.instructions[index]
         )
 
-    def __iter__(self) -> Iterable[AbstractInstruction]:
+    def __iter__(self) -> Iterator[AbstractInstruction]:
         """
         Allow built in iteration through a program's instructions, e.g. [a for a in Program(X(0))]
 

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -778,7 +778,7 @@ def get_default_qubit_mapping(program: Program) -> Dict[Union[Qubit, QubitPlaceh
 
 
 def address_qubits(
-    program: Program, qubit_mapping: Optional[QubitPlaceholder, Union[Qubit, int]] = None
+    program: Program, qubit_mapping: Optional[Dict[QubitPlaceholder, Union[Qubit, int]]] = None
 ) -> Program:
     """
     Takes a program which contains placeholders and assigns them all defined values.

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -159,7 +159,7 @@ class Program(object):
         """
         if self._synthesized_instructions is None:
             self._synthesize()
-
+        assert self._synthesized_instructions is not None
         return self._synthesized_instructions
 
     def inst(self, *instructions: InstructionDesignator) -> "Program":
@@ -203,7 +203,7 @@ class Program(object):
                         else:
                             self.measure(instruction[1], instruction[2])
                     else:
-                        params = []
+                        params: List[ParameterDesignator] = []
                         possible_params = instruction[1]
                         rest: Sequence[Any] = instruction[2:]
                         if isinstance(possible_params, list):
@@ -679,7 +679,7 @@ class Program(object):
         """
         return self.inst(other)
 
-    def __getitem__(self, index: Union[slice, int]) -> "Program":
+    def __getitem__(self, index: Union[slice, int]) -> Union[AbstractInstruction, "Program"]:
         """
         Allows indexing into the program to get an action.
 

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -286,7 +286,7 @@ class Program(object):
         return self.inst(DefGate(name, matrix, parameters))
 
     def define_noisy_gate(
-        self, name: str, qubit_indices: Sequence[Any], kraus_ops: Sequence[Any]
+        self, name: str, qubit_indices: Sequence[int], kraus_ops: Sequence[Any]
     ) -> "Program":
         """
         Overload a static ideal gate with a noisy one defined in terms of a Kraus map.
@@ -834,7 +834,7 @@ def address_qubits(
         else:
             raise ValueError("Qubit mapping must map to type Qubit or int (but not both)")
 
-    result = []
+    result: List[AbstractInstruction] = []
     for instr in program:
         # Remap qubits on Gate, Measurement, and ResetQubit instructions
         if isinstance(instr, Gate):
@@ -847,7 +847,7 @@ def address_qubits(
         elif isinstance(instr, ResetQubit):
             result.append(ResetQubit(qubit_mapping[instr.qubit]))
         elif isinstance(instr, Pragma):
-            new_args = []
+            new_args: List[Union[Qubit, int, str]] = []
             for arg in instr.args:
                 # Pragmas can have arguments that represent things besides qubits, so here we
                 # make sure to just look up the QubitPlaceholders.
@@ -892,7 +892,7 @@ def instantiate_labels(instructions: Iterable[AbstractInstruction]) -> List[Abst
     """
     label_i = 1
     result: List[AbstractInstruction] = []
-    label_mapping = dict()
+    label_mapping: Dict[LabelPlaceholder, Label] = dict()
     for instr in instructions:
         if isinstance(instr, Jump) and isinstance(instr.target, LabelPlaceholder):
             new_target, label_mapping, label_i = _get_label(instr.target, label_mapping, label_i)
@@ -969,7 +969,7 @@ def implicitly_declare_ro(instructions: List[AbstractInstruction]) -> List[Abstr
 
 
 def merge_with_pauli_noise(
-    prog_list: Iterable[Program], probabilities: Sequence[float], qubits: Sequence[Any]
+    prog_list: Iterable[Program], probabilities: Sequence[float], qubits: Sequence[int]
 ) -> Program:
     """
     Insert pauli noise channels between each item in the list of programs.

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -105,12 +105,12 @@ class Program(object):
         # labels so the program must first be have its labels instantiated.
         # _synthesized_instructions is simply a cache on the result of the _synthesize()
         # method.  It is marked as None whenever new instructions are added.
-        self._synthesized_instructions = None
+        self._synthesized_instructions: Optional[List[AbstractInstruction]] = None
 
         self.inst(*instructions)
 
         # Filled in with quil_to_native_quil
-        self.native_quil_metadata = None  # type: NativeQuilMetadata
+        self.native_quil_metadata: Optional[NativeQuilMetadata] = None
 
         # default number of shots to loop through
         self.num_shots = 1
@@ -618,7 +618,7 @@ class Program(object):
         self._synthesized_instructions = None
         return res
 
-    def dagger(self, inv_dict: None = None, suffix: str = "-INV") -> "Program":
+    def dagger(self, inv_dict: Optional[Any] = None, suffix: str = "-INV") -> "Program":
         """
         Creates the conjugate transpose of the Quil program. The program must
         contain only gate applications.
@@ -657,7 +657,7 @@ class Program(object):
         self._synthesized_instructions = implicitly_declare_ro(self._synthesized_instructions)
         return self
 
-    def __add__(self, other: "Program") -> "Program":
+    def __add__(self, other: InstructionDesignator) -> "Program":
         """
         Concatenate two programs together, returning a new one.
 
@@ -669,7 +669,7 @@ class Program(object):
         p.inst(other)
         return p
 
-    def __iadd__(self, other: object) -> "Program":
+    def __iadd__(self, other: InstructionDesignator) -> "Program":
         """
         Concatenate two programs together using +=, returning a new one.
 
@@ -678,7 +678,7 @@ class Program(object):
         """
         return self.inst(other)
 
-    def __getitem__(self, index: Any) -> "Program":
+    def __getitem__(self, index: Union[slice, int]) -> "Program":
         """
         Allows indexing into the program to get an action.
 
@@ -867,10 +867,8 @@ def address_qubits(
 
 
 def _get_label(
-    placeholder: Union[Label, LabelPlaceholder],
-    label_mapping: Dict[Union[Label, LabelPlaceholder], Label],
-    label_i: int,
-) -> Tuple[Label, Dict[Union[Label, LabelPlaceholder], Label], int]:
+    placeholder: LabelPlaceholder, label_mapping: Dict[LabelPlaceholder, Label], label_i: int,
+) -> Tuple[Label, Dict[LabelPlaceholder, Label], int]:
     """Helper function to either get the appropriate label for a given placeholder or generate
     a new label and update the mapping.
 
@@ -971,7 +969,7 @@ def implicitly_declare_ro(instructions: List[AbstractInstruction]) -> List[Abstr
 
 
 def merge_with_pauli_noise(
-    prog_list: Iterable[Program], probabilities: List[float], qubits: Sequence[Any]
+    prog_list: Iterable[Program], probabilities: Sequence[float], qubits: Sequence[Any]
 ) -> Program:
     """
     Insert pauli noise channels between each item in the list of programs.
@@ -1001,7 +999,7 @@ def merge_with_pauli_noise(
     return p
 
 
-def merge_programs(prog_list: List[Program]) -> Program:
+def merge_programs(prog_list: Sequence[Program]) -> Program:
     """
     Merges a list of pyQuil programs into a single one by appending them in sequence.
     If multiple programs in the list contain the same gate and/or noisy gate definition

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -32,6 +32,7 @@ from typing import (
     Set,
     Tuple,
     Union,
+    no_type_check,
 )
 
 import numpy as np
@@ -798,6 +799,7 @@ def get_default_qubit_mapping(program: Program) -> Dict[Union[Qubit, QubitPlaceh
     return {qp: Qubit(i) for i, qp in enumerate(qubits)}
 
 
+@no_type_check
 def address_qubits(
     program: Program, qubit_mapping: Optional[Dict[QubitPlaceholder, Union[Qubit, int]]] = None
 ) -> Program:


### PR DESCRIPTION
Description
-----------

Continuation of the effort to annotate quil.py.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
