### PR TITLE
Reduce mypy errors in paulis.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changelog
     `check-types` CI job (@karalekas, gh-1146).
 -   Use `dataclasses` instead of `namedtuples` in the `pyquil/device` module, and
     add type annotations to the entire module (@karalekas, gh-1149).
+-   Mypy errors of paulis.py have been reduced (@rht, gh-1147).
 
 ### Bugfixes
 

--- a/pyquil/experiment/_group.py
+++ b/pyquil/experiment/_group.py
@@ -189,6 +189,7 @@ def _max_weight_operator(ops: Iterable[PauliTerm]) -> Union[None, PauliTerm]:
     mapping = dict()  # type: Dict[int, str]
     for op in ops:
         for idx, op_str in op:
+            assert isinstance(idx, int)
             if idx in mapping:
                 if mapping[idx] != op_str:
                     return None

--- a/pyquil/experiment/_main.py
+++ b/pyquil/experiment/_main.py
@@ -286,7 +286,7 @@ class TomographyExperiment:
         """
         meas_qubits: Set[int] = set()
         for settings in self:
-            meas_qubits.update(settings[0].out_operator.get_qubits())
+            meas_qubits.update(cast(List[int], settings[0].out_operator.get_qubits()))
         return sorted(meas_qubits)
 
     def get_meas_registers(self, qubits: Optional[Sequence[int]] = None) -> List[int]:
@@ -377,8 +377,12 @@ class TomographyExperiment:
         """
         meas_qubits = self.get_meas_qubits()
 
-        in_pt = PauliTerm.from_list([(op, meas_qubits.index(q)) for q, op in setting.in_operator])
-        out_pt = PauliTerm.from_list([(op, meas_qubits.index(q)) for q, op in setting.out_operator])
+        in_pt = PauliTerm.from_list(
+            [(op, meas_qubits.index(cast(int, q))) for q, op in setting.in_operator]
+        )
+        out_pt = PauliTerm.from_list(
+            [(op, meas_qubits.index(cast(int, q))) for q, op in setting.out_operator]
+        )
 
         preparation_map = pauli_term_to_preparation_memory_map(in_pt)
         measurement_map = pauli_term_to_measurement_memory_map(out_pt)

--- a/pyquil/experiment/_memory.py
+++ b/pyquil/experiment/_memory.py
@@ -15,7 +15,7 @@
 ##############################################################################
 
 import itertools
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, cast
 
 import numpy as np
 
@@ -102,7 +102,7 @@ def pauli_term_to_euler_memory_map(
     gamma_label = f"{prefix}_{suffix_gamma}"
 
     # assume the pauli indices are equivalent to the memory region
-    memory_size = max(term.get_qubits()) + 1
+    memory_size = max(cast(List[int], term.get_qubits())) + 1
 
     memory_map = {
         alpha_label: [0.0] * memory_size,
@@ -113,6 +113,7 @@ def pauli_term_to_euler_memory_map(
     tuples = {"X": tuple_x, "Y": tuple_y, "Z": tuple_z, "I": tuple_z}
 
     for qubit, operator in term:
+        assert isinstance(qubit, int)
         if operator not in tuples:
             raise ValueError(f"Unknown operator {operator}")
         memory_map[alpha_label][qubit] = tuples[operator][0]

--- a/pyquil/experiment/_setting.py
+++ b/pyquil/experiment/_setting.py
@@ -123,7 +123,7 @@ def _pauli_to_product_state(in_state: PauliTerm) -> TensorProductState:
     else:
         return TensorProductState(
             [
-                _OneQState(label=pauli_label, index=0, qubit=qubit)
+                _OneQState(label=pauli_label, index=0, qubit=cast(int, qubit))
                 for qubit, pauli_label in in_state._ops.items()
             ]
         )

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -44,7 +44,7 @@ from numbers import Number
 from collections import OrderedDict
 import warnings
 
-PauliTargetDesignator = Union[int, FormalArgument]
+PauliTargetDesignator = Union[int, FormalArgument, QubitPlaceholder]
 PauliDesignator = Union["PauliTerm", "PauliSum"]
 
 PAULI_OPS = ["X", "Y", "Z", "I"]

--- a/pyquil/simulation/_numpy.py
+++ b/pyquil/simulation/_numpy.py
@@ -166,6 +166,7 @@ def _term_expectation(wf: np.ndarray, term: PauliTerm) -> Any:
     # Computes <psi|XYZ..XXZ|psi>
     wf2 = wf
     for qubit_i, op_str in term._ops.items():
+        assert isinstance(qubit_i, int)
         # Re-use QUANTUM_GATES since it has X, Y, Z
         op_mat = QUANTUM_GATES[op_str]
         wf2 = targeted_tensordot(gate=op_mat, wf=wf2, wf_target_inds=[qubit_i])

--- a/pyquil/simulation/_reference.py
+++ b/pyquil/simulation/_reference.py
@@ -30,6 +30,7 @@ def _term_expectation(wf: np.ndarray, term: PauliTerm, n_qubits: int) -> Any:
     # Computes <psi|XYZ..XXZ|psi>
     wf2 = wf
     for qubit_i, op_str in term._ops.items():
+        assert isinstance(qubit_i, int)
         # Re-use QUANTUM_GATES since it has X, Y, Z
         op_mat = QUANTUM_GATES[op_str]
         op_mat = lifted_gate_matrix(matrix=op_mat, qubit_inds=[qubit_i], n_qubits=n_qubits)


### PR DESCRIPTION
Description
-----------

This currently reduces the mypy error from 31 down to 20. For the rest, I am not so sure how to handle them.

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
