### PR TITLE
Fixes for migration2-qc.ipynb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Changelog
 -   Don't attach pipes to stdout/stderr when starting quilc and qvm processes in
     `local_forest_runtime`. This prevents the pipe buffers from getting full and
     causing hung quilc/qvm for long running processes (@appleby, gh-1122).
+-   Pass a sequence to np.vstack to avoid a FutureWarning, and add a protoquil keyword
+    argument to MyLazyCompiler.quil_to_native_quil to avoid a TypeError in in the
+    migration2-qc notebook (@appleby, gh-1138).
 
 [v2.15](https://github.com/rigetti/pyquil/compare/v2.14.0...v2.15.0) (December 20, 2019)
 ----------------------------------------------------------------------------------------

--- a/docs/source/migration2-qc.ipynb
+++ b/docs/source/migration2-qc.ipynb
@@ -227,7 +227,7 @@
    ],
    "source": [
     "import numpy as np\n",
-    "bitstring_array = np.vstack(bitstrings[q] for q in qc.qubits()).T\n",
+    "bitstring_array = np.vstack([bitstrings[q] for q in qc.qubits()]).T\n",
     "sums = np.sum(bitstring_array, axis=1)\n",
     "sums"
    ]
@@ -362,7 +362,7 @@
    ],
    "source": [
     "# Stacking everything\n",
-    "np.vstack(bitstrings[q] for q in qc.qubits()).T"
+    "np.vstack([bitstrings[q] for q in qc.qubits()]).T"
    ]
   },
   {
@@ -393,7 +393,7 @@
    "source": [
     "# Stacking what you want (contrast with above)\n",
     "qubits = [0, 1, 2]\n",
-    "np.vstack(bitstrings[q] for q in qubits).T"
+    "np.vstack([bitstrings[q] for q in qubits]).T"
    ]
   },
   {
@@ -448,7 +448,7 @@
     }
    ],
    "source": [
-    "bitstring_array = np.vstack(bitstrings[q] for q in qc.qubits()).T\n",
+    "bitstring_array = np.vstack([bitstrings[q] for q in qc.qubits()]).T\n",
     "sums = np.sum(bitstring_array, axis=1)\n",
     "sums"
    ]

--- a/docs/source/migration2-qc.ipynb
+++ b/docs/source/migration2-qc.ipynb
@@ -627,7 +627,7 @@
     "\n",
     "from pyquil.api._qac import AbstractCompiler\n",
     "class MyLazyCompiler(AbstractCompiler):\n",
-    "    def quil_to_native_quil(self, program):\n",
+    "    def quil_to_native_quil(self, program, *, protoquil=None):\n",
     "        return program\n",
     "    \n",
     "    def native_quil_to_executable(self, nq_program):\n",

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -350,7 +350,7 @@ class QuantumComputer:
         into a 2d numpy array of bitstrings, consider::
 
             bitstrings = qc.run_and_measure(...)
-            bitstring_array = np.vstack(bitstrings[q] for q in qc.qubits()).T
+            bitstring_array = np.vstack([bitstrings[q] for q in qc.qubits()]).T
             bitstring_array.shape  # (trials, len(qc.qubits()))
 
         .. note::


### PR DESCRIPTION
Description
-----------

**Eschew FutureWarning by passing np.vstack a sequence**

Fixes #1095

**Add protoquil kwarg to MyLazyCompiler.quil_to_native_quil**

Otherwise you get the following error when executing the last cell in this notebook:

    TypeError: quil_to_native_quil() got an unexpected keyword argument 'protoquil'

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
