### PR TITLE
Remove unused method Program._out() in quil.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Changelog
 -   Pass a sequence to np.vstack to avoid a FutureWarning, and add a protoquil keyword
     argument to MyLazyCompiler.quil_to_native_quil to avoid a TypeError in in the
     migration2-qc notebook (@appleby, gh-1138).
+-   Removed unused method `Program._out()` in quil.py (@rht, gh-1137).
 
 [v2.15](https://github.com/rigetti/pyquil/compare/v2.14.0...v2.15.0) (December 20, 2019)
 ----------------------------------------------------------------------------------------

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -514,20 +514,6 @@ class Program(object):
         self.num_shots = shots
         return self
 
-    def _out(self, allow_placeholders):
-        """
-        Converts the Quil program to a readable string.
-
-        :param allow_placeholders: Whether to complain if the program contains placeholders.
-        """
-        return "\n".join(
-            itertools.chain(
-                (dg.out() for dg in self._defined_gates),
-                (instr.out(allow_placeholders=allow_placeholders) for instr in self.instructions),
-                [""],
-            )
-        )
-
     def out(self) -> str:
         """
         Serializes the Quil program to a string suitable for submitting to the QVM or QPU.


### PR DESCRIPTION
Description
-----------

All of the classes that are derived from `AbstractInstruction` doesn't have `allow_placeholders` argument in their `out()` method.

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
