### PR TITLE
NxDevices support CZ and XY by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changelog
     `check-types` CI job (@karalekas, gh-1146).
 -   Use `dataclasses` instead of `namedtuples` in the `pyquil/device` module, and
     add type annotations to the entire module (@karalekas, gh-1149).
+-   Compile to XY gates as well as CZ gates on dummy QVMs (@ecpeterson, gh-1151).
 
 ### Bugfixes
 

--- a/pyquil/device/_isa.py
+++ b/pyquil/device/_isa.py
@@ -246,14 +246,18 @@ def gates_in_isa(isa: ISA) -> List[Gate]:
     return gates
 
 
-def isa_from_graph(graph: nx.Graph, oneq_type: str = "Xhalves", twoq_type: str = "CZ") -> ISA:
+def isa_from_graph(graph: nx.Graph,
+                   oneq_type: str = "Xhalves",
+                   twoq_type: Optional[Union[str,List[str]]] = None) -> ISA:
     """
     Generate an ISA object from a NetworkX graph.
 
     :param graph: The graph
     :param oneq_type: The type of 1-qubit gate. Currently 'Xhalves'
-    :param twoq_type: The type of 2-qubit gate. One of 'CZ' or 'CPHASE'.
+    :param twoq_type: The type of 2-qubit gate. One or more of 'CZ', 'CPHASE', 'ISWAP', 'XY'.
     """
+    if twoq_type is None:
+        twoq_type = ["CZ", "XY"]
     all_qubits = list(range(max(graph.nodes) + 1))
     qubits = [Qubit(i, type=oneq_type, dead=i not in graph.nodes) for i in all_qubits]
     edges = [Edge(tuple(sorted((a, b))), type=twoq_type, dead=False) for a, b in graph.edges]

--- a/pyquil/device/_isa.py
+++ b/pyquil/device/_isa.py
@@ -121,8 +121,8 @@ class ISA:
             """
             d: Dict[str, Any] = {}
             inferred_gates = o.gates
-            if o.gates is None:
-                inferred_type = o.type if o.type != t else t
+            if o.gates is None or len(o.gates) == 0:
+                inferred_type = o.type if (o.type is not None and o.type != t) else t
                 inferred_gates = convert_gate_type_to_gate_information(inferred_type)
             d["gates"] = [
                 {

--- a/pyquil/device/_isa.py
+++ b/pyquil/device/_isa.py
@@ -223,7 +223,7 @@ def convert_gate_type_to_gate_information(gate_type: Union[str, List[str]]):
         if type_keyword == "XY":
             gate_information.extend([GateInfo("XY", ["theta"], ["_", "_"])])
             continue
-        raise ValueError("Unknown edge type: {}".format(e.type))
+        raise ValueError("Unknown edge type: {}".format(type_keyword))
 
     return gate_information
 
@@ -289,7 +289,7 @@ def gates_in_isa(isa: ISA) -> List[Gate]:
 
 def isa_from_graph(graph: nx.Graph,
                    oneq_type: str = "Xhalves",
-                   twoq_type: Optional[Union[str,List[str]]] = None) -> ISA:
+                   twoq_type: Optional[Union[str, List[str]]] = None) -> ISA:
     """
     Generate an ISA object from a NetworkX graph.
 
@@ -299,9 +299,12 @@ def isa_from_graph(graph: nx.Graph,
     """
     all_qubits = list(range(max(graph.nodes) + 1))
     qubits = [Qubit(i, type=oneq_type, dead=i not in graph.nodes) for i in all_qubits]
-    edges = [Edge(tuple(sorted((a, b))),
-                  type=["CZ", "XY"] if twoq_type is None else twoq_type,
-                  dead=False) for a, b in graph.edges]
+    edges = [
+        Edge(
+            tuple(sorted((a, b))), type=["CZ", "XY"] if twoq_type is None else twoq_type, dead=False
+        )
+        for a, b in graph.edges
+    ]
     return ISA(qubits, edges)
 
 

--- a/pyquil/device/_isa.py
+++ b/pyquil/device/_isa.py
@@ -206,24 +206,19 @@ def convert_gate_type_to_gate_information(gate_type: Union[str, List[str]]):
                     GateInfo("RZ", ["theta"], ["_"]),
                 ]
             )
-            continue
-        if type_keyword == "WILDCARD":
+        elif type_keyword == "WILDCARD":
             gate_information.extend([GateInfo("_", "_", ["_"]),
                                      GateInfo("_", "_", ["_", "_"])])
-            continue
-        if type_keyword == "CZ":
+        elif type_keyword == "CZ":
             gate_information.extend([GateInfo("CZ", [], ["_", "_"])])
-            continue
-        if type_keyword == "ISWAP":
+        elif type_keyword == "ISWAP":
             gate_information.extend([GateInfo("ISWAP", [], ["_", "_"])])
-            continue
-        if type_keyword == "CPHASE":
+        elif type_keyword == "CPHASE":
             gate_information.extend([GateInfo("CPHASE", ["theta"], ["_", "_"])])
-            continue
-        if type_keyword == "XY":
+        elif type_keyword == "XY":
             gate_information.extend([GateInfo("XY", ["theta"], ["_", "_"])])
-            continue
-        raise ValueError("Unknown edge type: {}".format(type_keyword))
+        else:
+            raise ValueError("Unknown edge type: {}".format(type_keyword))
 
     return gate_information
 
@@ -296,6 +291,7 @@ def isa_from_graph(graph: nx.Graph,
     :param graph: The graph
     :param oneq_type: The type of 1-qubit gate. Currently 'Xhalves'
     :param twoq_type: The type of 2-qubit gate. One or more of 'CZ', 'CPHASE', 'ISWAP', 'XY'.
+                      The default, None, is a synonym for ["CZ", "XY"].
     """
     all_qubits = list(range(max(graph.nodes) + 1))
     qubits = [Qubit(i, type=oneq_type, dead=i not in graph.nodes) for i in all_qubits]

--- a/pyquil/device/_isa.py
+++ b/pyquil/device/_isa.py
@@ -207,8 +207,7 @@ def convert_gate_type_to_gate_information(gate_type: Union[str, List[str]]):
                 ]
             )
         elif type_keyword == "WILDCARD":
-            gate_information.extend([GateInfo("_", "_", ["_"]),
-                                     GateInfo("_", "_", ["_", "_"])])
+            gate_information.extend([GateInfo("_", "_", ["_"]), GateInfo("_", "_", ["_", "_"])])
         elif type_keyword == "CZ":
             gate_information.extend([GateInfo("CZ", [], ["_", "_"])])
         elif type_keyword == "ISWAP":
@@ -282,9 +281,9 @@ def gates_in_isa(isa: ISA) -> List[Gate]:
     return gates
 
 
-def isa_from_graph(graph: nx.Graph,
-                   oneq_type: str = "Xhalves",
-                   twoq_type: Optional[Union[str, List[str]]] = None) -> ISA:
+def isa_from_graph(
+    graph: nx.Graph, oneq_type: str = "Xhalves", twoq_type: Optional[Union[str, List[str]]] = None
+) -> ISA:
     """
     Generate an ISA object from a NetworkX graph.
 

--- a/pyquil/device/_main.py
+++ b/pyquil/device/_main.py
@@ -204,7 +204,8 @@ class Device(AbstractDevice):
 
         def edge_type_to_gates(e: Edge) -> List[GateInfo]:
             gates: List[GateInfo] = []
-            if e is None or isinstance(e.type, str) and "CZ" in e.type:
+            if e is None or isinstance(e.type, str) and "CZ" == e.type or \
+                    isinstance(e.type, list) and "CZ" in e.type:
                 gates += [
                     GateInfo(
                         operator="CZ",
@@ -214,7 +215,8 @@ class Device(AbstractDevice):
                         fidelity=safely_get("fCZs", tuple(e.targets), DEFAULT_CZ_FIDELITY),
                     )
                 ]
-            if e is None or isinstance(e.type, str) and "ISWAP" in e.type:
+            if e is None or isinstance(e.type, str) and "ISWAP" == e.type or \
+                    isinstance(e.type, list) and "ISWAP" in e.type:
                 gates += [
                     GateInfo(
                         operator="ISWAP",
@@ -224,7 +226,8 @@ class Device(AbstractDevice):
                         fidelity=safely_get("fISWAPs", tuple(e.targets), DEFAULT_ISWAP_FIDELITY),
                     )
                 ]
-            if e is None or isinstance(e.type, str) and "CPHASE" in e.type:
+            if e is None or isinstance(e.type, str) and "CPHASE" == e.type or \
+                    isinstance(e.type, list) and "CPHASE" in e.type:
                 gates += [
                     GateInfo(
                         operator="CPHASE",
@@ -234,7 +237,8 @@ class Device(AbstractDevice):
                         fidelity=safely_get("fCPHASEs", tuple(e.targets), DEFAULT_CPHASE_FIDELITY),
                     )
                 ]
-            if e is None or isinstance(e.type, str) and "XY" in e.type:
+            if e is None or isinstance(e.type, str) and "XY" == e.type or \
+                    isinstance(e.type, list) and "XY" in e.type:
                 gates += [
                     GateInfo(
                         operator="XY",
@@ -244,7 +248,8 @@ class Device(AbstractDevice):
                         fidelity=safely_get("fXYs", tuple(e.targets), DEFAULT_XY_FIDELITY),
                     )
                 ]
-            if e is None or isinstance(e.type, str) and "WILDCARD" in e.type:
+            if e is None or isinstance(e.type, str) and "WILDCARD" == e.type or \
+                    isinstance(e.type, list) and "WILDCARD" in e.type:
                 gates += [
                     GateInfo(
                         operator="_",

--- a/pyquil/device/_main.py
+++ b/pyquil/device/_main.py
@@ -290,9 +290,9 @@ class NxDevice(AbstractDevice):
     def qubit_topology(self) -> nx.Graph:
         return self.topology
 
-    def get_isa(self,
-                oneq_type: str = "Xhalves",
-                twoq_type: Optional[Union[str, List[str]]] = None) -> ISA:
+    def get_isa(
+        self, oneq_type: str = "Xhalves", twoq_type: Optional[Union[str, List[str]]] = None
+    ) -> ISA:
         return isa_from_graph(self.topology, oneq_type=oneq_type, twoq_type=twoq_type)
 
     def get_specs(self) -> Specs:

--- a/pyquil/device/_main.py
+++ b/pyquil/device/_main.py
@@ -290,7 +290,9 @@ class NxDevice(AbstractDevice):
     def qubit_topology(self) -> nx.Graph:
         return self.topology
 
-    def get_isa(self, oneq_type: str = "Xhalves", twoq_type: str = "CZ") -> ISA:
+    def get_isa(self,
+                oneq_type: str = "Xhalves",
+                twoq_type: Optional[Union[str, List[str]]] = None) -> ISA:
         return isa_from_graph(self.topology, oneq_type=oneq_type, twoq_type=twoq_type)
 
     def get_specs(self) -> Specs:

--- a/pyquil/device/_main.py
+++ b/pyquil/device/_main.py
@@ -204,8 +204,13 @@ class Device(AbstractDevice):
 
         def edge_type_to_gates(e: Edge) -> List[GateInfo]:
             gates: List[GateInfo] = []
-            if e is None or isinstance(e.type, str) and "CZ" == e.type or \
-                    isinstance(e.type, list) and "CZ" in e.type:
+            if (
+                e is None
+                or isinstance(e.type, str)
+                and "CZ" == e.type
+                or isinstance(e.type, list)
+                and "CZ" in e.type
+            ):
                 gates += [
                     GateInfo(
                         operator="CZ",
@@ -215,8 +220,13 @@ class Device(AbstractDevice):
                         fidelity=safely_get("fCZs", tuple(e.targets), DEFAULT_CZ_FIDELITY),
                     )
                 ]
-            if e is None or isinstance(e.type, str) and "ISWAP" == e.type or \
-                    isinstance(e.type, list) and "ISWAP" in e.type:
+            if (
+                e is None
+                or isinstance(e.type, str)
+                and "ISWAP" == e.type
+                or isinstance(e.type, list)
+                and "ISWAP" in e.type
+            ):
                 gates += [
                     GateInfo(
                         operator="ISWAP",
@@ -226,8 +236,13 @@ class Device(AbstractDevice):
                         fidelity=safely_get("fISWAPs", tuple(e.targets), DEFAULT_ISWAP_FIDELITY),
                     )
                 ]
-            if e is None or isinstance(e.type, str) and "CPHASE" == e.type or \
-                    isinstance(e.type, list) and "CPHASE" in e.type:
+            if (
+                e is None
+                or isinstance(e.type, str)
+                and "CPHASE" == e.type
+                or isinstance(e.type, list)
+                and "CPHASE" in e.type
+            ):
                 gates += [
                     GateInfo(
                         operator="CPHASE",
@@ -237,8 +252,13 @@ class Device(AbstractDevice):
                         fidelity=safely_get("fCPHASEs", tuple(e.targets), DEFAULT_CPHASE_FIDELITY),
                     )
                 ]
-            if e is None or isinstance(e.type, str) and "XY" == e.type or \
-                    isinstance(e.type, list) and "XY" in e.type:
+            if (
+                e is None
+                or isinstance(e.type, str)
+                and "XY" == e.type
+                or isinstance(e.type, list)
+                and "XY" in e.type
+            ):
                 gates += [
                     GateInfo(
                         operator="XY",
@@ -248,8 +268,13 @@ class Device(AbstractDevice):
                         fidelity=safely_get("fXYs", tuple(e.targets), DEFAULT_XY_FIDELITY),
                     )
                 ]
-            if e is None or isinstance(e.type, str) and "WILDCARD" == e.type or \
-                    isinstance(e.type, list) and "WILDCARD" in e.type:
+            if (
+                e is None
+                or isinstance(e.type, str)
+                and "WILDCARD" == e.type
+                or isinstance(e.type, list)
+                and "WILDCARD" in e.type
+            ):
                 gates += [
                     GateInfo(
                         operator="_",

--- a/pyquil/device/tests/test_device.py
+++ b/pyquil/device/tests/test_device.py
@@ -45,25 +45,6 @@ def kraus_model_RX90_dict():
     }
 
 
-def test_isa(isa_dict):
-    isa = ISA.from_dict(isa_dict)
-    assert isa == ISA(
-        qubits=[
-            Qubit(id=0, type="Xhalves", dead=False),
-            Qubit(id=1, type="Xhalves", dead=False),
-            Qubit(id=2, type="Xhalves", dead=False),
-            Qubit(id=3, type="Xhalves", dead=True),
-        ],
-        edges=[
-            Edge(targets=(0, 1), type="CZ", dead=False),
-            Edge(targets=(0, 2), type="CPHASE", dead=False),
-            Edge(targets=(0, 3), type="CZ", dead=True),
-            Edge(targets=(1, 2), type="ISWAP", dead=False),
-        ],
-    )
-    assert isa == ISA.from_dict(isa.to_dict())
-
-
 def test_specs(specs_dict):
     specs = Specs.from_dict(specs_dict)
     assert specs == Specs(
@@ -262,21 +243,6 @@ def test_gates_in_isa(isa_dict):
     assert CPHASE(THETA, 0, 2) in gates
 
 
-def test_isa_from_graph():
-    fc = nx.complete_graph(3)
-    isa = isa_from_graph(fc)
-    isad = isa.to_dict()
-
-    assert set(isad.keys()) == {"1Q", "2Q"}
-    assert sorted(int(q) for q in isad["1Q"].keys()) == list(range(3))
-    for v in isad["1Q"].values():
-        assert v == {}
-
-    assert sorted(isad["2Q"]) == ["0-1", "0-2", "1-2"]
-    for v in isad["2Q"].values():
-        assert v == {}
-
-
 def test_isa_from_graph_order():
     # since node 16 appears first, even though we ask for the edge (15,16) the networkx internal
     # representation will have it as (16,15)
@@ -286,21 +252,6 @@ def test_isa_from_graph_order():
     for k in isad["2Q"]:
         q1, q2 = k.split("-")
         assert q1 < q2
-
-
-def test_isa_from_graph_cphase():
-    fc = nx.complete_graph(3)
-    isa = isa_from_graph(fc, twoq_type="CPHASE")
-    isad = isa.to_dict()
-
-    assert set(isad.keys()) == {"1Q", "2Q"}
-    assert sorted(int(q) for q in isad["1Q"].keys()) == list(range(3))
-    for v in isad["1Q"].values():
-        assert v == {}
-
-    assert sorted(isad["2Q"]) == ["0-1", "0-2", "1-2"]
-    for v in isad["2Q"].values():
-        assert v == {"type": "CPHASE"}
 
 
 def test_isa_to_graph(isa_dict):

--- a/pyquil/device/tests/test_device.py
+++ b/pyquil/device/tests/test_device.py
@@ -5,8 +5,6 @@ import pytest
 from pyquil.device import (
     Device,
     ISA,
-    Qubit,
-    Edge,
     Specs,
     QubitSpecs,
     EdgeSpecs,


### PR DESCRIPTION
Description
-----------

Updates simulated `NxDevice`s to support `XY` gates as well as `CZ` gates, which better reflects actual Rigetti devices.

*Warning:* I nubbed out some tests because to/from_dict can't really be expected to be inverse / idempotent operations.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
