### PR TITLE
Add type annotations to noise.py and verify in the CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changelog
     rename the style-related `Makefile` targets and CI jobs so that they have
     a uniform naming convention: `check-all`, `check-format`, `check-style`,
     and `check-types` (@karalekas, gh-1133).
--   Added type hints to `noise.py` (@rht, gh-1136)
+-   Added type hints to `noise.py` (@rht, gh-1136).
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog
     rename the style-related `Makefile` targets and CI jobs so that they have
     a uniform naming convention: `check-all`, `check-format`, `check-style`,
     and `check-types` (@karalekas, gh-1133).
+-   Added type hints to `noise.py` (@rht, gh-1136)
 
 ### Bugfixes
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ check-format:
 # The dream is to one day run mypy on the whole tree. For now, limit checks to known-good files.
 .PHONY: check-types
 check-types:
-	mypy pyquil/quilatom.py pyquil/quilbase.py pyquil/gates.py
+	mypy pyquil/quilatom.py pyquil/quilbase.py pyquil/gates.py pyquil/noise.py
 
 .PHONY: check-style
 check-style:

--- a/docs/source/apidocs/noise.rst
+++ b/docs/source/apidocs/noise.rst
@@ -20,12 +20,9 @@ Functions
     get_noisy_gate
     _decoherence_noise_model
     decoherence_noise_with_asymmetric_ro
-    apply_noise_model
-    add_decoherence_noise
     estimate_bitstring_probs
     corrupt_bitstring_probs
     bitstring_probs_to_z_moments
-    estimate_assignment_probs
 
 
 Classes

--- a/pyquil/noise.py
+++ b/pyquil/noise.py
@@ -28,7 +28,7 @@ from pyquil.quilatom import MemoryReference, format_parameter, ParameterDesignat
 
 if TYPE_CHECKING:
     from pyquil.quil import Program
-    from pyquil.api import QPUConnection, QVMConnection
+    from pyquil.api import QPUConnection, QVMConnection  # noqa: F401
 
 INFINITY = float("inf")
 "Used for infinite coherence times."

--- a/pyquil/noise.py
+++ b/pyquil/noise.py
@@ -17,16 +17,16 @@
 Module for creating and verifying noisy gate and readout definitions.
 """
 from collections import namedtuple
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple, TYPE_CHECKING, Union
 
 import numpy as np
 import sys
 
 from pyquil.gates import I, MEASURE, X
 from pyquil.quilbase import Pragma, Gate
-from pyquil.quilatom import MemoryReference, format_parameter
+from pyquil.quilatom import MemoryReference, format_parameter, ParameterDesignator
 
-if False:  # used in mypy
+if TYPE_CHECKING:
     from pyquil.quil import Program
     from pyquil.api import QPUConnection, QVMConnection
 
@@ -163,7 +163,7 @@ class NoiseModel(_NoiseModel):
             assignment_probs={int(qid): np.array(a) for qid, a in d["assignment_probs"].items()},
         )
 
-    def gates_by_name(self, name: str) -> Sequence[KrausModel]:
+    def gates_by_name(self, name: str) -> List[KrausModel]:
         """
         Return all defined noisy gates of a particular gate name.
 
@@ -235,7 +235,7 @@ def append_kraus_to_gate(
     return [kj.dot(gate_matrix) for kj in kraus_ops]
 
 
-def pauli_kraus_map(probabilities: List[float]) -> List[np.ndarray]:
+def pauli_kraus_map(probabilities: Sequence[float]) -> List[np.ndarray]:
     r"""
     Generate the Kraus operators corresponding to a pauli channel.
 
@@ -368,7 +368,7 @@ class NoisyGateUndefined(Exception):
     pass
 
 
-def get_noisy_gate(gate_name: str, params: Tuple[float, ...]) -> Tuple[np.ndarray, str]:
+def get_noisy_gate(gate_name: str, params: Iterable[ParameterDesignator]) -> Tuple[np.ndarray, str]:
     """
     Look up the numerical gate representation and a proposed 'noisy' name.
 
@@ -677,7 +677,7 @@ def estimate_bitstring_probs(results: np.ndarray) -> np.ndarray:
 _CHARS = "klmnopqrstuvwxyzabcdefgh0123456789"
 
 
-def _apply_local_transforms(p: np.ndarray, ts: Sequence[np.ndarray]) -> np.ndarray:
+def _apply_local_transforms(p: np.ndarray, ts: Iterable[np.ndarray]) -> np.ndarray:
     """
     Given a 2d array of single shot results (outer axis iterates over shots, inner axis over bits)
     and a list of assignment probability matrices (one for each bit in the readout, ordered like

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -20,7 +20,7 @@ import itertools
 import types
 import warnings
 from collections import OrderedDict, defaultdict
-from typing import Any, Dict, List, Iterable, Optional, Set, Union
+from typing import Any, Dict, List, Iterable, Optional, Sequence, Set, Union
 
 import numpy as np
 from rpcq.messages import NativeQuilMetadata
@@ -262,7 +262,9 @@ class Program(object):
         """
         return self.inst(DefGate(name, matrix, parameters))
 
-    def define_noisy_gate(self, name, qubit_indices, kraus_ops):
+    def define_noisy_gate(
+        self, name: str, qubit_indices: Sequence[Any], kraus_ops: Sequence[Any]
+    ) -> "Program":
         """
         Overload a static ideal gate with a noisy one defined in terms of a Kraus map.
 
@@ -274,29 +276,29 @@ class Program(object):
             See also :ref:`the related docs in the WavefunctionSimulator Overview <basis_ordering>`.
 
 
-        :param str name: The name of the gate.
-        :param tuple|list qubit_indices: The qubits it acts on.
-        :param tuple|list kraus_ops: The Kraus operators.
+        :param name: The name of the gate.
+        :param qubit_indices: The qubits it acts on.
+        :param kraus_ops: The Kraus operators.
         :return: The Program instance
-        :rtype: Program
         """
         kraus_ops = [np.asarray(k, dtype=np.complex128) for k in kraus_ops]
         _check_kraus_ops(len(qubit_indices), kraus_ops)
         return self.inst(_create_kraus_pragmas(name, tuple(qubit_indices), kraus_ops))
 
-    def define_noisy_readout(self, qubit, p00, p11):
+    def define_noisy_readout(
+        self, qubit: Union[int, QubitPlaceholder], p00: float, p11: float
+    ) -> "Program":
         """
         For this program define a classical bit flip readout error channel parametrized by
         ``p00`` and ``p11``. This models the effect of thermal noise that corrupts the readout
         signal **after** it has interrogated the qubit.
 
-        :param int|QubitPlaceholder qubit: The qubit with noisy readout.
-        :param float p00: The probability of obtaining the measurement result 0 given that the qubit
+        :param qubit: The qubit with noisy readout.
+        :param p00: The probability of obtaining the measurement result 0 given that the qubit
           is in state 0.
-        :param float p11: The probability of obtaining the measurement result 1 given that the qubit
+        :param p11: The probability of obtaining the measurement result 1 given that the qubit
           is in state 1.
         :return: The Program with an appended READOUT-POVM Pragma.
-        :rtype: Program
         """
         if not 0.0 <= p00 <= 1.0:
             raise ValueError("p00 must be in the interval [0,1].")


### PR DESCRIPTION
Description
-----------

Remaining mypy errors of noise.py:
```
pyquil/noise.py:477: error: Argument 2 to "get_noisy_gate" has incompatible type "List[Union[Expression, Any, complex]]"; expected "Tuple[float, ...]"
pyquil/noise.py:558: error: Call to untyped function "define_noisy_gate" in typed context
pyquil/noise.py:562: error: Call to untyped function "define_noisy_readout" in typed context
pyquil/noise.py:580: error: Argument 1 to "tuple" has incompatible type "List[Union[Expression, Any, complex]]"; expected "Iterable[float]"
pyquil/noise.py:766: error: Argument 2 to "_apply_local_transforms" has incompatible type "Generator[Any, None, None]"; expected "Sequence[Any]"pyquil/noise.py:784: error: Argument 2 to "_apply_local_transforms" has incompatible type "Generator[Any, None, None]"; expected "Sequence[Any]"
Found 6 errors in 1 file (checked 1 source file)
```
Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
