### PR TITLE
Start using Travis CI, upgrade style checks to py37

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,28 @@
 Description
 -----------
 
-Insert your PR description here. Thanks for contributing to pyQuil! 🙂
+Insert your PR description here. Thanks for [contributing][contributing] to pyQuil! 🙂
 
 Checklist
 ---------
 
 - [ ] The above description motivates these changes.
 - [ ] There is a unit test that covers these changes.
-- [ ] All new and existing tests pass locally and on Semaphore.
-- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
-- [ ] Functions and classes have useful sphinx-style docstrings.
-- [ ] (New Feature) The docs have been updated accordingly.
-- [ ] (Bugfix) The associated issue is referenced above using
-      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
-- [ ] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
-      including author and PR number (@username, gh-xxx).
+- [ ] All new and existing tests pass locally and on [Travis CI][travis].
+- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
+- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
+- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
+- [ ] (New Feature) The [docs][docs] have been updated accordingly.
+- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
+- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).
+
+
+[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
+[black]: https://black.readthedocs.io/en/stable/index.html
+[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
+[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
+[docs]: https://pyquil.readthedocs.io
+[flake8]: http://flake8.pycqa.org
+[pep-484]: https://www.python.org/dev/peps/pep-0484/
+[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
+[travis]: https://travis-ci.org/rigetti/pyquil

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ services:
     command: ["-R"]
 
 build-docs:
-  image: python:3.6
+  image: python:3.7
   tags:
     - github
   script:
@@ -26,7 +26,7 @@ build-docs:
     - make docs
 
 check-format:
-  image: python:3.6
+  image: python:3.7
   tags:
     - github
   script:
@@ -35,7 +35,7 @@ check-format:
     - make check-format
 
 check-style:
-  image: python:3.6
+  image: python:3.7
   tags:
     - github
   script:
@@ -44,7 +44,7 @@ check-style:
     - make check-style
 
 check-types:
-  image: python:3.6
+  image: python:3.7
   tags:
     - github
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ services:
     command: ["-R"]
 
 build-docs:
-  image: python:3.7
+  image: python:3.6
   tags:
     - github
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - '3.7'
+env:
+  - TARGET=build-docs
+  - TARGET=check-format
+  - TARGET=check-types
+  - TARGET=check-style
+  - TARGET=test
+jobs:
+  include:
+    - python: '3.6'
+      env: TARGET=test
+    - python: '3.8'
+      env: TARGET=test
+script: make $TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: python
+
+addons:
+  apt:
+    packages:
+      - pandoc
+
 python:
   - '3.7'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - '3.7'
 env:
-  - TARGET=build-docs
+  - TARGET=docs
   - TARGET=check-format
   - TARGET=check-types
   - TARGET=check-style

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
 install:
   - make install
   - make requirements
+  - pip install --upgrade pytest
 
 script:
   - make $TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,17 @@ jobs:
       env: TARGET=test
     - python: '3.8'
       env: TARGET=test
-script: make $TARGET
+
+services:
+  - docker
+
+before_install:
+  - docker run --rm -itd -p 5555:5555 rigetti/quilc -R
+  - docker run --rm -itd -p 5000:5000 rigetti/qvm -S
+
+install:
+  - make install
+  - make requirements
+
+script:
+  - make $TARGET

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Changelog
 -   The code in `gate_matrices.py`, `numpy_simulator.py`, `reference_simulator.py`,
     and `unitary_tools.py` has been typed and reorganized into a new `simulation`
     subdirectory, maintaining backwards compatibility (@karalekas, gh-1143).
+-   Added a `.travis.yml` file to enable Travis CI for external-contributor builds,
+    and upgraded GitLab CI style checks to py37 (@karalekas, gh-1145).
 
 ### Bugfixes
 

--- a/pyquil/latex/_diagram.py
+++ b/pyquil/latex/_diagram.py
@@ -448,7 +448,7 @@ class DiagramBuilder:
             if isinstance(instruction_j, Pragma) and instruction_j.command == PRAGMA_END_GROUP:
                 # recursively build the diagram for this block
                 # we do not want labels here!
-                block_settings = replace(  # type: ignore
+                block_settings = replace(
                     self.settings, label_qubit_lines=False, qubit_line_open_wire_length=0
                 )
                 subcircuit = Program(*self.working_instructions[start:j])


### PR DESCRIPTION
Description
-----------

Turns out `mypy` cannot typecheck the py36-vendored dataclasses because support was only added in py37. Thus, we need to upgrade the CI to use py37 in order to avoid ignoring large swaths of code during the type-checking process. Problem is, Semaphore Classic doesn't natively support py37, so I've decided to give Travis a try as a replacement. The build matrix stuff is pretty slick, and using Travis allows for the fork PR builds to be source-controlled in the form of a `.travis.yml` file (rather than in the Sempahore Classic UI).

TODO
------
- [x] Update PR checklist to say "Travis" instead of Semaphore
- [x] Mention style & formatting in the PR checklist

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
