### PR TITLE
Fix string concatenation style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog
     a uniform naming convention: `check-all`, `check-format`, `check-style`,
     and `check-types` (@karalekas, gh-1133).
 -   Added type hints to `noise.py` (@rht, gh-1136).
+-   Fixed string concatenation style (@peterjc, gh-1139).
 
 ### Bugfixes
 

--- a/pyquil/gates.py
+++ b/pyquil/gates.py
@@ -555,7 +555,7 @@ def MEASURE(
     elif isinstance(classical_reg, int):
         warn(
             "Indexing measurement addresses by integers is deprecated. "
-            + "Replacing this with the MemoryReference ro[i] instead."
+            "Replacing this with the MemoryReference ro[i] instead."
         )
         address = MemoryReference("ro", classical_reg)
     else:

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -812,7 +812,7 @@ class ClassicalMove(AbstractInstruction):
             and not isinstance(right, float)
         ):
             raise TypeError(
-                "Right operand of MOVE should be an MemoryReference " "or a numeric literal"
+                "Right operand of MOVE should be an MemoryReference or a numeric literal"
             )
         self.left = left
         self.right = right


### PR DESCRIPTION
Description
-----------

Fix two odd bits of string concatenation, one of which was likely a side effect of running black. Both found via this flake8 plugin (which I have used and contributed to):

https://github.com/keisheiled/flake8-implicit-str-concat

Checklist
---------

- [X] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
