### PR TITLE
Add typing to experiment module and verify in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ services:
     command: ["-R"]
 
 build-docs:
-  image: python:3.6
+  image: python:3.7
   tags:
     - github
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ services:
     command: ["-R"]
 
 build-docs:
-  image: python:3.7
+  image: python:3.6
   tags:
     - github
   script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Changelog
     subdirectory, maintaining backwards compatibility (@karalekas, gh-1143).
 -   Added a `.travis.yml` file to enable Travis CI for external-contributor builds,
     and upgraded GitLab CI style checks to py37 (@karalekas, gh-1145).
+-   Added typing to the `pyquil/experiment` module and added the module to the
+    `check-types` CI job (@karalekas, gh-1146).
 
 ### Bugfixes
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ check-format:
 # The dream is to one day run mypy on the whole tree. For now, limit checks to known-good files.
 .PHONY: check-types
 check-types:
-	mypy pyquil/quilatom.py pyquil/quilbase.py pyquil/gates.py \
-		pyquil/noise.py pyquil/quil.py pyquil/latex pyquil/simulation
+	mypy pyquil/quilatom.py pyquil/quilbase.py pyquil/gates.py pyquil/noise.py \
+		pyquil/quil.py pyquil/latex pyquil/simulation pyquil/experiment
 
 .PHONY: check-style
 check-style:

--- a/pyquil/experiment/_group.py
+++ b/pyquil/experiment/_group.py
@@ -47,12 +47,14 @@ def get_results_by_qubit_groups(
         corresponding value is the list of experiment results whose observables measure some
         subset of that qubit group. The result order is maintained within each group.
     """
-    qubit_groups = [tuple(sorted(group)) for group in qubit_groups]
-    results_by_qubit_group = {group: [] for group in qubit_groups}
+    tuple_groups = [tuple(sorted(group)) for group in qubit_groups]
+    results_by_qubit_group: Dict[Tuple[int, ...], List[ExperimentResult]] = {
+        group: [] for group in tuple_groups
+    }
     for res in results:
         res_qs = res.setting.out_operator.get_qubits()
 
-        for group in qubit_groups:
+        for group in tuple_groups:
             if set(res_qs).issubset(set(group)):
                 results_by_qubit_group[group].append(res)
 

--- a/pyquil/experiment/_main.py
+++ b/pyquil/experiment/_main.py
@@ -165,7 +165,7 @@ class TomographyExperiment:
             else:
                 s = cast(List[List[ExperimentSetting]], settings)
 
-        self._settings = s  # type: List[List[ExperimentSetting]]
+        self._settings = s
         self.program = program
         if qubits is not None:
             warnings.warn(
@@ -206,7 +206,7 @@ class TomographyExperiment:
     def append(self, expts: Union[ExperimentSetting, List[ExperimentSetting]]) -> None:
         if not isinstance(expts, list):
             expts = [expts]
-        return self._settings.append(expts)
+        self._settings.append(expts)
 
     def count(self, expt: List[ExperimentSetting]) -> int:
         return self._settings.count(expt)
@@ -215,19 +215,19 @@ class TomographyExperiment:
         return self._settings.index(expt, start, stop)
 
     def extend(self, expts: List[List[ExperimentSetting]]) -> None:
-        return self._settings.extend(expts)
+        self._settings.extend(expts)
 
     def insert(self, index: int, expt: List[ExperimentSetting]) -> None:
-        return self._settings.insert(index, expt)
+        self._settings.insert(index, expt)
 
     def pop(self, index: int = 0) -> List[ExperimentSetting]:
         return self._settings.pop(index)
 
     def remove(self, expt: List[ExperimentSetting]) -> None:
-        return self._settings.remove(expt)
+        self._settings.remove(expt)
 
     def reverse(self) -> None:
-        return self._settings.reverse()
+        self._settings.reverse()
 
     def sort(
         self, key: Optional[Callable[[List[ExperimentSetting]], Any]] = None, reverse: bool = False
@@ -264,7 +264,7 @@ class TomographyExperiment:
         string += f"settings:\n{self.settings_string(abbrev_after=20)}"
         return string
 
-    def serializable(self) -> Mapping[str, Any]:
+    def serializable(self) -> Dict[str, Any]:
         return {
             "type": "TomographyExperiment",
             "settings": self._settings,
@@ -274,7 +274,7 @@ class TomographyExperiment:
             "reset": self.reset,
         }
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, TomographyExperiment):
             return False
         return self.serializable() == other.serializable()

--- a/pyquil/experiment/_main.py
+++ b/pyquil/experiment/_main.py
@@ -23,7 +23,19 @@ import json
 import logging
 import warnings
 from json import JSONEncoder
-from typing import Any, Callable, Dict, Generator, List, Mapping, Optional, Sequence, Set, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+    cast,
+)
 
 from pyquil.experiment._memory import (
     pauli_term_to_measurement_memory_map,
@@ -182,10 +194,10 @@ class TomographyExperiment:
     def __delitem__(self, key: int) -> None:
         self._settings.__delitem__(key)
 
-    def __iter__(self) -> Generator[ExperimentSetting]:
+    def __iter__(self) -> Generator[List[ExperimentSetting], None, None]:
         yield from self._settings
 
-    def __reversed__(self) -> Generator[ExperimentSetting]:
+    def __reversed__(self) -> Generator[List[ExperimentSetting], None, None]:
         yield from reversed(self._settings)
 
     def __contains__(self, item: List[ExperimentSetting]) -> bool:
@@ -217,10 +229,12 @@ class TomographyExperiment:
     def reverse(self) -> None:
         return self._settings.reverse()
 
-    def sort(self, key: Optional[Callable[[List[ExperimentSetting]], Any]] = None, reverse: bool = False) -> None:
+    def sort(
+        self, key: Optional[Callable[[List[ExperimentSetting]], Any]] = None, reverse: bool = False
+    ) -> None:
         return self._settings.sort(key=key, reverse=reverse)
 
-    def setting_strings(self) -> Generator[str]:
+    def setting_strings(self) -> Generator[str, None, None]:
         yield from (
             "{i}: {st_str}".format(i=i, st_str=", ".join(str(setting) for setting in settings))
             for i, settings in enumerate(self._settings)

--- a/pyquil/experiment/_program.py
+++ b/pyquil/experiment/_program.py
@@ -18,8 +18,8 @@ from typing import Sequence
 
 import numpy as np
 
-from pyquil import Program
 from pyquil.gates import MEASURE, RX, RZ
+from pyquil.quil import Program
 
 
 def parameterized_euler_rotations(

--- a/pyquil/experiment/_result.py
+++ b/pyquil/experiment/_result.py
@@ -67,7 +67,7 @@ def bitstrings_to_expectations(
     return np.stack(e, axis=-1)
 
 
-@dataclass(frozen=True)  # type: ignore
+@dataclass(frozen=True)
 class ExperimentResult:
     """An expectation and standard deviation for the measurement of one experiment setting
     in a tomographic experiment.
@@ -81,26 +81,26 @@ class ExperimentResult:
     expectation: Union[float, complex]
     total_counts: int
     std_err: Optional[Union[float, complex]] = None
-    raw_expectation:  Optional[Union[float, complex]] = None
-    raw_std_err:  Optional[float] = None
-    calibration_expectation:  Optional[Union[float, complex]] = None
-    calibration_std_err:  Optional[Union[float, complex]] = None
-    calibration_counts:  Optional[int] = None
+    raw_expectation: Optional[Union[float, complex]] = None
+    raw_std_err: Optional[float] = None
+    calibration_expectation: Optional[Union[float, complex]] = None
+    calibration_std_err: Optional[Union[float, complex]] = None
+    calibration_counts: Optional[int] = None
 
     def __init__(
         self,
         setting: ExperimentSetting,
         expectation: Union[float, complex],
         total_counts: int,
-        stddev:  Optional[Union[float, complex]] = None,
-        std_err:  Optional[Union[float, complex]] = None,
-        raw_expectation:  Optional[Union[float, complex]] = None,
-        raw_stddev:  Optional[float] = None,
-        raw_std_err:  Optional[float] = None,
-        calibration_expectation:  Optional[Union[float, complex]] = None,
-        calibration_stddev:  Optional[Union[float, complex]] = None,
-        calibration_std_err:  Optional[Union[float, complex]] = None,
-        calibration_counts:  Optional[int] = None,
+        stddev: Optional[Union[float, complex]] = None,
+        std_err: Optional[Union[float, complex]] = None,
+        raw_expectation: Optional[Union[float, complex]] = None,
+        raw_stddev: Optional[float] = None,
+        raw_std_err: Optional[float] = None,
+        calibration_expectation: Optional[Union[float, complex]] = None,
+        calibration_stddev: Optional[Union[float, complex]] = None,
+        calibration_std_err: Optional[Union[float, complex]] = None,
+        calibration_counts: Optional[int] = None,
     ):
 
         object.__setattr__(self, "setting", setting)
@@ -125,7 +125,7 @@ class ExperimentResult:
             calibration_std_err = calibration_stddev
         object.__setattr__(self, "calibration_std_err", calibration_std_err)
 
-    def get_stddev(self) ->  Optional[Union[float, complex]]:
+    def get_stddev(self) -> Optional[Union[float, complex]]:
         warnings.warn("'stddev' has been renamed to 'std_err'")
         return self.std_err
 
@@ -135,7 +135,7 @@ class ExperimentResult:
 
     stddev = property(get_stddev, set_stddev)
 
-    def get_raw_stddev(self) ->  Optional[float]:
+    def get_raw_stddev(self) -> Optional[float]:
         warnings.warn("'raw_stddev' has been renamed to 'raw_std_err'")
         return self.raw_std_err
 
@@ -145,7 +145,7 @@ class ExperimentResult:
 
     raw_stddev = property(get_raw_stddev, set_raw_stddev)
 
-    def get_calibration_stddev(self) ->  Optional[Union[float, complex]]:
+    def get_calibration_stddev(self) -> Optional[Union[float, complex]]:
         warnings.warn("'calibration_stddev' has been renamed to 'calibration_std_err'")
         return self.calibration_std_err
 

--- a/pyquil/experiment/_result.py
+++ b/pyquil/experiment/_result.py
@@ -20,7 +20,7 @@ measurements that are aimed at estimating the expectation value of some observab
 import logging
 import sys
 import warnings
-from typing import List, Optional, Union
+from typing import Any, List, Mapping, Optional, Union
 
 import numpy as np
 
@@ -67,7 +67,7 @@ def bitstrings_to_expectations(
     return np.stack(e, axis=-1)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # type: ignore
 class ExperimentResult:
     """An expectation and standard deviation for the measurement of one experiment setting
     in a tomographic experiment.
@@ -80,27 +80,27 @@ class ExperimentResult:
     setting: ExperimentSetting
     expectation: Union[float, complex]
     total_counts: int
-    std_err: Union[float, complex] = None
-    raw_expectation: Union[float, complex] = None
-    raw_std_err: float = None
-    calibration_expectation: Union[float, complex] = None
-    calibration_std_err: Union[float, complex] = None
-    calibration_counts: int = None
+    std_err: Optional[Union[float, complex]] = None
+    raw_expectation:  Optional[Union[float, complex]] = None
+    raw_std_err:  Optional[float] = None
+    calibration_expectation:  Optional[Union[float, complex]] = None
+    calibration_std_err:  Optional[Union[float, complex]] = None
+    calibration_counts:  Optional[int] = None
 
     def __init__(
         self,
         setting: ExperimentSetting,
         expectation: Union[float, complex],
         total_counts: int,
-        stddev: Union[float, complex] = None,
-        std_err: Union[float, complex] = None,
-        raw_expectation: Union[float, complex] = None,
-        raw_stddev: float = None,
-        raw_std_err: float = None,
-        calibration_expectation: Union[float, complex] = None,
-        calibration_stddev: Union[float, complex] = None,
-        calibration_std_err: Union[float, complex] = None,
-        calibration_counts: int = None,
+        stddev:  Optional[Union[float, complex]] = None,
+        std_err:  Optional[Union[float, complex]] = None,
+        raw_expectation:  Optional[Union[float, complex]] = None,
+        raw_stddev:  Optional[float] = None,
+        raw_std_err:  Optional[float] = None,
+        calibration_expectation:  Optional[Union[float, complex]] = None,
+        calibration_stddev:  Optional[Union[float, complex]] = None,
+        calibration_std_err:  Optional[Union[float, complex]] = None,
+        calibration_counts:  Optional[int] = None,
     ):
 
         object.__setattr__(self, "setting", setting)
@@ -125,43 +125,43 @@ class ExperimentResult:
             calibration_std_err = calibration_stddev
         object.__setattr__(self, "calibration_std_err", calibration_std_err)
 
-    def get_stddev(self) -> Union[float, complex]:
+    def get_stddev(self) ->  Optional[Union[float, complex]]:
         warnings.warn("'stddev' has been renamed to 'std_err'")
         return self.std_err
 
-    def set_stddev(self, value: Union[float, complex]):
+    def set_stddev(self, value: Union[float, complex]) -> None:
         warnings.warn("'stddev' has been renamed to 'std_err'")
         object.__setattr__(self, "std_err", value)
 
     stddev = property(get_stddev, set_stddev)
 
-    def get_raw_stddev(self) -> float:
+    def get_raw_stddev(self) ->  Optional[float]:
         warnings.warn("'raw_stddev' has been renamed to 'raw_std_err'")
         return self.raw_std_err
 
-    def set_raw_stddev(self, value: float):
+    def set_raw_stddev(self, value: float) -> None:
         warnings.warn("'raw_stddev' has been renamed to 'raw_std_err'")
         object.__setattr__(self, "raw_std_err", value)
 
     raw_stddev = property(get_raw_stddev, set_raw_stddev)
 
-    def get_calibration_stddev(self) -> Union[float, complex]:
+    def get_calibration_stddev(self) ->  Optional[Union[float, complex]]:
         warnings.warn("'calibration_stddev' has been renamed to 'calibration_std_err'")
         return self.calibration_std_err
 
-    def set_calibration_stddev(self, value: Union[float, complex]):
+    def set_calibration_stddev(self, value: Union[float, complex]) -> None:
         warnings.warn("'calibration_stddev' has been renamed to 'calibration_std_err'")
         object.__setattr__(self, "calibration_std_err", value)
 
     calibration_stddev = property(get_calibration_stddev, set_calibration_stddev)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.setting}: {self.expectation} +- {self.std_err}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"ExperimentResult[{self}]"
 
-    def serializable(self):
+    def serializable(self) -> Mapping[str, Any]:
         return {
             "type": "ExperimentResult",
             "setting": self.setting,

--- a/pyquil/experiment/_result.py
+++ b/pyquil/experiment/_result.py
@@ -20,7 +20,7 @@ measurements that are aimed at estimating the expectation value of some observab
 import logging
 import sys
 import warnings
-from typing import Any, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 
@@ -161,7 +161,7 @@ class ExperimentResult:
     def __repr__(self) -> str:
         return f"ExperimentResult[{self}]"
 
-    def serializable(self) -> Mapping[str, Any]:
+    def serializable(self) -> Dict[str, Any]:
         return {
             "type": "ExperimentResult",
             "setting": self.setting,

--- a/pyquil/experiment/_setting.py
+++ b/pyquil/experiment/_setting.py
@@ -21,7 +21,7 @@ import logging
 import re
 import sys
 import warnings
-from typing import Iterable, Tuple
+from typing import Any, FrozenSet, Generator, Iterable, List, Optional, cast
 
 from pyquil.paulis import PauliTerm, sI, is_identity
 
@@ -34,7 +34,7 @@ else:
 log = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # type: ignore
 class _OneQState:
     """
     A description of a named one-qubit quantum state.
@@ -48,70 +48,70 @@ class _OneQState:
     index: int
     qubit: int
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.label}{self.index}_{self.qubit}"
 
     @classmethod
-    def from_str(cls, s):
+    def from_str(cls, s: str) -> "_OneQState":
         ma = re.match(r"\s*(\w+)(\d+)_(\d+)\s*", s)
         if ma is None:
             raise ValueError(f"Couldn't parse '{s}'")
         return _OneQState(label=ma.group(1), index=int(ma.group(2)), qubit=int(ma.group(3)))
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # type: ignore
 class TensorProductState:
     """
     A description of a multi-qubit quantum state that is a tensor product of many _OneQStates
     states.
     """
 
-    states: Tuple[_OneQState]
+    states: List[_OneQState]
 
-    def __init__(self, states=None):
+    def __init__(self, states: Optional[List[_OneQState]] = None):
         if states is None:
-            states = tuple()
-        object.__setattr__(self, "states", tuple(states))
+            states = []
+        object.__setattr__(self, "states", list(states))
 
-    def __mul__(self, other):
+    def __mul__(self, other: "TensorProductState") -> "TensorProductState":
         return TensorProductState(self.states + other.states)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return " * ".join(str(s) for s in self.states)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"TensorProductState[{self}]"
 
-    def __getitem__(self, qubit):
+    def __getitem__(self, qubit: int) -> _OneQState:
         """Return the _OneQState at the given qubit."""
         for oneq_state in self.states:
             if oneq_state.qubit == qubit:
                 return oneq_state
         raise IndexError()
 
-    def __iter__(self):
+    def __iter__(self) -> Generator[_OneQState]:
         yield from self.states
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.states)
 
-    def states_as_set(self):
+    def states_as_set(self) -> FrozenSet[_OneQState]:
         return frozenset(self.states)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, TensorProductState):
             return False
 
         return self.states_as_set() == other.states_as_set()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.states_as_set())
 
     @classmethod
-    def from_str(cls, s):
+    def from_str(cls, s: str) -> "TensorProductState":
         if s == "":
             return TensorProductState()
-        return TensorProductState(tuple(_OneQState.from_str(x) for x in s.split("*")))
+        return TensorProductState(list(_OneQState.from_str(x) for x in s.split("*")))
 
 
 def _pauli_to_product_state(in_state: PauliTerm) -> TensorProductState:
@@ -119,62 +119,61 @@ def _pauli_to_product_state(in_state: PauliTerm) -> TensorProductState:
     Convert a Pauli term to a TensorProductState.
     """
     if is_identity(in_state):
-        in_state = TensorProductState()
+        return TensorProductState()
     else:
-        in_state = TensorProductState(
+        return TensorProductState(
             [
                 _OneQState(label=pauli_label, index=0, qubit=qubit)
                 for qubit, pauli_label in in_state._ops.items()
             ]
         )
-    return in_state
 
 
-def SIC0(q):
-    return TensorProductState((_OneQState("SIC", 0, q),))
+def SIC0(q: int) -> TensorProductState:
+    return TensorProductState([_OneQState(label="SIC", index=0, qubit=q)])
 
 
-def SIC1(q):
-    return TensorProductState((_OneQState("SIC", 1, q),))
+def SIC1(q: int) -> TensorProductState:
+    return TensorProductState([_OneQState(label="SIC", index=1, qubit=q)])
 
 
-def SIC2(q):
-    return TensorProductState((_OneQState("SIC", 2, q),))
+def SIC2(q: int) -> TensorProductState:
+    return TensorProductState([_OneQState("SIC", 2, q)])
 
 
-def SIC3(q):
-    return TensorProductState((_OneQState("SIC", 3, q),))
+def SIC3(q: int) -> TensorProductState:
+    return TensorProductState([_OneQState("SIC", 3, q)])
 
 
-def plusX(q):
-    return TensorProductState((_OneQState("X", 0, q),))
+def plusX(q: int) -> TensorProductState:
+    return TensorProductState([_OneQState("X", 0, q)])
 
 
-def minusX(q):
-    return TensorProductState((_OneQState("X", 1, q),))
+def minusX(q: int) -> TensorProductState:
+    return TensorProductState([_OneQState("X", 1, q)])
 
 
-def plusY(q):
-    return TensorProductState((_OneQState("Y", 0, q),))
+def plusY(q: int) -> TensorProductState:
+    return TensorProductState([_OneQState("Y", 0, q)])
 
 
-def minusY(q):
-    return TensorProductState((_OneQState("Y", 1, q),))
+def minusY(q: int) -> TensorProductState:
+    return TensorProductState([_OneQState("Y", 1, q)])
 
 
-def plusZ(q):
-    return TensorProductState((_OneQState("Z", 0, q),))
+def plusZ(q: int) -> TensorProductState:
+    return TensorProductState([_OneQState("Z", 0, q)])
 
 
-def minusZ(q):
-    return TensorProductState((_OneQState("Z", 1, q),))
+def minusZ(q: int) -> TensorProductState:
+    return TensorProductState([_OneQState("Z", 1, q)])
 
 
-def zeros_state(qubits: Iterable[int]):
-    return TensorProductState(_OneQState("Z", 0, q) for q in qubits)
+def zeros_state(qubits: Iterable[int]) -> TensorProductState:
+    return TensorProductState([_OneQState("Z", 0, q) for q in qubits])
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True, init=False)  # type: ignore
 class ExperimentSetting:
     """
     Input and output settings for a tomography-like experiment.
@@ -205,7 +204,7 @@ class ExperimentSetting:
         object.__setattr__(self, "out_operator", out_operator)
 
     @property
-    def in_operator(self):
+    def in_operator(self) -> PauliTerm:
         warnings.warn(
             "ExperimentSetting.in_operator is deprecated in favor of in_state", stacklevel=2
         )
@@ -218,21 +217,22 @@ class ExperimentSetting:
             if oneq_state.index != 0:
                 raise ValueError(f"Can't shim {oneq_state} into a pauli term. Use in_state.")
 
-            pt *= PauliTerm(op=oneq_state.label, index=oneq_state.qubit)
+            new_pt = pt * PauliTerm(op=oneq_state.label, index=oneq_state.qubit)
+            pt = cast(PauliTerm, new_pt)
 
         return pt
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.in_state}→{self.out_operator.compact_str()}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"ExperimentSetting[{self}]"
 
-    def serializable(self):
+    def serializable(self) -> str:
         return str(self)
 
     @classmethod
-    def from_str(cls, s: str):
+    def from_str(cls, s: str) -> "ExperimentSetting":
         """The opposite of str(expt)"""
         instr, outstr = s.split("→")
         return ExperimentSetting(

--- a/pyquil/experiment/_setting.py
+++ b/pyquil/experiment/_setting.py
@@ -68,7 +68,7 @@ class TensorProductState:
 
     states: List[_OneQState]
 
-    def __init__(self, states: Optional[List[_OneQState]] = None):
+    def __init__(self, states: Optional[Iterable[_OneQState]] = None):
         if states is None:
             states = []
         object.__setattr__(self, "states", list(states))

--- a/pyquil/experiment/_setting.py
+++ b/pyquil/experiment/_setting.py
@@ -34,7 +34,7 @@ else:
 log = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)  # type: ignore
+@dataclass(frozen=True)
 class _OneQState:
     """
     A description of a named one-qubit quantum state.
@@ -59,7 +59,7 @@ class _OneQState:
         return _OneQState(label=ma.group(1), index=int(ma.group(2)), qubit=int(ma.group(3)))
 
 
-@dataclass(frozen=True)  # type: ignore
+@dataclass(frozen=True)
 class TensorProductState:
     """
     A description of a multi-qubit quantum state that is a tensor product of many _OneQStates
@@ -89,7 +89,7 @@ class TensorProductState:
                 return oneq_state
         raise IndexError()
 
-    def __iter__(self) -> Generator[_OneQState]:
+    def __iter__(self) -> Generator[_OneQState, None, None]:
         yield from self.states
 
     def __len__(self) -> int:
@@ -138,42 +138,42 @@ def SIC1(q: int) -> TensorProductState:
 
 
 def SIC2(q: int) -> TensorProductState:
-    return TensorProductState([_OneQState("SIC", 2, q)])
+    return TensorProductState([_OneQState(label="SIC", index=2, qubit=q)])
 
 
 def SIC3(q: int) -> TensorProductState:
-    return TensorProductState([_OneQState("SIC", 3, q)])
+    return TensorProductState([_OneQState(label="SIC", index=3, qubit=q)])
 
 
 def plusX(q: int) -> TensorProductState:
-    return TensorProductState([_OneQState("X", 0, q)])
+    return TensorProductState([_OneQState(label="X", index=0, qubit=q)])
 
 
 def minusX(q: int) -> TensorProductState:
-    return TensorProductState([_OneQState("X", 1, q)])
+    return TensorProductState([_OneQState(label="X", index=1, qubit=q)])
 
 
 def plusY(q: int) -> TensorProductState:
-    return TensorProductState([_OneQState("Y", 0, q)])
+    return TensorProductState([_OneQState(label="Y", index=0, qubit=q)])
 
 
 def minusY(q: int) -> TensorProductState:
-    return TensorProductState([_OneQState("Y", 1, q)])
+    return TensorProductState([_OneQState(label="Y", index=1, qubit=q)])
 
 
 def plusZ(q: int) -> TensorProductState:
-    return TensorProductState([_OneQState("Z", 0, q)])
+    return TensorProductState([_OneQState(label="Z", index=0, qubit=q)])
 
 
 def minusZ(q: int) -> TensorProductState:
-    return TensorProductState([_OneQState("Z", 1, q)])
+    return TensorProductState([_OneQState(label="Z", index=1, qubit=q)])
 
 
 def zeros_state(qubits: Iterable[int]) -> TensorProductState:
-    return TensorProductState([_OneQState("Z", 0, q) for q in qubits])
+    return TensorProductState([_OneQState(label="Z", index=0, qubit=q) for q in qubits])
 
 
-@dataclass(frozen=True, init=False)  # type: ignore
+@dataclass(frozen=True, init=False)
 class ExperimentSetting:
     """
     Input and output settings for a tomography-like experiment.

--- a/pyquil/latex/_ipython.py
+++ b/pyquil/latex/_ipython.py
@@ -18,8 +18,9 @@ import os
 import shutil
 import subprocess
 import tempfile
-from IPython.display import Image
 from typing import Any, Optional
+
+from IPython.display import Image
 
 from pyquil.latex._main import to_latex
 from pyquil.latex._diagram import DiagramSettings


### PR DESCRIPTION
Description
-----------

Keep the train going.

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] The [changelog](https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md) is updated,
      including author and PR number (@username, gh-xxx).
