### PR TITLE
Add typing to the latex module and mypy check in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,19 +17,21 @@ Changelog
     rename the style-related `Makefile` targets and CI jobs so that they have
     a uniform naming convention: `check-all`, `check-format`, `check-style`,
     and `check-types` (@karalekas, gh-1133).
--   Added type hints to `noise.py` (@rht, gh-1136).
--   Fixed string concatenation style (@peterjc, gh-1139).
+-   Added type hints to `noise.py`, began verifying in the CI (@rht, gh-1136).
 -   Improved reStructuredText markup in docstrings (@peterjc, gh-1141).
+-   Added typing to the `pyquil/latex` module and added the module to the
+    `check-types` CI job (@karalekas, gh-1142).
 
 ### Bugfixes
 
 -   Don't attach pipes to stdout/stderr when starting quilc and qvm processes in
     `local_forest_runtime`. This prevents the pipe buffers from getting full and
     causing hung quilc/qvm for long running processes (@appleby, gh-1122).
--   Pass a sequence to np.vstack to avoid a FutureWarning, and add a protoquil keyword
-    argument to MyLazyCompiler.quil_to_native_quil to avoid a TypeError in in the
-    migration2-qc notebook (@appleby, gh-1138).
--   Removed unused method `Program._out()` in quil.py (@rht, gh-1137).
+-   Pass a sequence to `np.vstack` to avoid a `FutureWarning`, and add a protoquil
+    keyword argument to `MyLazyCompiler.quil_to_native_quil` to avoid a `TypeError`
+    in the `migration2-qc.ipynb` notebook (@appleby, gh-1138).
+-   Removed unused method `Program._out()` in `quil.py` (@rht, gh-1137).
+-   Fixed string concatenation style, caused by `black` (@peterjc, gh-1139).
 
 [v2.15](https://github.com/rigetti/pyquil/compare/v2.14.0...v2.15.0) (December 20, 2019)
 ----------------------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ Changelog
 
 ### Improvements and Changes
 
--   Some of the type hints have been added to the `quil.py` file
-    (@rht, gh-1115, gh-1134).
+-   Type hints have been added to the `quil.py` file (@rht, gh-1115, gh-1134).
 -   Use [Black](https://black.readthedocs.io/en/stable/index.html) for code style
     and enforce it (along with a line length of 100) via the `style` (`flake8`)
     and `formatcheck` (`black --check`) CI jobs (@karalekas, gh-1132).

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ check-format:
 .PHONY: check-types
 check-types:
 	mypy pyquil/quilatom.py pyquil/quilbase.py pyquil/gates.py \
-		pyquil/noise.py pyquil/quil.py
+		pyquil/noise.py pyquil/quil.py pyquil/latex
 
 .PHONY: check-style
 check-style:

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,3 +22,11 @@ no_implicit_reexport = True
 # Ignore errors in generated parser files
 [mypy-pyquil._parser.gen3.*]
 ignore_errors = True
+
+# Ignore errors in vendored third-party libraries
+[mypy-pyquil.external.*]
+ignore_errors = True
+
+# Ignore errors in test files
+[mypy-*/tests/*]
+ignore_errors = True

--- a/pyquil/latex/_diagram.py
+++ b/pyquil/latex/_diagram.py
@@ -445,8 +445,7 @@ class DiagramBuilder:
         # walk instructions until the group end
         for j in range(start, len(self.working_instructions)):
             instruction_j = self.working_instructions[j]
-            assert isinstance(instruction_j, Pragma)
-            if instruction_j.command == PRAGMA_END_GROUP:
+            if isinstance(instruction_j, Pragma) and instruction_j.command == PRAGMA_END_GROUP:
                 # recursively build the diagram for this block
                 # we do not want labels here!
                 block_settings = replace(  # type: ignore

--- a/pyquil/latex/_diagram.py
+++ b/pyquil/latex/_diagram.py
@@ -15,6 +15,7 @@
 ##############################################################################
 
 import sys
+from collections import defaultdict
 from typing import Iterable, List, Sequence, Mapping, Optional, Set, Tuple, cast
 from warnings import warn
 
@@ -42,7 +43,6 @@ from pyquil.quilbase import (
     Gate,
     Pragma,
 )
-from collections import defaultdict
 
 if sys.version_info < (3, 7):
     from pyquil.external.dataclasses import dataclass, replace

--- a/pyquil/latex/_diagram.py
+++ b/pyquil/latex/_diagram.py
@@ -224,7 +224,7 @@ class DiagramState:
         self.qubits = qubits
         self.lines: Mapping[int, List[str]] = defaultdict(list)
 
-    def extend_lines_to_common_edge(self, qubits: Sequence[int], offset: int = 0) -> None:
+    def extend_lines_to_common_edge(self, qubits: Iterable[int], offset: int = 0) -> None:
         """
         Add NOP operations on the lines associated with the given qubits, until
         all lines are of the same width.
@@ -356,7 +356,7 @@ class DiagramBuilder:
         """
         Actually build the diagram.
         """
-        qubits = cast(Set[int], self.circuit.get_qubits())
+        qubits = cast(Set[int], self.circuit.get_qubits(indices=True))
         all_qubits = (
             range(min(qubits), max(qubits) + 1)
             if self.settings.impute_missing_qubits

--- a/pyquil/latex/_diagram.py
+++ b/pyquil/latex/_diagram.py
@@ -15,11 +15,11 @@
 ##############################################################################
 
 import sys
+from typing import Iterable, List, Sequence, Mapping, Optional, Set, Tuple, cast
 from warnings import warn
 
-from pyquil import Program
-from pyquil.quil import Measurement, Gate, Pragma
-from pyquil.quilatom import format_parameter
+from pyquil.quil import Program
+from pyquil.quilatom import ParameterDesignator, QubitDesignator, format_parameter
 from pyquil.quilbase import (
     AbstractInstruction,
     Wait,
@@ -38,6 +38,9 @@ from pyquil.quilbase import (
     ClassicalStore,
     ClassicalComparison,
     RawInstr,
+    Measurement,
+    Gate,
+    Pragma,
 )
 from collections import defaultdict
 
@@ -119,52 +122,63 @@ UNSUPPORTED_INSTRUCTION_CLASSES = (
 # TikZ operators
 
 
-def TIKZ_LEFT_KET(qubit):
+def TIKZ_LEFT_KET(qubit: int) -> str:
     return r"\lstick{{\ket{{q_{{{qubit}}}}}}}".format(qubit=qubit)
 
 
-def TIKZ_CONTROL(control, offset):
+def TIKZ_CONTROL(control: int, offset: int) -> str:
     return r"\ctrl{{{offset}}}".format(offset=offset)
 
 
-def TIKZ_CNOT_TARGET():
+def TIKZ_CNOT_TARGET() -> str:
     return r"\targ{}"
 
 
-def TIKZ_CPHASE_TARGET():
+def TIKZ_CPHASE_TARGET() -> str:
     return r"\control{}"
 
 
-def TIKZ_SWAP(source, offset):
+def TIKZ_SWAP(source: int, offset: int) -> str:
     return r"\swap{{{offset}}}".format(offset=offset)
 
 
-def TIKZ_SWAP_TARGET():
+def TIKZ_SWAP_TARGET() -> str:
     return r"\targX{}"
 
 
-def TIKZ_NOP():
+def TIKZ_NOP() -> str:
     return r"\qw"
 
 
-def TIKZ_MEASURE():
+def TIKZ_MEASURE() -> str:
     return r"\meter{}"
 
 
-def _format_parameter(param, settings=None):
+def _format_parameter(
+    param: ParameterDesignator, settings: Optional[DiagramSettings] = None
+) -> str:
     formatted = format_parameter(param)
     if settings and settings.texify_numerical_constants:
         formatted = formatted.replace("pi", r"\pi")
     return formatted
 
 
-def _format_parameters(params, settings=None):
+def _format_parameters(
+    params: Iterable[ParameterDesignator], settings: Optional[DiagramSettings] = None
+) -> str:
     return "(" + ",".join(_format_parameter(param, settings) for param in params) + ")"
 
 
-def TIKZ_GATE(name, size=1, params=None, dagger=False, settings=None):
+def TIKZ_GATE(
+    name: str,
+    size: int = 1,
+    params: Optional[Sequence[ParameterDesignator]] = None,
+    dagger: bool = False,
+    settings: Optional[DiagramSettings] = None,
+) -> str:
     cmd = r"\gate"
-    if settings and settings.abbreviate_controlled_rotations and name in ["RX", "RY", "RZ"]:
+    rotations = ["RX", "RY", "RZ"]
+    if settings and settings.abbreviate_controlled_rotations and name in rotations and params:
         name = name[1] + "_{{{param}}}".format(param=_format_parameter(params[0], settings))
         return cmd + "{{{name}}}".format(name=name)
     # now, handle the general case
@@ -180,7 +194,7 @@ def TIKZ_GATE(name, size=1, params=None, dagger=False, settings=None):
     return cmd + "{{{name}}}".format(name=name)
 
 
-def TIKZ_GATE_GROUP(qubits, width, label):
+def TIKZ_GATE_GROUP(qubits: Sequence[int], width: int, label: str) -> str:
     num_qubits = max(qubits) - min(qubits) + 1
     return (
         "\\gategroup[{qubits},steps={width},style={{dashed, rounded corners,"
@@ -206,11 +220,11 @@ class DiagramState:
     TikZ operators.
     """
 
-    def __init__(self, qubits):
+    def __init__(self, qubits: Sequence[int]):
         self.qubits = qubits
-        self.lines = defaultdict(list)
+        self.lines: Mapping[int, List[str]] = defaultdict(list)
 
-    def extend_lines_to_common_edge(self, qubits, offset=0):
+    def extend_lines_to_common_edge(self, qubits: Sequence[int], offset: int = 0) -> None:
         """
         Add NOP operations on the lines associated with the given qubits, until
         all lines are of the same width.
@@ -220,20 +234,22 @@ class DiagramState:
             while self.width(q) < max_width:
                 self.append(q, TIKZ_NOP())
 
-    def width(self, qubit):
+    def width(self, qubit: int) -> int:
         """
         The width of the diagram, in terms of the number of operations, on the
         specified qubit line.
         """
         return len(self.lines[qubit])
 
-    def append(self, qubit, op):
+    def append(self, qubit: int, op: str) -> None:
         """
         Add an operation to the rightmost edge of the specified qubit line.
         """
         self.lines[qubit].append(op)
 
-    def append_diagram(self, diagram, group=None):
+    def append_diagram(
+        self, diagram: "DiagramState", group: Optional[str] = None
+    ) -> "DiagramState":
         """
         Add all operations represented by the given diagram to their
         corresponding qubit lines in this diagram.
@@ -263,7 +279,7 @@ class DiagramState:
             )
         return self
 
-    def interval(self, low, high) -> list:
+    def interval(self, low: int, high: int) -> List[int]:
         """
         All qubits in the diagram, from low to high, inclusive.
         """
@@ -271,14 +287,16 @@ class DiagramState:
         qubits = list(set(full_interval) & set(self.qubits))
         return sorted(qubits)
 
-    def is_interval(self, qubits) -> bool:
+    def is_interval(self, qubits: Sequence[int]) -> bool:
         """
         Do the specified qubits correspond to an interval in this diagram?
         """
         return qubits == self.interval(min(qubits), max(qubits))
 
 
-def split_on_terminal_measures(program: Program) -> tuple:
+def split_on_terminal_measures(
+    program: Program,
+) -> Tuple[List[AbstractInstruction], List[AbstractInstruction]]:
     """
     Split a program into two lists of instructions:
 
@@ -289,10 +307,10 @@ def split_on_terminal_measures(program: Program) -> tuple:
     if not any(isinstance(instr, Measurement) for instr in program.instructions):
         return [], program.instructions
 
-    seen_qubits = set()
+    seen_qubits: Set[QubitDesignator] = set()
 
-    measures = []
-    remaining = []
+    measures: List[AbstractInstruction] = []
+    remaining: List[AbstractInstruction] = []
     in_group = False
     for instr in reversed(program.instructions):
         if not in_group and isinstance(instr, Measurement) and instr.qubit not in seen_qubits:
@@ -322,23 +340,23 @@ class DiagramBuilder:
     recursive methods.
     """
 
-    def __init__(self, circuit, settings):
+    def __init__(self, circuit: Program, settings: DiagramSettings):
         self.circuit = circuit
         self.settings = settings
         # instructions currently being processed
-        self.working_instructions = None
+        self.working_instructions: Optional[List[AbstractInstruction]] = None
         # index into working instructions. we maintain the invariant that
         # working_instructions[0:index] has been processed, with the diagram
         # updated accordingly
         self.index = 0
         # partially constructed diagram
-        self.diagram = None
+        self.diagram: Optional[DiagramState] = None
 
-    def build(self):
+    def build(self) -> DiagramState:
         """
         Actually build the diagram.
         """
-        qubits = self.circuit.get_qubits()
+        qubits = cast(Set[int], self.circuit.get_qubits())
         all_qubits = (
             range(min(qubits), max(qubits) + 1)
             if self.settings.impute_missing_qubits
@@ -410,13 +428,15 @@ class DiagramBuilder:
         self.diagram.extend_lines_to_common_edge(self.diagram.qubits, offset=offset)
         return self.diagram
 
-    def _build_group(self):
+    def _build_group(self) -> None:
         """
         Update the partial diagram with the subcircuit delimited by the grouping PRAGMA.
 
         Advances the index beyond the ending pragma.
         """
+        assert self.working_instructions is not None
         instr = self.working_instructions[self.index]
+        assert isinstance(instr, Pragma)
         if len(instr.args) != 0:
             raise ValueError(
                 f"PRAGMA {PRAGMA_BEGIN_GROUP} expected a freeform string, or nothing at all."
@@ -424,18 +444,18 @@ class DiagramBuilder:
         start = self.index + 1
         # walk instructions until the group end
         for j in range(start, len(self.working_instructions)):
-            if (
-                isinstance(self.working_instructions[j], Pragma)
-                and self.working_instructions[j].command == PRAGMA_END_GROUP
-            ):
+            instruction_j = self.working_instructions[j]
+            assert isinstance(instruction_j, Pragma)
+            if instruction_j.command == PRAGMA_END_GROUP:
                 # recursively build the diagram for this block
                 # we do not want labels here!
-                block_settings = replace(
+                block_settings = replace(  # type: ignore
                     self.settings, label_qubit_lines=False, qubit_line_open_wire_length=0
                 )
-                subcircuit = Program(self.working_instructions[start:j])
+                subcircuit = Program(*self.working_instructions[start:j])
                 block = DiagramBuilder(subcircuit, block_settings).build()
                 block_name = instr.freeform_string if instr.freeform_string else ""
+                assert self.diagram is not None
                 self.diagram.append_diagram(block, group=block_name)
                 # advance to the instruction following this one
                 self.index = j + 1
@@ -443,25 +463,31 @@ class DiagramBuilder:
 
         raise ValueError("Unable to find PRAGMA {} matching {}.".format(PRAGMA_END_GROUP, instr))
 
-    def _build_measure(self):
+    def _build_measure(self) -> None:
         """
         Update the partial diagram with a measurement operation.
 
         Advances the index by one.
         """
+        assert self.working_instructions is not None
         instr = self.working_instructions[self.index]
+        assert isinstance(instr, Measurement)
+        assert self.diagram is not None
         self.diagram.append(instr.qubit.index, TIKZ_MEASURE())
         self.index += 1
 
-    def _build_custom_source_target_op(self):
+    def _build_custom_source_target_op(self) -> None:
         """
         Update the partial diagram with a single operation involving a source and a target
         (e.g. a controlled gate, a swap).
 
         Advances the index by one.
         """
+        assert self.working_instructions is not None
         instr = self.working_instructions[self.index]
+        assert isinstance(instr, Gate)
         source, target = qubit_indices(instr)
+        assert self.diagram is not None
         displaced = self.diagram.interval(min(source, target), max(source, target))
         self.diagram.extend_lines_to_common_edge(displaced)
         source_op, target_op = SOURCE_TARGET_OP[instr.name]
@@ -471,32 +497,39 @@ class DiagramBuilder:
         self.diagram.extend_lines_to_common_edge(displaced)
         self.index += 1
 
-    def _build_1q_unitary(self):
+    def _build_1q_unitary(self) -> None:
         """
         Update the partial diagram with a 1Q gate.
 
         Advances the index by one.
         """
+        assert self.working_instructions is not None
         instr = self.working_instructions[self.index]
+        assert isinstance(instr, Gate)
         qubits = qubit_indices(instr)
         dagger = sum(m == "DAGGER" for m in instr.modifiers) % 2 == 1
+
+        assert self.diagram is not None
         self.diagram.append(
             qubits[0],
             TIKZ_GATE(instr.name, params=instr.params, dagger=dagger, settings=self.settings),
         )
         self.index += 1
 
-    def _build_generic_unitary(self):
+    def _build_generic_unitary(self) -> None:
         """
         Update the partial diagram with a unitary operation.
 
         Advances the index by one.
         """
+        assert self.working_instructions is not None
         instr = self.working_instructions[self.index]
+        assert isinstance(instr, Gate)
         qubits = qubit_indices(instr)
         dagger = sum(m == "DAGGER" for m in instr.modifiers) % 2 == 1
         controls = sum(m == "CONTROLLED" for m in instr.modifiers)
 
+        assert self.diagram is not None
         self.diagram.extend_lines_to_common_edge(qubits)
 
         control_qubits = qubits[:controls]
@@ -521,7 +554,7 @@ class DiagramBuilder:
         self.index += 1
 
 
-def qubit_indices(instr: AbstractInstruction) -> list:
+def qubit_indices(instr: AbstractInstruction) -> List[int]:
     """
     Get a list of indices associated with the given instruction.
     """

--- a/pyquil/latex/_ipython.py
+++ b/pyquil/latex/_ipython.py
@@ -18,15 +18,17 @@ import os
 import subprocess
 import shutil
 import tempfile
-from typing import Optional
+from typing import Any, Optional
 from IPython.display import Image
 
-from pyquil import Program
+from pyquil.quil import Program
 from pyquil.latex._main import to_latex
 from pyquil.latex._diagram import DiagramSettings
 
 
-def display(circuit: Program, settings: Optional[DiagramSettings] = None, **image_options) -> Image:
+def display(
+    circuit: Program, settings: Optional[DiagramSettings] = None, **image_options: Any
+) -> Image:
     """
     Displays a PyQuil circuit as an IPython image object.
 

--- a/pyquil/latex/_ipython.py
+++ b/pyquil/latex/_ipython.py
@@ -15,15 +15,15 @@
 ##############################################################################
 
 import os
-import subprocess
 import shutil
+import subprocess
 import tempfile
-from typing import Any, Optional
 from IPython.display import Image
+from typing import Any, Optional
 
-from pyquil.quil import Program
 from pyquil.latex._main import to_latex
 from pyquil.latex._diagram import DiagramSettings
+from pyquil.quil import Program
 
 
 def display(

--- a/pyquil/latex/_ipython.py
+++ b/pyquil/latex/_ipython.py
@@ -41,11 +41,9 @@ def display(
        ``geometry``, ``tikz``, and ``quantikz``. If it does not, you need to install
        these yourself.
 
-    :param Program circuit: The circuit to be drawn, represented as a pyquil program.
-    :param DiagramSettings settings: An optional object of settings controlling diagram rendering
-        and layout.
+    :param circuit: The circuit to be drawn, represented as a pyquil program.
+    :param settings: An optional object of settings controlling diagram rendering and layout.
     :return: PNG image render of the circuit.
-    :rtype: IPython.display.Image
     """
     # The conversion process relies on two passes: first, 'pdflatex' is called to
     # render the tikz to a pdf. Second, Imagemagick's 'convert' is called to translate

--- a/pyquil/latex/_main.py
+++ b/pyquil/latex/_main.py
@@ -18,7 +18,7 @@ The main entry point to the LaTeX generation functionality in pyQuil.
 """
 from typing import Optional
 
-from pyquil import Program
+from pyquil.quil import Program
 from pyquil.latex._diagram import DiagramBuilder, DiagramSettings
 
 

--- a/pyquil/latex/_main.py
+++ b/pyquil/latex/_main.py
@@ -18,8 +18,8 @@ The main entry point to the LaTeX generation functionality in pyQuil.
 """
 from typing import Optional
 
-from pyquil.quil import Program
 from pyquil.latex._diagram import DiagramBuilder, DiagramSettings
+from pyquil.quil import Program
 
 
 def to_latex(circuit: Program, settings: Optional[DiagramSettings] = None) -> str:

--- a/pyquil/latex/latex_generation.py
+++ b/pyquil/latex/latex_generation.py
@@ -17,7 +17,7 @@
 import warnings
 from typing import Optional
 
-from pyquil import Program
+from pyquil.quil import Program
 from pyquil.latex._diagram import DiagramSettings
 
 

--- a/pyquil/latex/latex_generation.py
+++ b/pyquil/latex/latex_generation.py
@@ -17,8 +17,8 @@
 import warnings
 from typing import Optional
 
-from pyquil.quil import Program
 from pyquil.latex._diagram import DiagramSettings
+from pyquil.quil import Program
 
 
 def to_latex(circuit: Program, settings: Optional[DiagramSettings] = None) -> str:


### PR DESCRIPTION
Description
-----------

More fun with typing.

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
