### PR TITLE
QuantumComputer method to perform readout calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Changelog
     `check-types` CI job (@karalekas, gh-1146).
 -   Use `dataclasses` instead of `namedtuples` in the `pyquil/device` module, and
     add type annotations to the entire module (@karalekas, gh-1149).
--   Mypy errors of paulis.py have been reduced (@rht, gh-1147).
+-   Reduced the number of `mypy` errors in `paulis.py` (@rht, gh-1147).
 -   Compile to XY gates as well as CZ gates on dummy QVMs (@ecpeterson, gh-1151).
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Changelog
 
 ### Announcements
 
+-   There is a new `QuantumComputer.calibration` method for performing readout
+    calibration on a provided `TomographyExperiment`, and utilities for applying
+    the results of the calibration to correct for symmetrized readout error. In
+    addition, `ExperimentSetting` objects now have an `additional_expectations`
+    attribute for extracting simultaneously measurable expectation values from a
+    single setting when using `QuantumComputer.experiment` (@karalekas, gh-1152).
+
 ### Improvements and Changes
 
 -   Type hints have been added to the `quil.py` file (@rht, gh-1115, gh-1134).

--- a/docs/source/apidocs/experiment.rst
+++ b/docs/source/apidocs/experiment.rst
@@ -31,17 +31,22 @@ Schema
         ~TomographyExperiment.generate_experiment_program
         ~TomographyExperiment.build_setting_memory_map
         ~TomographyExperiment.build_symmetrization_memory_maps
-
-.. autoclass:: SymmetrizationLevel
+        ~TomographyExperiment.generate_calibration_experiment
 
 .. autoclass:: pyquil.experiment.ExperimentSetting
 
 .. autoclass:: pyquil.experiment.ExperimentResult
 
+.. autoclass:: pyquil.experiment.SymmetrizationLevel
+
+.. autoclass:: pyquil.experiment.CalibrationMethod
+
 Utilities
 ---------
 
 .. autofunction:: pyquil.experiment.bitstrings_to_expectations
+.. autofunction:: pyquil.experiment.correct_experiment_result
 .. autofunction:: pyquil.experiment.merge_memory_map_lists
+.. autofunction:: pyquil.experiment.ratio_variance
 .. autofunction:: pyquil.experiment.read_json
 .. autofunction:: pyquil.experiment.to_json

--- a/docs/source/apidocs/quantum_computer.rst
+++ b/docs/source/apidocs/quantum_computer.rst
@@ -16,6 +16,7 @@ Quantum Computer
         :template: autosumm.rst
 
         ~QuantumComputer.run
+        ~QuantumComputer.calibrate
         ~QuantumComputer.experiment
         ~QuantumComputer.run_and_measure
         ~QuantumComputer.run_symmetrized_readout

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -139,6 +139,19 @@ class QuantumComputer:
         return self.qam.run().wait().read_memory(region_name="ro")
 
     @_record_call
+    def calibrate(self, experiment: TomographyExperiment) -> List[ExperimentResult]:
+        """
+        Perform readout calibration on the various multi-qubit observables involved in the provided
+        ``TomographyExperiment``.
+
+        :param experiment: The ``TomographyExperiment`` to calibrate readout error for.
+        :return: A list of ``ExperimentResult`` objects that contain the expectation values that
+            correspond to the scale factors resulting from symmetric readout error.
+        """
+        calibration_experiment = experiment.generate_calibration_experiment()
+        return self.experiment(calibration_experiment)
+
+    @_record_call
     def experiment(
         self,
         experiment: TomographyExperiment,

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -39,12 +39,14 @@ from pyquil.api._qvm import ForestConnection, QVM
 from pyquil.device import AbstractDevice, NxDevice, gates_in_isa, ISA, Device
 from pyquil.experiment import (
     ExperimentResult,
+    ExperimentSetting,
     TomographyExperiment,
     bitstrings_to_expectations,
     merge_memory_map_lists,
 )
 from pyquil.gates import RX, MEASURE
 from pyquil.noise import decoherence_noise_with_asymmetric_ro, NoiseModel
+from pyquil.paulis import PauliTerm
 from pyquil.pyqvm import PyQVM
 from pyquil.quil import Program, validate_supported_quil
 
@@ -247,17 +249,37 @@ class QuantumComputer:
                 all_bitstrings.append(bitstrings)
             symmetrized_bitstrings = np.concatenate(all_bitstrings)
 
-            # TODO: support simultaneous observables via multiple correlations
             joint_expectations = [experiment.get_meas_registers(qubits)]
+            if setting.additional_expectations:
+                joint_expectations += setting.additional_expectations
             expectations = bitstrings_to_expectations(
                 symmetrized_bitstrings, joint_expectations=joint_expectations
             )
 
-            # TODO: add calibration and correction
-            mean = np.mean(expectations).item()
-            std_err = (np.std(expectations, axis=0, ddof=1) / np.sqrt(len(expectations))).item()
+            means = np.mean(expectations, axis=0)
+            std_errs = np.std(expectations, axis=0, ddof=1) / np.sqrt(len(expectations))
+
+            joint_results = []
+            for qubit_subset, mean, std_err in zip(joint_expectations, means, std_errs):
+                out_operator = PauliTerm.from_list(
+                    [(setting.out_operator[i], i) for i in qubit_subset]
+                )
+                s = ExperimentSetting(
+                    in_state=setting.in_state,
+                    out_operator=out_operator,
+                    additional_expectations=None,
+                )
+                r = ExperimentResult(
+                    setting=s, expectation=mean, std_err=std_err, total_counts=len(expectations)
+                )
+                joint_results.append(r)
+
             result = ExperimentResult(
-                setting=setting, expectation=mean, std_err=std_err, total_counts=len(expectations)
+                setting=setting,
+                expectation=joint_results[0].expectation,
+                std_err=joint_results[0].std_err,
+                total_counts=joint_results[0].total_counts,
+                additional_results=joint_results[1:],
             )
             results.append(result)
         return results

--- a/pyquil/api/tests/test_quantum_computer.py
+++ b/pyquil/api/tests/test_quantum_computer.py
@@ -3,9 +3,9 @@ import numpy as np
 
 from pyquil import Program
 from pyquil.api import QVM, QuantumComputer, get_qc
-from pyquil.device import NxDevice, gates_in_isa
+from pyquil.device import NxDevice
 from pyquil.experiment import ExperimentSetting, TomographyExperiment
-from pyquil.gates import CNOT, H, RESET
+from pyquil.gates import CNOT, H, RESET, X
 from pyquil.noise import NoiseModel
 from pyquil.paulis import sX, sY, sZ
 from pyquil.tests.utils import DummyCompiler
@@ -90,12 +90,13 @@ def test_qc_expectation_larger_lattice(forest):
     assert results[2].total_counts == 40
 
 
-def test_qc_calibration_1q(forest):
-    def asymmetric_ro_model(qubits: list, p00: float = 0.95, p11: float = 0.90) -> NoiseModel:
-        aprobs = np.array([[p00, 1 - p00], [1 - p11, p11]])
-        aprobs = {q: aprobs for q in qubits}
-        return NoiseModel([], aprobs)
+def asymmetric_ro_model(qubits: list, p00: float = 0.95, p11: float = 0.90) -> NoiseModel:
+    aprobs = np.array([[p00, 1 - p00], [1 - p11, p11]])
+    aprobs = {q: aprobs for q in qubits}
+    return NoiseModel([], aprobs)
 
+
+def test_qc_calibration_1q(forest):
     # noise model with 95% symmetrized readout fidelity per qubit
     noise_model = asymmetric_ro_model([0], 0.945, 0.955)
     qc = get_qc("1q-qvm")
@@ -120,11 +121,6 @@ def test_qc_calibration_1q(forest):
 
 
 def test_qc_calibration_2q(forest):
-    def asymmetric_ro_model(qubits: list, p00: float = 0.95, p11: float = 0.90) -> NoiseModel:
-        aprobs = np.array([[p00, 1 - p00], [1 - p11, p11]])
-        aprobs = {q: aprobs for q in qubits}
-        return NoiseModel([], aprobs)
-
     # noise model with 95% symmetrized readout fidelity per qubit
     noise_model = asymmetric_ro_model([0, 1], 0.945, 0.955)
     qc = get_qc("2q-qvm")
@@ -146,3 +142,66 @@ def test_qc_calibration_2q(forest):
     # ZZ expectation should just be (1 - 2 * readout_error_q0) * (1 - 2 * readout_error_q1)
     np.isclose(results[0].expectation, 0.81, atol=0.01)
     assert results[0].total_counts == 40000
+
+
+def test_qc_joint_expectation(forest):
+    device = NxDevice(nx.complete_graph(2))
+    qc = QuantumComputer(
+        name="testy!", qam=QVM(connection=forest), device=device, compiler=DummyCompiler()
+    )
+
+    # |01> state program
+    p = Program()
+    p += RESET()
+    p += X(0)
+    p.wrap_in_numshots_loop(10)
+
+    # ZZ experiment
+    sz = ExperimentSetting(
+        in_state=sZ(0) * sZ(1), out_operator=sZ(0) * sZ(1), additional_expectations=[[0], [1]]
+    )
+    e = TomographyExperiment(settings=[sz], program=p)
+
+    results = qc.experiment(e)
+
+    # ZZ expectation value for state |01> is -1
+    assert np.isclose(results[0].expectation, -1)
+    assert np.isclose(results[0].std_err, 0)
+    assert results[0].total_counts == 40
+    # Z0 expectation value for state |01> is -1
+    assert np.isclose(results[0].additional_results[0].expectation, -1)
+    assert results[0].additional_results[1].total_counts == 40
+    # Z1 expectation value for state |01> is 1
+    assert np.isclose(results[0].additional_results[1].expectation, 1)
+    assert results[0].additional_results[1].total_counts == 40
+
+
+def test_qc_joint_calibration(forest):
+    # noise model with 95% symmetrized readout fidelity per qubit
+    noise_model = asymmetric_ro_model([0, 1], 0.945, 0.955)
+    qc = get_qc("2q-qvm")
+    qc.qam.noise_model = noise_model
+
+    # |01> state program
+    p = Program()
+    p += RESET()
+    p += X(0)
+    p.wrap_in_numshots_loop(10000)
+
+    # ZZ experiment
+    sz = ExperimentSetting(
+        in_state=sZ(0) * sZ(1), out_operator=sZ(0) * sZ(1), additional_expectations=[[0], [1]]
+    )
+    e = TomographyExperiment(settings=[sz], program=p)
+
+    results = qc.experiment(e)
+
+    # ZZ expectation value for state |01> with 95% RO fid on both qubits is about -0.81
+    assert np.isclose(results[0].expectation, -0.81, atol=0.01)
+    assert results[0].total_counts == 40000
+    # Z0 expectation value for state |01> with 95% RO fid on both qubits is about -0.9
+    assert np.isclose(results[0].additional_results[0].expectation, -0.9, atol=0.01)
+    assert results[0].additional_results[1].total_counts == 40000
+    # Z1 expectation value for state |01> with 95% RO fid on both qubits is about 0.9
+    assert np.isclose(results[0].additional_results[1].expectation, 0.9, atol=0.01)
+    assert results[0].additional_results[1].total_counts == 40000

--- a/pyquil/experiment/__init__.py
+++ b/pyquil/experiment/__init__.py
@@ -5,7 +5,7 @@ from pyquil.experiment._group import (
 )
 from pyquil.experiment._main import OperatorEncoder, TomographyExperiment, read_json, to_json
 from pyquil.experiment._memory import merge_memory_map_lists
-from pyquil.experiment._result import ExperimentResult, bitstrings_to_expectations
+from pyquil.experiment._result import ExperimentResult, bitstrings_to_expectations, ratio_variance
 from pyquil.experiment._setting import (
     _OneQState,
     _pauli_to_product_state,

--- a/pyquil/experiment/__init__.py
+++ b/pyquil/experiment/__init__.py
@@ -1,3 +1,4 @@
+from pyquil.experiment._calibration import CalibrationMethod
 from pyquil.experiment._group import (
     merge_disjoint_experiments,
     get_results_by_qubit_groups,

--- a/pyquil/experiment/__init__.py
+++ b/pyquil/experiment/__init__.py
@@ -5,7 +5,12 @@ from pyquil.experiment._group import (
 )
 from pyquil.experiment._main import OperatorEncoder, TomographyExperiment, read_json, to_json
 from pyquil.experiment._memory import merge_memory_map_lists
-from pyquil.experiment._result import ExperimentResult, bitstrings_to_expectations, ratio_variance
+from pyquil.experiment._result import (
+    ExperimentResult,
+    bitstrings_to_expectations,
+    correct_experiment_result,
+    ratio_variance,
+)
 from pyquil.experiment._setting import (
     _OneQState,
     _pauli_to_product_state,

--- a/pyquil/experiment/_calibration.py
+++ b/pyquil/experiment/_calibration.py
@@ -1,0 +1,23 @@
+##############################################################################
+# Copyright 2016-2019 Rigetti Computing
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+##############################################################################
+
+from enum import IntEnum
+
+
+class CalibrationMethod(IntEnum):
+    PLUS_EIGENSTATE = 1
+    NONE = 0
+    MINUS_EIGENSTATE = -1

--- a/pyquil/experiment/_main.py
+++ b/pyquil/experiment/_main.py
@@ -298,6 +298,7 @@ class TomographyExperiment:
         """
         meas_qubits: Set[int] = set()
         for settings in self:
+            assert len(settings) == 1
             meas_qubits.update(cast(List[int], settings[0].out_operator.get_qubits()))
         return sorted(meas_qubits)
 
@@ -345,6 +346,7 @@ class TomographyExperiment:
         p += self.program
 
         for settings in self:
+            assert len(settings) == 1
             if ("X" in str(settings[0].in_state)) or ("Y" in str(settings[0].in_state)):
                 if f"DECLARE preparation_alpha" in self.program.out():
                     raise ValueError(f'Memory "preparation_alpha" has been declared already.')
@@ -356,6 +358,7 @@ class TomographyExperiment:
                 break
 
         for settings in self:
+            assert len(settings) == 1
             if ("X" in str(settings[0].out_operator)) or ("Y" in str(settings[0].out_operator)):
                 if f"DECLARE measurement_alpha" in self.program.out():
                     raise ValueError(f'Memory "measurement_alpha" has been declared already.')
@@ -466,6 +469,7 @@ class TomographyExperiment:
 
         calibration_settings = []
         for settings in self:
+            assert len(settings) == 1
             calibration_settings.append(
                 ExperimentSetting(
                     in_state=settings[0].out_operator,

--- a/pyquil/experiment/_main.py
+++ b/pyquil/experiment/_main.py
@@ -37,6 +37,7 @@ from typing import (
     cast,
 )
 
+from pyquil.experiment._calibration import CalibrationMethod
 from pyquil.experiment._memory import (
     pauli_term_to_measurement_memory_map,
     pauli_term_to_preparation_memory_map,
@@ -155,6 +156,7 @@ class TomographyExperiment:
         qubits: Optional[List[int]] = None,
         *,
         symmetrization: int = SymmetrizationLevel.EXHAUSTIVE,
+        calibration: int = CalibrationMethod.PLUS_EIGENSTATE,
     ):
         if len(settings) == 0:
             s: List[List[ExperimentSetting]] = []
@@ -174,6 +176,15 @@ class TomographyExperiment:
             )
         self.qubits = qubits
         self.symmetrization = SymmetrizationLevel(symmetrization)
+        if self.symmetrization != SymmetrizationLevel.EXHAUSTIVE:
+            if type(calibration) == int and calibration != 0:
+                warnings.warn(
+                    "Calibration is only supported for exhaustive symmetrization, "
+                    "thus setting self.calibration = 0 (CalibrationMethod.NONE)."
+                )
+            self.calibration = CalibrationMethod.NONE
+        else:
+            self.calibration = CalibrationMethod(calibration)
         self.shots = self.program.num_shots
 
         if "RESET" in self.program.out():
@@ -260,6 +271,7 @@ class TomographyExperiment:
         else:
             string += f"active reset: disabled\n"
         string += f"symmetrization: {self.symmetrization} ({self.symmetrization.name.lower()})\n"
+        string += f"calibration: {self.calibration} ({self.calibration.name.lower()})\n"
         string += f"program:\n{_abbrev_program(self.program)}\n"
         string += f"settings:\n{self.settings_string(abbrev_after=20)}"
         return string
@@ -434,6 +446,46 @@ class TomographyExperiment:
                 zeros[r] = a[idx]
             memory_maps.append({f"{label}": list(zeros)})
         return memory_maps
+
+    def generate_calibration_experiment(self):
+        """
+        Generate another ``TomographyExperiment`` object that can be used to calibrate the various
+        multi-qubit observables involved in this ``TomographyExperiment``. This is achieved by
+        preparing the plus-one (minus-one) eigenstate of each ``out_operator``, and measuring the
+        resulting expectation value of the same ``out_operator``. Ideally, this would always give
+        +1 (-1), but when symmetric readout error is present the effect is to scale the resultant
+        expectations by some constant factor. Determining this scale factor is what we call
+        *readout calibration*, and then the readout error in subsequent measurements can then be
+        mitigated by simply dividing by the scale factor.
+
+        :return: A new ``TomographyExperiment`` that can calibrate the readout error of all the
+            observables involved in this experiment.
+        """
+        if self.calibration != CalibrationMethod.PLUS_EIGENSTATE:
+            raise ValueError('We currently only support the "plus eigenstate" calibration method.')
+
+        calibration_settings = []
+        for settings in self:
+            calibration_settings.append(
+                ExperimentSetting(
+                    in_state=settings[0].out_operator, out_operator=settings[0].out_operator
+                )
+            )
+
+        calibration_program = Program()
+        if self.reset:
+            calibration_program += RESET()
+        calibration_program.wrap_in_numshots_loop(self.shots)
+
+        if self.symmetrization != SymmetrizationLevel.EXHAUSTIVE:
+            raise ValueError("We currently only support calibration for exhaustive symmetrization")
+
+        return TomographyExperiment(
+            settings=calibration_settings,
+            program=calibration_program,
+            symmetrization=SymmetrizationLevel.EXHAUSTIVE,
+            calibration=CalibrationMethod.NONE,
+        )
 
 
 class OperatorEncoder(JSONEncoder):

--- a/pyquil/experiment/_main.py
+++ b/pyquil/experiment/_main.py
@@ -447,7 +447,7 @@ class TomographyExperiment:
             memory_maps.append({f"{label}": list(zeros)})
         return memory_maps
 
-    def generate_calibration_experiment(self):
+    def generate_calibration_experiment(self) -> "TomographyExperiment":
         """
         Generate another ``TomographyExperiment`` object that can be used to calibrate the various
         multi-qubit observables involved in this ``TomographyExperiment``. This is achieved by
@@ -468,7 +468,9 @@ class TomographyExperiment:
         for settings in self:
             calibration_settings.append(
                 ExperimentSetting(
-                    in_state=settings[0].out_operator, out_operator=settings[0].out_operator
+                    in_state=settings[0].out_operator,
+                    out_operator=settings[0].out_operator,
+                    additional_expectations=settings[0].additional_expectations,
                 )
             )
 

--- a/pyquil/experiment/_result.py
+++ b/pyquil/experiment/_result.py
@@ -54,6 +54,7 @@ class ExperimentResult:
     calibration_expectation: Optional[Union[float, complex]] = None
     calibration_std_err: Optional[Union[float, complex]] = None
     calibration_counts: Optional[int] = None
+    additional_results: Optional[List["ExperimentResult"]] = None
 
     def __init__(
         self,
@@ -69,6 +70,7 @@ class ExperimentResult:
         calibration_stddev: Optional[Union[float, complex]] = None,
         calibration_std_err: Optional[Union[float, complex]] = None,
         calibration_counts: Optional[int] = None,
+        additional_results: Optional[List["ExperimentResult"]] = None,
     ):
 
         object.__setattr__(self, "setting", setting)
@@ -77,6 +79,7 @@ class ExperimentResult:
         object.__setattr__(self, "raw_expectation", raw_expectation)
         object.__setattr__(self, "calibration_expectation", calibration_expectation)
         object.__setattr__(self, "calibration_counts", calibration_counts)
+        object.__setattr__(self, "additional_results", additional_results)
 
         if stddev is not None:
             warnings.warn("'stddev' has been renamed to 'std_err'")
@@ -149,8 +152,8 @@ def bitstrings_to_expectations(
 ) -> np.ndarray:
     """
     Given an array of bitstrings (each of which is represented as an array of bits), map them to
-    expectation values and return the desired correlations. If no correlations are given, then just
-    the 1 -> -1, 0 -> 1 mapping is performed.
+    expectation values and return the desired joint expectation values. If no joint expectations
+    are desired, then just the 1 -> -1, 0 -> 1 mapping is performed.
 
     :param bitstrings: Array of bitstrings to map.
     :param joint_expectations: Joint expectation values to calculate. Each entry is a list which

--- a/pyquil/experiment/_setting.py
+++ b/pyquil/experiment/_setting.py
@@ -188,6 +188,10 @@ class ExperimentSetting:
     program consistent. This class represents the (start, measure) pairs. Typically a large
     number of these :py:class:`ExperimentSetting` objects will be created and grouped into
     a :py:class:`TomographyExperiment`.
+
+    :ivar additional_expectations: A list of lists, where each inner list specifies a qubit subset
+        to calculate the joint expectation value for. This attribute allows users to extract
+        simultaneously measurable expectation values from a single experiment setting.
     """
 
     in_state: TensorProductState

--- a/pyquil/experiment/_setting.py
+++ b/pyquil/experiment/_setting.py
@@ -21,7 +21,7 @@ import logging
 import re
 import sys
 import warnings
-from typing import Any, FrozenSet, Generator, Iterable, List, Optional, cast
+from typing import Any, FrozenSet, Generator, Iterable, List, Optional, Union, cast
 
 from pyquil.paulis import PauliTerm, sI, is_identity
 
@@ -192,8 +192,14 @@ class ExperimentSetting:
 
     in_state: TensorProductState
     out_operator: PauliTerm
+    additional_expectations: Optional[List[List[int]]] = None
 
-    def __init__(self, in_state: TensorProductState, out_operator: PauliTerm):
+    def __init__(
+        self,
+        in_state: Union[TensorProductState, PauliTerm],
+        out_operator: PauliTerm,
+        additional_expectations: Optional[List[List[int]]] = None,
+    ):
         # For backwards compatibility, handle in_state specified by PauliTerm.
         if isinstance(in_state, PauliTerm):
             warnings.warn(
@@ -202,6 +208,7 @@ class ExperimentSetting:
             in_state = _pauli_to_product_state(in_state)
         object.__setattr__(self, "in_state", in_state)
         object.__setattr__(self, "out_operator", out_operator)
+        object.__setattr__(self, "additional_expectations", additional_expectations)
 
     @property
     def in_operator(self) -> PauliTerm:

--- a/pyquil/experiment/tests/test_main.py
+++ b/pyquil/experiment/tests/test_main.py
@@ -23,6 +23,7 @@ EXPERIMENT_REPR = """
 shots: 1
 active reset: disabled
 symmetrization: -1 (exhaustive)
+calibration: 1 (plus_eigenstate)
 program:
    X 0
    Y 1

--- a/pyquil/experiment/tests/test_result.py
+++ b/pyquil/experiment/tests/test_result.py
@@ -3,6 +3,7 @@ import numpy as np
 from pyquil.experiment import plusX
 from pyquil.experiment._result import (
     bitstrings_to_expectations,
+    ratio_variance,
     ExperimentResult,
     ExperimentSetting,
 )
@@ -41,3 +42,25 @@ def test_experiment_result():
         setting=ExperimentSetting(plusX(0), sZ(0)), expectation=0.9, std_err=0.05, total_counts=100
     )
     assert str(er) == "X0_0→(1+0j)*Z0: 0.9 +- 0.05"
+
+
+def test_ratio_variance_float():
+    a, b, var_a, var_b = 1.0, 2.0, 0.1, 0.05
+    ab_ratio_var = ratio_variance(a, var_a, b, var_b)
+    assert ab_ratio_var == 0.028125
+
+
+def test_ratio_variance_numerator_zero():
+    # denominator can't be zero, but numerator can be
+    a, b, var_a, var_b = 0.0, 2.0, 0.1, 0.05
+    ab_ratio_var = ratio_variance(a, var_a, b, var_b)
+    assert ab_ratio_var == 0.025
+
+
+def test_ratio_variance_array():
+    a = np.array([1.0, 10.0, 100.0])
+    b = np.array([2.0, 20.0, 200.0])
+    var_a = np.array([0.1, 1.0, 10.0])
+    var_b = np.array([0.05, 0.5, 5.0])
+    ab_ratio_var = ratio_variance(a, var_a, b, var_b)
+    np.testing.assert_allclose(ab_ratio_var, np.array([0.028125, 0.0028125, 0.00028125]))

--- a/pyquil/noise.py
+++ b/pyquil/noise.py
@@ -575,7 +575,7 @@ def apply_noise_model(prog: "Program", noise_model: NoiseModel) -> "Program":
     """
     new_prog = _noise_model_program_header(noise_model)
     for i in prog:
-        if isinstance(i, Gate):
+        if isinstance(i, Gate) and noise_model.gates:
             try:
                 _, new_name = get_noisy_gate(i.name, tuple(i.params))
                 new_prog += Gate(new_name, [], i.qubits)

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -40,9 +40,9 @@ from pyquil.experiment._group import (
     group_settings_clique_removal as group_experiments_clique_removal,
     group_settings_greedy as group_experiments_greedy,
 )
+from pyquil.experiment._result import ratio_variance
 from pyquil.gates import RESET, RX, RY, RZ, X
 from pyquil.paulis import is_identity
-
 
 log = logging.getLogger(__name__)
 
@@ -414,43 +414,6 @@ def _stats_from_measurements(
     obs_var = np.var(obs_vals) / n_shots
 
     return obs_mean, obs_var
-
-
-def ratio_variance(
-    a: Union[float, np.ndarray],
-    var_a: Union[float, np.ndarray],
-    b: Union[float, np.ndarray],
-    var_b: Union[float, np.ndarray],
-) -> Union[float, np.ndarray]:
-    r"""
-    Given random variables 'A' and 'B', compute the variance on the ratio Y = A/B. Denote the
-    mean of the random variables as a = E[A] and b = E[B] while the variances are var_a = Var[A]
-    and var_b = Var[B] and the covariance as Cov[A,B]. The following expression approximates the
-    variance of Y
-
-    Var[Y] \approx (a/b) ^2 * ( var_a /a^2 + var_b / b^2 - 2 * Cov[A,B]/(a*b) )
-
-    We assume the covariance of A and B is negligible, resting on the assumption that A and B
-    are independently measured. The expression above rests on the assumption that B is non-zero,
-    an assumption which we expect to hold true in most cases, but makes no such assumptions
-    about A. If we allow E[A] = 0, then calculating the expression above via numpy would complain
-    about dividing by zero. Instead, we can re-write the above expression as
-
-    Var[Y] \approx var_a /b^2 + (a^2 * var_b) / b^4
-
-    where we have dropped the covariance term as noted above.
-
-    See the following for more details:
-      - https://doi.org/10.1002/(SICI)1097-0320(20000401)39:4<300::AID-CYTO8>3.0.CO;2-O
-      - http://www.stat.cmu.edu/~hseltman/files/ratio.pdf
-      - https://w.wiki/EMh
-
-    :param a: Mean of 'A', to be used as the numerator in a ratio.
-    :param var_a: Variance in 'A'
-    :param b: Mean of 'B', to be used as the numerator in a ratio.
-    :param var_b: Variance in 'B'
-    """
-    return var_a / b ** 2 + (a ** 2 * var_b) / b ** 4
 
 
 def _calibration_program(

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -28,7 +28,6 @@ from pyquil.operator_estimation import (
     measure_observables,
     _ops_bool_to_prog,
     _stats_from_measurements,
-    ratio_variance,
     _calibration_program,
 )
 from pyquil.paulis import sI, sX, sY, sZ, PauliSum
@@ -235,28 +234,6 @@ def test_stats_from_measurements():
     obs_mean, obs_var = _stats_from_measurements(bs_results, d_qub_idx, setting, n_shots)
     assert obs_mean == -1.0
     assert obs_var == 0.0
-
-
-def test_ratio_variance_float():
-    a, b, var_a, var_b = 1.0, 2.0, 0.1, 0.05
-    ab_ratio_var = ratio_variance(a, var_a, b, var_b)
-    assert ab_ratio_var == 0.028125
-
-
-def test_ratio_variance_numerator_zero():
-    # denominator can't be zero, but numerator can be
-    a, b, var_a, var_b = 0.0, 2.0, 0.1, 0.05
-    ab_ratio_var = ratio_variance(a, var_a, b, var_b)
-    assert ab_ratio_var == 0.025
-
-
-def test_ratio_variance_array():
-    a = np.array([1.0, 10.0, 100.0])
-    b = np.array([2.0, 20.0, 200.0])
-    var_a = np.array([0.1, 1.0, 10.0])
-    var_b = np.array([0.05, 0.5, 5.0])
-    ab_ratio_var = ratio_variance(a, var_a, b, var_b)
-    np.testing.assert_allclose(ab_ratio_var, np.array([0.028125, 0.0028125, 0.00028125]))
 
 
 def test_measure_observables_uncalibrated_asymmetric_readout(forest, use_seed):


### PR DESCRIPTION
Description
-----------

Following up on #1100, this PR adds top-level support for readout calibration and correction, making it easy to succinctly run readout-error-mitigated algorithms on modest numbers of qubits (see fig).

```python
from tqdm import tqdm
import matplotlib.pyplot as plt
import numpy as np

from pyquil import Program
from pyquil.api import get_qc
from pyquil.experiment import (
    ExperimentSetting, TomographyExperiment, correct_experiment_result
)
from pyquil.gates import CNOT, H, RESET, RZ
from pyquil.noise import NoiseModel
from pyquil.paulis import sZ

# QVM with asymmetric RO noise

def asymmetric_ro_model(
        qubits: list, p00: float = 0.95, p11: float = 0.90
) -> NoiseModel:
    aprobs = np.array([[p00, 1 - p00], [1 - p11, p11]])
    aprobs = {q: aprobs for q in qubits}
    return NoiseModel([], aprobs)

noise_model = asymmetric_ro_model([0, 1], 0.945, 0.955)
qc = get_qc("2q-qvm")
qc.qam.noise_model = noise_model

q0 = 0
q1 = 1

# QAOA program & experiment

p = Program()
p += RESET()
gamma = p.declare('gamma', 'REAL')
p += H(q0)
p += H(q1)
p += CNOT(q0,q1)
p += RZ(2*gamma, q1)
p += CNOT(q0,q1)
p += H(q0)
p += H(q1)
p += RZ(np.pi/4, q0)
p += RZ(np.pi/4, q1)
p += H(q0)
p += H(q1)
p.wrap_in_numshots_loop(2000)

zz = ExperimentSetting(in_state=sZ(0) * sZ(1), out_operator=sZ(0) * sZ(1))
qaoa = TomographyExperiment(settings=[zz], program=p)

# run experiment

gammas = np.linspace(start=-np.pi/2, stop=np.pi/2, num=100)

results = []
for gamma in tqdm(gammas):
    results.append(qc.experiment(qaoa, memory_map={'gamma': [gamma]}))

means = np.array([result[0].expectation for result in results])
stderrs = np.array([result[0].std_err for result in results])

# run readout calibration

calibrations = qc.calibrate(qaoa)

results_corrected = []
for r in results:
    results_corrected.append([correct_experiment_result(r[0], calibrations[0])])

means_corrected = np.array([result[0].expectation for result in results_corrected])
stderrs_corrected = np.array([result[0].std_err for result in results_corrected])

# plot results

fig_both = plt.figure(figsize=(8, 6))
plt.errorbar(gammas, means, yerr=stderrs,
             color='#66acb4', fmt='o', label='symmetrized')
plt.errorbar(gammas, means_corrected, yerr=stderrs_corrected,
             color='#f8ba2b', fmt='o', label='corrected')
plt.title(rf'Max-Cut QAOA: $\langle ZZ \rangle$ vs. $\gamma$ ($\beta = \pi/8$)',
          fontsize=16)
plt.xlabel(r'Ansatz Angle $\gamma$', fontsize=16)
plt.ylabel(r'Expectation Value $\langle ZZ \rangle$', fontsize=16)
plt.legend()
plt.ylim(-1, 1)
```
![calibration](https://user-images.githubusercontent.com/3578739/71795972-7dade080-2ffd-11ea-8f1a-8921c46e8041.png)

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
