### PR TITLE
Add type hints to all remaining top-level files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Changelog
 -   Compile to XY gates as well as CZ gates on dummy QVMs (@ecpeterson, gh-1151).
 -   `QAM.write_memory` now accepts either a `Sequence` of values or a single
     value (@tommy-moffat, gh-1114).
+-   Added type hints for all remaining top-level files (@karalekas, gh-1150).
 
 ### Bugfixes
 

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ check-format:
 .PHONY: check-types
 check-types:
 	mypy pyquil/gate_matrices.py pyquil/gates.py pyquil/noise.py pyquil/numpy_simulator.py \
-		pyquil/operator_estimation.py pyquil/parser.py pyquil/pyqvm.py pyquil/quil.py \
-		pyquil/quilatom.py pyquil/quilbase.py pyquil/reference_simulator.py \
+		pyquil/operator_estimation.py pyquil/parser.py pyquil/paulis.py pyquil/pyqvm.py \
+		pyquil/quil.py pyquil/quilatom.py pyquil/quilbase.py pyquil/reference_simulator.py \
 		pyquil/unitary_tools.py pyquil/version.py pyquil/wavefunction.py \
 		pyquil/device pyquil/experiment pyquil/latex pyquil/simulation
 

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,11 @@ check-format:
 # The dream is to one day run mypy on the whole tree. For now, limit checks to known-good files.
 .PHONY: check-types
 check-types:
-	mypy pyquil/gates.py pyquil/gate_matrices.py pyquil/noise.py pyquil/numpy_simulator.py \
-		pyquil/quil.py pyquil/quilatom.py pyquil/quilbase.py pyquil/reference_simulator.py \
-		pyquil/unitary_tools.py pyquil/latex pyquil/simulation pyquil/experiment pyquil/device
+	mypy pyquil/gate_matrices.py pyquil/gates.py pyquil/noise.py pyquil/numpy_simulator.py \
+		pyquil/operator_estimation.py pyquil/parser.py pyquil/pyqvm.py pyquil/quil.py \
+		pyquil/quilatom.py pyquil/quilbase.py pyquil/reference_simulator.py \
+		pyquil/unitary_tools.py pyquil/version.py pyquil/wavefunction.py \
+		pyquil/device pyquil/experiment pyquil/latex pyquil/simulation
 
 .PHONY: check-style
 check-style:

--- a/mypy.ini
+++ b/mypy.ini
@@ -30,3 +30,11 @@ ignore_errors = True
 # Ignore errors in test files
 [mypy-*/tests/*]
 ignore_errors = True
+
+# Ignore errors in conftest.py file
+[mypy-conftest]
+ignore_errors = True
+
+# Ignore errors in pyquil/magic.py file
+[mypy-pyquil.magic]
+ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,22 +19,22 @@ warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
 
-# Ignore errors in generated parser files
-[mypy-pyquil._parser.gen3.*]
+# Ignore errors in all parser-related files
+[mypy-pyquil._parser.*]
 ignore_errors = True
 
 # Ignore errors in vendored third-party libraries
 [mypy-pyquil.external.*]
 ignore_errors = True
 
-# Ignore errors in test files
+# Ignore errors in all test files
 [mypy-*/tests/*]
 ignore_errors = True
 
-# Ignore errors in conftest.py file
+# Ignore errors in the conftest.py file
 [mypy-conftest]
 ignore_errors = True
 
-# Ignore errors in pyquil/magic.py file
+# Ignore errors in the pyquil/magic.py file
 [mypy-pyquil.magic]
 ignore_errors = True

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from math import pi
-from typing import Callable, Dict, Generator, List, Union, Tuple, Optional, cast
+from typing import Callable, Generator, List, Mapping, Union, Tuple, Optional, cast
 
 import numpy as np
 
@@ -306,7 +306,8 @@ def measure_observables(
         # either the first column, second column, or both and multiplying along the row.
         for setting in settings:
             # Get the term's coefficient so we can multiply it in later.
-            coeff = complex(cast(complex, setting.out_operator.coefficient))
+            coeff = setting.out_operator.coefficient
+            assert isinstance(coeff, complex)
             if not np.isclose(coeff.imag, 0):
                 raise ValueError(f"{setting}'s out_operator has a complex coefficient.")
             coeff = coeff.real
@@ -390,7 +391,7 @@ def _ops_bool_to_prog(ops_bool: Tuple[bool], qubits: List[int]) -> Program:
 
 def _stats_from_measurements(
     bs_results: np.ndarray,
-    qubit_index_map: Dict[int, int],
+    qubit_index_map: Mapping[int, int],
     setting: ExperimentSetting,
     n_shots: int,
     coeff: float = 1.0,

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -175,11 +175,12 @@ def _generate_experiment_programs(
                 "so that groups of parallel settings have compatible observables."
             )
         for qubit, op_str in max_weight_out_op:
+            assert isinstance(qubit, int)
             total_prog += _local_pauli_eig_meas(op_str, qubit)
 
         programs.append(total_prog)
 
-        meas_qubits.append(max_weight_out_op.get_qubits())
+        meas_qubits.append(cast(List[int], max_weight_out_op.get_qubits()))
     return programs, meas_qubits
 
 
@@ -328,7 +329,7 @@ def measure_observables(
                 # Obtain calibration program
                 calibr_prog = _calibration_program(qc, tomo_experiment, setting)
                 calibr_qubs = setting.out_operator.get_qubits()
-                calibr_qub_dict = {q: idx for idx, q in enumerate(calibr_qubs)}
+                calibr_qub_dict = {cast(int, q): idx for idx, q in enumerate(calibr_qubs)}
 
                 # Perform symmetrization on the calibration program
                 calibr_results = qc.run_symmetrized_readout(
@@ -403,7 +404,7 @@ def _stats_from_measurements(
     :return: tuple specifying (mean, variance)
     """
     # Identify classical register indices to select
-    idxs = [qubit_index_map[q] for q, _ in setting.out_operator]
+    idxs = [qubit_index_map[cast(int, q)] for q, _ in setting.out_operator]
     # Pick columns corresponding to qubits with a non-identity out_operation
     obs_strings = bs_results[:, idxs]
     # Transform bits to eigenvalues; ie (+1, -1)
@@ -444,9 +445,11 @@ def _calibration_program(
     calibr_prog += kraus_instructions
     # Prepare the +1 eigenstate for the out operator
     for q, op in setting.out_operator.operations_as_set():
+        assert isinstance(q, int)
         calibr_prog += _one_q_pauli_prep(label=op, index=0, qubit=q)
     # Measure the out operator in this state
     for q, op in setting.out_operator.operations_as_set():
+        assert isinstance(q, int)
         calibr_prog += _local_pauli_eig_meas(op, q)
 
     return calibr_prog

--- a/pyquil/parser.py
+++ b/pyquil/parser.py
@@ -16,12 +16,14 @@
 """
 Module for parsing Quil programs from text into PyQuil objects
 """
-from pyquil.quil import Program
+from typing import List
 
 from pyquil._parser.PyQuilListener import run_parser
+from pyquil.quil import Program
+from pyquil.quilbase import AbstractInstruction
 
 
-def parse_program(quil):
+def parse_program(quil: str) -> Program:
     """
     Parse a raw Quil program and return a PyQuil program.
 
@@ -31,7 +33,7 @@ def parse_program(quil):
     return Program(parse(quil))
 
 
-def parse(quil):
+def parse(quil: str) -> List[AbstractInstruction]:
     """
     Parse a raw Quil program and return a corresponding list of PyQuil objects.
 

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -34,9 +34,15 @@ from typing import (
     Sequence,
     Tuple,
     Union,
+    cast,
 )
 
-from pyquil.quilatom import QubitPlaceholder, FormalArgument, Expression, ExpressionDesignator
+from pyquil.quilatom import (
+    QubitPlaceholder,
+    FormalArgument,
+    Expression,
+    ExpressionDesignator,
+)
 
 from .quil import Program
 from .gates import H, RZ, RX, CNOT, X, PHASE, QUANTUM_GATES
@@ -126,7 +132,10 @@ class PauliTerm(object):
     """
 
     def __init__(
-        self, op: str, index: PauliTargetDesignator, coefficient: ExpressionDesignator = 1.0
+        self,
+        op: str,
+        index: Optional[PauliTargetDesignator],
+        coefficient: ExpressionDesignator = 1.0,
     ):
         """ Create a new Pauli Term with a Pauli operator at a particular index and a leading
         coefficient.
@@ -140,6 +149,7 @@ class PauliTerm(object):
 
         self._ops: Dict[PauliTargetDesignator, str] = OrderedDict()
         if op != "I":
+            assert index is not None
             if not _valid_qubit(index):
                 raise ValueError(f"{index} is not a valid qubit")
             self._ops[index] = op
@@ -286,8 +296,7 @@ class PauliTerm(object):
                 new_term = new_term._multiply_factor(op, index)
 
             return term_with_coeff(new_term, new_term.coefficient * new_coeff)
-        else:  # is a Number
-            return term_with_coeff(self, self.coefficient * term)
+        return term_with_coeff(self, self.coefficient * term)
 
     def __rmul__(self, other: ExpressionDesignator) -> "PauliTerm":
         """Multiplies this PauliTerm with another object, probably a number.
@@ -295,8 +304,9 @@ class PauliTerm(object):
         :param other: A number or PauliTerm to multiply by
         :returns: A new PauliTerm
         """
-        assert isinstance(other, Number)
-        return self * other
+        p = self * other
+        assert isinstance(p, PauliTerm)
+        return p
 
     def __pow__(self, power: int) -> "PauliTerm":
         """Raises this PauliTerm to power.
@@ -313,7 +323,9 @@ class PauliTerm(object):
 
         result = ID()
         for _ in range(power):
-            result *= self
+            pow = result * self
+            assert isinstance(pow, PauliTerm)
+            result = pow
         return result
 
     def __add__(self, other: Union[PauliDesignator, ExpressionDesignator]) -> "PauliSum":
@@ -330,16 +342,15 @@ class PauliTerm(object):
         else:  # is a Number
             return self + PauliTerm("I", 0, other)
 
-    def __radd__(self, other: ExpressionDesignator) -> "PauliTerm":
+    def __radd__(self, other: ExpressionDesignator) -> "PauliSum":
         """Adds this PauliTerm with a Number.
 
         :param other: A Number
         :returns: A new PauliTerm
         """
-        assert isinstance(other, Number)
         return PauliTerm("I", 0, other) + self
 
-    def __sub__(self, other: Union["PauliTerm", Number]) -> "PauliSum":
+    def __sub__(self, other: Union["PauliTerm", ExpressionDesignator]) -> "PauliSum":
         """Subtracts a PauliTerm from this one.
 
         :param other: A PauliTerm object or a Number
@@ -347,7 +358,7 @@ class PauliTerm(object):
         """
         return self + -1.0 * other
 
-    def __rsub__(self, other: Union["PauliTerm", Number]) -> "PauliSum":
+    def __rsub__(self, other: Union["PauliTerm", ExpressionDesignator]) -> "PauliSum":
         """Subtracts this PauliTerm from a Number or PauliTerm.
 
         :param other: A PauliTerm object or a Number
@@ -430,9 +441,8 @@ class PauliTerm(object):
 
         # parse the coefficient into either a float or complex
         str_coef = str_coef.replace(" ", "")
-        coef: Union[float, complex]
         try:
-            coef = float(str_coef)
+            coef: Union[float, complex] = float(str_coef)
         except ValueError:
             try:
                 coef = complex(str_coef)
@@ -441,6 +451,7 @@ class PauliTerm(object):
 
         op = sI() * coef
         if str_op == "I":
+            assert isinstance(op, PauliTerm)
             return op
 
         # parse the operator
@@ -453,6 +464,7 @@ class PauliTerm(object):
         for factor in re.finditer(r"([XYZ])(\d+)", str_op):
             op *= cls(factor.group(1), int(factor.group(2)))
 
+        assert isinstance(op, PauliTerm)
         return op
 
     def pauli_string(self, qubits: Optional[Iterable[int]] = None) -> str:
@@ -483,7 +495,7 @@ class PauliTerm(object):
                 "Please provide a list of qubits when using PauliTerm.pauli_string",
                 DeprecationWarning,
             )
-            qubits = self.get_qubits()
+            qubits = cast(List[int], self.get_qubits())
         assert qubits is not None
 
         return "".join(self[q] for q in qubits)
@@ -626,16 +638,19 @@ class PauliSum(object):
         :param other: a PauliSum, PauliTerm or Number object
         :return: A new PauliSum object given by the multiplication.
         """
-        if not isinstance(other, (Number, PauliTerm, PauliSum)):
+        if not isinstance(other, (Expression, int, complex, float, PauliTerm, PauliSum)):
             raise ValueError(
                 "Cannot multiply PauliSum by term that is not a Number, PauliTerm, or PauliSum"
             )
-        elif isinstance(other, PauliSum):
-            other_terms = other.terms
+
+        other_terms: List[Union[PauliTerm, ExpressionDesignator]] = []
+        if isinstance(other, PauliSum):
+            other_terms += other.terms
         else:
-            other_terms = [other]
+            other_terms += [other]
+
         new_terms = [lterm * rterm for lterm, rterm in product(self.terms, other_terms)]
-        new_sum = PauliSum(new_terms)
+        new_sum = PauliSum(cast(List[PauliTerm], new_terms))
         return new_sum.simplify()
 
     def __rmul__(self, other: ExpressionDesignator) -> "PauliSum":
@@ -685,11 +700,13 @@ class PauliSum(object):
         :return: A new PauliSum object given by the addition.
         """
         if isinstance(other, PauliTerm):
-            other = PauliSum([other])
-        elif isinstance(other, Number):
-            other = PauliSum([other * ID()])
+            other_sum = PauliSum([other])
+        elif isinstance(other, (Expression, int, complex, float)):
+            other_sum = PauliSum([other * ID()])
+        else:
+            other_sum = other
         new_terms = [term.copy() for term in self.terms]
-        new_terms.extend(other.terms)
+        new_terms.extend(other_sum.terms)
         new_sum = PauliSum(new_terms)
         return new_sum.simplify()
 
@@ -730,7 +747,10 @@ class PauliSum(object):
 
         :returns: A list of all the qubits in the sum of terms.
         """
-        return list(set().union(*[term.get_qubits() for term in self.terms]))
+        all_qubits = []
+        for term in self.terms:
+            all_qubits.extend(term.get_qubits())
+        return list(set(all_qubits))
 
     def simplify(self) -> "PauliSum":
         """
@@ -899,6 +919,8 @@ def exponential_map(term: PauliTerm) -> Callable[[float], Program]:
     :param term: A pauli term to exponentiate
     :returns: A function that takes an angle parameter and returns a program.
     """
+    assert isinstance(term.coefficient, complex)
+
     if not np.isclose(np.imag(term.coefficient), 0.0):
         raise TypeError("PauliTerm coefficient must be real")
 
@@ -964,14 +986,13 @@ def _exponentiate_general_case(pauli_term: PauliTerm, param: float) -> Program:
     highest_target_index = None
 
     for index, op in pauli_term:
+        assert isinstance(index, int) or isinstance(index, QubitPlaceholder)
         if "X" == op:
             change_to_z_basis.inst(H(index))
             change_to_original_basis.inst(H(index))
-
         elif "Y" == op:
             change_to_z_basis.inst(RX(np.pi / 2.0, index))
             change_to_original_basis.inst(RX(-np.pi / 2.0, index))
-
         elif "I" == op:
             continue
 
@@ -984,6 +1005,7 @@ def _exponentiate_general_case(pauli_term: PauliTerm, param: float) -> Program:
     # building rotation circuit
     quil_prog += change_to_z_basis
     quil_prog += cnot_seq
+    assert isinstance(pauli_term.coefficient, complex) and highest_target_index is not None
     quil_prog.inst(RZ(2.0 * pauli_term.coefficient * param, highest_target_index))
     quil_prog += reverse_hack(cnot_seq)
     quil_prog += change_to_original_basis
@@ -1053,8 +1075,10 @@ def is_zero(pauli_object: PauliDesignator) -> bool:
     :returns: True if PauliTerm is zero, False otherwise
     """
     if isinstance(pauli_object, PauliTerm):
-        return np.isclose(pauli_object.coefficient, 0)
+        assert isinstance(pauli_object.coefficient, complex)
+        return bool(np.isclose(pauli_object.coefficient, 0))
     elif isinstance(pauli_object, PauliSum):
+        assert isinstance(pauli_object.terms[0].coefficient, complex)
         return len(pauli_object.terms) == 1 and np.isclose(pauli_object.terms[0].coefficient, 0)
     else:
         raise TypeError("is_zero only checks PauliTerms and PauliSum objects!")

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -321,9 +321,7 @@ class PauliTerm(object):
 
         result = ID()
         for _ in range(power):
-            pow = result * self
-            assert isinstance(pow, PauliTerm)
-            result = pow
+            result = cast(PauliTerm, result * self)
         return result
 
     def __add__(self, other: Union[PauliDesignator, ExpressionDesignator]) -> "PauliSum":
@@ -344,14 +342,14 @@ class PauliTerm(object):
         """Adds this PauliTerm with a Number.
 
         :param other: A Number
-        :returns: A new PauliTerm
+        :returns: A new PauliSum
         """
         return PauliTerm("I", 0, other) + self
 
     def __sub__(self, other: Union["PauliTerm", ExpressionDesignator]) -> "PauliSum":
         """Subtracts a PauliTerm from this one.
 
-        :param other: A PauliTerm object or a Number
+        :param other: A PauliTerm object, a number, or an Expression
         :returns: A PauliSum object representing the difference of this PauliTerm and term
         """
         return self + -1.0 * other
@@ -984,7 +982,7 @@ def _exponentiate_general_case(pauli_term: PauliTerm, param: float) -> Program:
     highest_target_index = None
 
     for index, op in pauli_term:
-        assert isinstance(index, int) or isinstance(index, QubitPlaceholder)
+        assert isinstance(index, (int, QubitPlaceholder))
         if "X" == op:
             change_to_z_basis.inst(H(index))
             change_to_original_basis.inst(H(index))

--- a/pyquil/tests/test_wavefunction.py
+++ b/pyquil/tests/test_wavefunction.py
@@ -5,7 +5,6 @@ import itertools
 from pyquil.wavefunction import (
     get_bitstring_from_index,
     Wavefunction,
-    _round_to_next_multiple,
     _octet_bits,
 )
 
@@ -46,16 +45,6 @@ def test_ground_state():
     ground = Wavefunction.zeros(2)
     assert len(ground) == 2
     assert ground.amplitudes[0] == 1.0
-
-
-def test_rounding():
-    for i in range(8):
-        if 0 == i % 8:
-            assert i == _round_to_next_multiple(i, 8)
-        else:
-            assert 8 == _round_to_next_multiple(i, 8)
-            assert 16 == _round_to_next_multiple(i + 8, 8)
-            assert 24 == _round_to_next_multiple(i + 16, 8)
 
 
 def test_octet_bits():

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -19,7 +19,7 @@ Module containing the Wavefunction object and methods for working with wavefunct
 import itertools
 import struct
 import warnings
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Dict, Iterator, List, Optional, Sequence, cast
 
 import numpy as np
 
@@ -97,11 +97,11 @@ class Wavefunction(object):
     def __len__(self) -> int:
         return len(self.amplitudes).bit_length() - 1
 
-    def __iter__(self) -> Any:
-        return self.amplitudes.__iter__()
+    def __iter__(self) -> Iterator[complex]:
+        return cast(Iterator[complex], self.amplitudes.__iter__())
 
-    def __getitem__(self, index: int) -> Any:
-        return self.amplitudes[index]
+    def __getitem__(self, index: int) -> complex:
+        return cast(complex, self.amplitudes[index])
 
     def __setitem__(self, key: int, value: complex) -> None:
         self.amplitudes[key] = value

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -103,7 +103,7 @@ class Wavefunction(object):
     def __getitem__(self, index: int) -> Any:
         return self.amplitudes[index]
 
-    def __setitem__(self, key: int, value: float) -> None:
+    def __setitem__(self, key: int, value: complex) -> None:
         self.amplitudes[key] = value
 
     def __str__(self) -> str:
@@ -221,17 +221,6 @@ def get_bitstring_from_index(index: int, qubit_num: int) -> str:
     if index > (2 ** qubit_num - 1):
         raise IndexError("Index {} too large for {} qubits.".format(index, qubit_num))
     return bin(index)[2:].rjust(qubit_num, "0")
-
-
-def _round_to_next_multiple(n: float, m: int) -> float:
-    """
-    Round up the the next multiple.
-
-    :param n: The number to round up.
-    :param m: The multiple.
-    :return: The rounded number
-    """
-    return n if n % m == 0 else n + m - n % m
 
 
 def _octet_bits(o: int) -> List[int]:

--- a/pyquil/wavefunction.py
+++ b/pyquil/wavefunction.py
@@ -16,9 +16,10 @@
 """
 Module containing the Wavefunction object and methods for working with wavefunctions.
 """
+import itertools
 import struct
 import warnings
-import itertools
+from typing import Any, Dict, List, Optional, Sequence
 
 import numpy as np
 
@@ -40,7 +41,7 @@ class Wavefunction(object):
         <basis_ordering>`.
     """
 
-    def __init__(self, amplitude_vector):
+    def __init__(self, amplitude_vector: np.ndarray):
         """
         Initializes a wavefunction
 
@@ -58,29 +59,27 @@ class Wavefunction(object):
             )
 
     @staticmethod
-    def ground(qubit_num):
+    def ground(qubit_num: int) -> "Wavefunction":
         warnings.warn("ground() has been deprecated in favor of zeros()", stacklevel=2)
         return Wavefunction.zeros(qubit_num)
 
     @staticmethod
-    def zeros(qubit_num):
+    def zeros(qubit_num: int) -> "Wavefunction":
         """
         Constructs the groundstate wavefunction for a given number of qubits.
 
-        :param int qubit_num:
+        :param qubit_num:
         :return: A Wavefunction in the ground state
-        :rtype: Wavefunction
         """
         amplitude_vector = np.zeros(2 ** qubit_num)
         amplitude_vector[0] = 1.0
         return Wavefunction(amplitude_vector)
 
     @staticmethod
-    def from_bit_packed_string(coef_string):
+    def from_bit_packed_string(coef_string: bytes) -> "Wavefunction":
         """
         From a bit packed string, unpacks to get the wavefunction
-        :param bytes coef_string:
-        :return:
+        :param coef_string:
         """
         num_octets = len(coef_string)
 
@@ -95,26 +94,26 @@ class Wavefunction(object):
 
         return Wavefunction(wf)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.amplitudes).bit_length() - 1
 
-    def __iter__(self):
+    def __iter__(self) -> Any:
         return self.amplitudes.__iter__()
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> Any:
         return self.amplitudes[index]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: int, value: float) -> None:
         self.amplitudes[key] = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.pretty_print(decimal_digits=10)
 
-    def probabilities(self):
+    def probabilities(self) -> np.ndarray:
         """Returns an array of probabilities in lexicographical order"""
         return np.abs(self.amplitudes) ** 2
 
-    def get_outcome_probs(self):
+    def get_outcome_probs(self) -> Dict[str, float]:
         """
         Parses a wavefunction (array of complex amplitudes) and returns a dictionary of
         outcomes and associated probabilities.
@@ -129,14 +128,15 @@ class Wavefunction(object):
             outcome_dict[outcome] = abs(amplitude) ** 2
         return outcome_dict
 
-    def pretty_print_probabilities(self, decimal_digits=2):
+    def pretty_print_probabilities(self, decimal_digits: int = 2) -> Dict[str, float]:
         """
+        TODO: This doesn't seem like it is named correctly...
+
         Prints outcome probabilities, ignoring all outcomes with approximately zero probabilities
         (up to a certain number of decimal digits) and rounding the probabilities to decimal_digits.
 
         :param int decimal_digits: The number of digits to truncate to.
         :return: A dict with outcomes as keys and probabilities as values.
-        :rtype: dict
         """
         outcome_dict = {}
         qubit_num = len(self)
@@ -147,15 +147,14 @@ class Wavefunction(object):
                 outcome_dict[outcome] = prob
         return outcome_dict
 
-    def pretty_print(self, decimal_digits=2):
+    def pretty_print(self, decimal_digits: int = 2) -> str:
         """
         Returns a string repr of the wavefunction, ignoring all outcomes with approximately zero
         amplitude (up to a certain number of decimal digits) and rounding the amplitudes to
         decimal_digits.
 
         :param int decimal_digits: The number of digits to truncate to.
-        :return: A dict with outcomes as keys and complex amplitudes as values.
-        :rtype: str
+        :return: A string representation of the wavefunction.
         """
         outcome_dict = {}
         qubit_num = len(self)
@@ -172,12 +171,13 @@ class Wavefunction(object):
             pp_string = pp_string[:-3]  # remove the dangling + if it is there
         return pp_string
 
-    def plot(self, qubit_subset=None):
+    def plot(self, qubit_subset: Optional[Sequence[int]] = None) -> None:
         """
+        TODO: calling this will error because of matplotlib
+
         Plots a bar chart with bitstring on the x axis and probability on the y axis.
 
-        :param list qubit_subset: Optional parameter used for plotting a subset of the Hilbert
-            space.
+        :param qubit_subset: Optional parameter used for plotting a subset of the Hilbert space.
         """
         import matplotlib.pyplot as plt
 
@@ -197,7 +197,7 @@ class Wavefunction(object):
         plt.xticks(range(len(prob_dict)), prob_dict.keys())
         plt.show()
 
-    def sample_bitstrings(self, n_samples):
+    def sample_bitstrings(self, n_samples: int) -> np.ndarray:
         """
         Sample bitstrings from the distribution defined by the wavefunction.
 
@@ -210,7 +210,7 @@ class Wavefunction(object):
         return bitstrings
 
 
-def get_bitstring_from_index(index, qubit_num):
+def get_bitstring_from_index(index: int, qubit_num: int) -> str:
     """
     Returns the bitstring in lexical order that corresponds to the given index in 0 to 2^(qubit_num)
     :param int index:
@@ -223,7 +223,7 @@ def get_bitstring_from_index(index, qubit_num):
     return bin(index)[2:].rjust(qubit_num, "0")
 
 
-def _round_to_next_multiple(n, m):
+def _round_to_next_multiple(n: float, m: int) -> float:
     """
     Round up the the next multiple.
 
@@ -234,13 +234,12 @@ def _round_to_next_multiple(n, m):
     return n if n % m == 0 else n + m - n % m
 
 
-def _octet_bits(o):
+def _octet_bits(o: int) -> List[int]:
     """
     Get the bits of an octet.
 
     :param o: The octets.
     :return: The bits as a list in LSB-to-MSB order.
-    :rtype: list
     """
     if not isinstance(o, int):
         raise TypeError("o should be an int")


### PR DESCRIPTION
Description
-----------

Some typing odds and ends.

- [x] Ignore `conftest.py`, `pyquil/magic.py`, and all the files in `pyquil/_parser`
- [x] Add typing to all remaining top-level files other than `pyquil/paulis.py`
- [x] Finish off @rht's work and complete the typing for `pyquil/paulis.py`
- [x] Address all feedback (specifically the division issue in pyQVM)

Next PR will be to deal with the API module, which is the only thing left.

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
