### PR TITLE
Rename TomographyExperiment to Experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ Changelog
 
 ### Announcements
 
--   There is a new `QuantumComputer.calibration` method for performing readout
-    calibration on a provided `TomographyExperiment`, and utilities for applying
-    the results of the calibration to correct for symmetrized readout error. In
-    addition, `ExperimentSetting` objects now have an `additional_expectations`
-    attribute for extracting simultaneously measurable expectation values from a
-    single setting when using `QuantumComputer.experiment` (@karalekas, gh-1152).
+-   The `TomographyExperiment` class has been renamed to `Experiment`. In addition,
+    there is a new `QuantumComputer.calibration` method for performing readout
+    calibration on a provided `Experiment`, and utilities for applying the results
+    of the calibration to correct for symmetrized readout error. `ExperimentSetting`
+    objects now also have an `additional_expectations` attribute for extracting
+    simultaneously measurable expectation values from a single setting when using
+    `QuantumComputer.experiment` (@karalekas, gh-1152, gh-1158).
 
 ### Improvements and Changes
 

--- a/docs/source/apidocs/experiment.rst
+++ b/docs/source/apidocs/experiment.rst
@@ -2,7 +2,7 @@ Experiment
 ==========
 
 The ``experiment`` module offers a schema and utilities for succinctly expressing commonly
-used applications and algorithms in near-term quantum programming. A ``TomographyExperiment``
+used applications and algorithms in near-term quantum programming. An ``Experiment`` object
 is intended to be consumed by the ``QuantumComputer.experiment`` method.
 
 **NOTE**: When working with the `experiment` method, the following declared memory labels are
@@ -18,7 +18,7 @@ reserved:
 Schema
 ------
 
-.. autoclass:: pyquil.experiment.TomographyExperiment
+.. autoclass:: pyquil.experiment.Experiment
 
    .. rubric:: Methods
 
@@ -26,12 +26,12 @@ Schema
         :toctree: autogen
         :template: autosumm.rst
 
-        ~TomographyExperiment.get_meas_qubits
-        ~TomographyExperiment.get_meas_registers
-        ~TomographyExperiment.generate_experiment_program
-        ~TomographyExperiment.build_setting_memory_map
-        ~TomographyExperiment.build_symmetrization_memory_maps
-        ~TomographyExperiment.generate_calibration_experiment
+        ~Experiment.get_meas_qubits
+        ~Experiment.get_meas_registers
+        ~Experiment.generate_experiment_program
+        ~Experiment.build_setting_memory_map
+        ~Experiment.build_symmetrization_memory_maps
+        ~Experiment.generate_calibration_experiment
 
 .. autoclass:: pyquil.experiment.ExperimentSetting
 

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -23,7 +23,7 @@ import numpy as np
 from rpcq.messages import BinaryExecutableResponse, ParameterAref, PyQuilExecutableResponse
 
 from pyquil.api._error_reporting import _record_call
-from pyquil.experiment._main import TomographyExperiment
+from pyquil.experiment._main import Experiment
 
 
 class QAMError(RuntimeError):
@@ -160,6 +160,6 @@ class QAM(ABC):
         self._variables_shim = {}
         self._executable = None
         self._memory_results = defaultdict(lambda: None)
-        self._experiment: Optional[TomographyExperiment] = None
+        self._experiment: Optional[Experiment] = None
 
         self.status = "connected"

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -38,7 +38,7 @@ from pyquil.api._qpu import QPU
 from pyquil.api._qvm import QVM
 from pyquil.device._main import AbstractDevice, Device, NxDevice
 from pyquil.device._isa import gates_in_isa, ISA
-from pyquil.experiment._main import TomographyExperiment
+from pyquil.experiment._main import Experiment
 from pyquil.experiment._memory import merge_memory_map_lists
 from pyquil.experiment._result import ExperimentResult, bitstrings_to_expectations
 from pyquil.experiment._setting import ExperimentSetting
@@ -137,12 +137,12 @@ class QuantumComputer:
         return self.qam.run().wait().read_memory(region_name="ro")
 
     @_record_call
-    def calibrate(self, experiment: TomographyExperiment) -> List[ExperimentResult]:
+    def calibrate(self, experiment: Experiment) -> List[ExperimentResult]:
         """
         Perform readout calibration on the various multi-qubit observables involved in the provided
-        ``TomographyExperiment``.
+        ``Experiment``.
 
-        :param experiment: The ``TomographyExperiment`` to calibrate readout error for.
+        :param experiment: The ``Experiment`` to calibrate readout error for.
         :return: A list of ``ExperimentResult`` objects that contain the expectation values that
             correspond to the scale factors resulting from symmetric readout error.
         """
@@ -152,12 +152,11 @@ class QuantumComputer:
     @_record_call
     def experiment(
         self,
-        experiment: TomographyExperiment,
+        experiment: Experiment,
         memory_map: Optional[Mapping[str, Sequence[Union[int, float]]]] = None,
     ) -> List[ExperimentResult]:
         """
-        Run a ``TomographyExperiment`` on a QVM or QPU backend. A ``TomographyExperiment``
-        is composed of:
+        Run an ``Experiment`` on a QVM or QPU backend. An ``Experiment`` is composed of:
 
             - A main ``Program`` body (or ansatz).
             - A collection of ``ExperimentSetting`` objects, each of which encodes a particular
@@ -165,24 +164,23 @@ class QuantumComputer:
             - A ``SymmetrizationLevel`` for enacting different readout symmetrization strategies.
             - A number of shots to collect for each (unsymmetrized) ``ExperimentSetting``.
 
-        Because the main ``Program`` is static from run to run of a ``TomographyExperiment``, we
-        can leverage our platform's Parametric Compilation feature. This means that the ``Program``
-        can be compiled only once, and the various alterations due to state preparation,
-        measurement, and symmetrization can all be realized at runtime by providing a
-        ``memory_map``. Thus, the steps in the ``experiment`` method are as follows:
+        Because the main ``Program`` is static from run to run of an ``Experiment``, we can leverage
+        our platform's Parametric Compilation feature. This means that the ``Program`` can be
+        compiled only once, and the various alterations due to state preparation, measurement,
+        and symmetrization can all be realized at runtime by providing a ``memory_map``. Thus, the
+        steps in the ``experiment`` method are as follows:
 
-            1. Check to see if this ``TomographyExperiment`` has already been loaded into this
+            1. Check to see if this ``Experiment`` has already been loaded into this
                ``QuantumComputer`` object. If so, skip to step 2. Otherwise, do the following:
 
-                a. Generate a parameterized program corresponding to the ``TomographyExperiment``
-                   (see the ``TomographyExperiment.generate_experiment_program()`` method for more
+                a. Generate a parameterized program corresponding to the ``Experiment``
+                   (see the ``Experiment.generate_experiment_program()`` method for more
                    details on how it changes the main body program to support state preparation,
                    measurement, and symmetrization).
                 b. Compile the parameterized program into a parametric (binary) executable, which
                    contains declared variables that can be assigned at runtime.
 
-            2. For each ``ExperimentSetting`` in the ``TomographyExperiment``, we repeat the
-               following:
+            2. For each ``ExperimentSetting`` in the ``Experiment``, we repeat the following:
 
                 a. Build a collection of memory maps that correspond to the various state
                    preparation, measurement, and symmetrization specifications.
@@ -196,7 +194,7 @@ class QuantumComputer:
         This method is extremely useful shorthand for running near-term applications and algorithms,
         which often have this ansatz + settings structure.
 
-        :param experiment: The ``TomographyExperiment`` to run.
+        :param experiment: The ``Experiment`` to run.
         :param memory_map: A dictionary mapping declared variables / parameters to their values.
             The values are a list of floats or integers. Each float or integer corresponds to
             a particular classical memory register. The memory map provided to the ``experiment``
@@ -204,7 +202,7 @@ class QuantumComputer:
             at runtime (e.g. the variational parameters provided to the ansatz of the variational
             quantum eigensolver).
         :return: A list of ``ExperimentResult`` objects containing the statistics gathered
-            according to the specifications of the ``TomographyExperiment``.
+            according to the specifications of the ``Experiment``.
         """
         executable = self.qam._executable
         # if this experiment was the last experiment run on this QuantumComputer,

--- a/pyquil/api/tests/test_quantum_computer.py
+++ b/pyquil/api/tests/test_quantum_computer.py
@@ -4,7 +4,7 @@ import numpy as np
 from pyquil import Program
 from pyquil.api import QVM, QuantumComputer, get_qc
 from pyquil.device import NxDevice
-from pyquil.experiment import ExperimentSetting, TomographyExperiment
+from pyquil.experiment import ExperimentSetting, Experiment
 from pyquil.gates import CNOT, H, RESET, X
 from pyquil.noise import NoiseModel
 from pyquil.paulis import sX, sY, sZ
@@ -29,7 +29,7 @@ def test_qc_expectation(forest):
     sy = ExperimentSetting(in_state=sZ(0) * sZ(1), out_operator=sY(0) * sY(1))
     sz = ExperimentSetting(in_state=sZ(0) * sZ(1), out_operator=sZ(0) * sZ(1))
 
-    e = TomographyExperiment(settings=[sx, sy, sz], program=p)
+    e = Experiment(settings=[sx, sy, sz], program=p)
 
     results = qc.experiment(e)
 
@@ -70,7 +70,7 @@ def test_qc_expectation_larger_lattice(forest):
     sy = ExperimentSetting(in_state=sZ(q0) * sZ(q1), out_operator=sY(q0) * sY(q1))
     sz = ExperimentSetting(in_state=sZ(q0) * sZ(q1), out_operator=sZ(q0) * sZ(q1))
 
-    e = TomographyExperiment(settings=[sx, sy, sz], program=p)
+    e = Experiment(settings=[sx, sy, sz], program=p)
 
     results = qc.experiment(e)
 
@@ -111,7 +111,7 @@ def test_qc_calibration_1q(forest):
 
     # Z experiment
     sz = ExperimentSetting(in_state=sZ(0), out_operator=sZ(0))
-    e = TomographyExperiment(settings=[sz], program=p)
+    e = Experiment(settings=[sz], program=p)
 
     results = qc.calibrate(e)
 
@@ -135,7 +135,7 @@ def test_qc_calibration_2q(forest):
 
     # ZZ experiment
     sz = ExperimentSetting(in_state=sZ(0) * sZ(1), out_operator=sZ(0) * sZ(1))
-    e = TomographyExperiment(settings=[sz], program=p)
+    e = Experiment(settings=[sz], program=p)
 
     results = qc.calibrate(e)
 
@@ -160,7 +160,7 @@ def test_qc_joint_expectation(forest):
     sz = ExperimentSetting(
         in_state=sZ(0) * sZ(1), out_operator=sZ(0) * sZ(1), additional_expectations=[[0], [1]]
     )
-    e = TomographyExperiment(settings=[sz], program=p)
+    e = Experiment(settings=[sz], program=p)
 
     results = qc.experiment(e)
 
@@ -192,7 +192,7 @@ def test_qc_joint_calibration(forest):
     sz = ExperimentSetting(
         in_state=sZ(0) * sZ(1), out_operator=sZ(0) * sZ(1), additional_expectations=[[0], [1]]
     )
-    e = TomographyExperiment(settings=[sz], program=p)
+    e = Experiment(settings=[sz], program=p)
 
     results = qc.experiment(e)
 

--- a/pyquil/experiment/__init__.py
+++ b/pyquil/experiment/__init__.py
@@ -4,7 +4,13 @@ from pyquil.experiment._group import (
     get_results_by_qubit_groups,
     group_settings,
 )
-from pyquil.experiment._main import OperatorEncoder, TomographyExperiment, read_json, to_json
+from pyquil.experiment._main import (
+    Experiment,
+    OperatorEncoder,
+    TomographyExperiment,
+    read_json,
+    to_json,
+)
 from pyquil.experiment._memory import merge_memory_map_lists
 from pyquil.experiment._result import (
     ExperimentResult,

--- a/pyquil/experiment/_setting.py
+++ b/pyquil/experiment/_setting.py
@@ -187,7 +187,7 @@ class ExperimentSetting:
     Where we typically use a large number of (start, measure) pairs but keep the ansatz preparation
     program consistent. This class represents the (start, measure) pairs. Typically a large
     number of these :py:class:`ExperimentSetting` objects will be created and grouped into
-    a :py:class:`TomographyExperiment`.
+    an :py:class:`Experiment`.
 
     :ivar additional_expectations: A list of lists, where each inner list specifies a qubit subset
         to calculate the joint expectation value for. This attribute allows users to extract

--- a/pyquil/experiment/tests/test_group.py
+++ b/pyquil/experiment/tests/test_group.py
@@ -1,7 +1,7 @@
 import itertools
 import pytest
 
-from pyquil.experiment._main import TomographyExperiment
+from pyquil.experiment._main import Experiment
 from pyquil.experiment._result import ExperimentResult
 from pyquil.experiment._setting import (
     ExperimentSetting,
@@ -63,9 +63,9 @@ def test_merge_disjoint_experiments():
     sett4 = ExperimentSetting(minusX(1), sY(1))
     sett5 = ExperimentSetting(TensorProductState(), sZ(2))
 
-    expt1 = TomographyExperiment(settings=[sett1, sett2], program=Program(X(1)))
-    expt2 = TomographyExperiment(settings=[sett3, sett4], program=Program(Z(0)))
-    expt3 = TomographyExperiment(settings=[sett5], program=Program())
+    expt1 = Experiment(settings=[sett1, sett2], program=Program(X(1)))
+    expt2 = Experiment(settings=[sett3, sett4], program=Program(Z(0)))
+    expt3 = Experiment(settings=[sett5], program=Program())
 
     merged_expt = merge_disjoint_experiments([expt1, expt2, expt3])
     assert len(merged_expt) == 2
@@ -100,7 +100,7 @@ def test_group_experiments(grouping_method):
         ExperimentSetting(TensorProductState(), sZ(0) * sI(1)),
         ExperimentSetting(TensorProductState(), sI(0) * sZ(1)),
     ]
-    suite = TomographyExperiment(expts, Program())
+    suite = Experiment(expts, Program())
     grouped_suite = group_settings(suite, method=grouping_method)
     assert len(suite) == 4
     assert len(grouped_suite) == 2
@@ -191,7 +191,7 @@ def test_max_tpb_overlap_1():
         ExperimentSetting(plusX(2) * plusZ(1), sY(2) * sZ(0)),
     ]
     tomo_expt_program = Program(H(0), H(1), H(2))
-    tomo_expt = TomographyExperiment(tomo_expt_settings, tomo_expt_program)
+    tomo_expt = Experiment(tomo_expt_settings, tomo_expt_program)
     expected_dict = {
         ExperimentSetting(plusX(0) * plusZ(1) * plusX(2), sZ(0) * sY(1) * sY(2)): [
             ExperimentSetting(plusZ(1) * plusX(0), sY(2) * sY(1)),
@@ -207,7 +207,7 @@ def test_max_tpb_overlap_2():
         PauliTerm.from_compact_str("(1+0j)*Z4X8Y5X3Y7Y1"),
     )
     p = Program(H(0), H(1), H(2))
-    tomo_expt = TomographyExperiment([expt_setting], p)
+    tomo_expt = Experiment([expt_setting], p)
     expected_dict = {expt_setting: [expt_setting]}
     assert expected_dict == _max_tpb_overlap(tomo_expt)
 
@@ -220,13 +220,13 @@ def test_max_tpb_overlap_3():
     )
     expt_setting2 = ExperimentSetting(plusZ(7), sY(1))
     p = Program(H(0), H(1), H(2))
-    tomo_expt2 = TomographyExperiment([expt_setting, expt_setting2], p)
+    tomo_expt2 = Experiment([expt_setting, expt_setting2], p)
     expected_dict2 = {expt_setting: [expt_setting, expt_setting2]}
     assert expected_dict2 == _max_tpb_overlap(tomo_expt2)
 
 
 def test_group_experiments_greedy():
-    ungrouped_tomo_expt = TomographyExperiment(
+    ungrouped_tomo_expt = Experiment(
         [
             [
                 ExperimentSetting(
@@ -239,7 +239,7 @@ def test_group_experiments_greedy():
         program=Program(H(0), H(1), H(2)),
     )
     grouped_tomo_expt = group_settings(ungrouped_tomo_expt, method="greedy")
-    expected_grouped_tomo_expt = TomographyExperiment(
+    expected_grouped_tomo_expt = Experiment(
         [
             [
                 ExperimentSetting(

--- a/pyquil/experiment/tests/test_main.py
+++ b/pyquil/experiment/tests/test_main.py
@@ -10,7 +10,7 @@ from pyquil.experiment._program import (
 from pyquil.experiment import (
     ExperimentSetting,
     TensorProductState,
-    TomographyExperiment,
+    Experiment,
     plusZ,
     read_json,
     to_json,
@@ -36,7 +36,7 @@ def test_tomo_experiment():
         ExperimentSetting(plusZ(0), sZ(0)),
     ]
 
-    suite = TomographyExperiment(settings=expts, program=Program(X(0), Y(1)))
+    suite = Experiment(settings=expts, program=Program(X(0), Y(1)))
     assert len(suite) == 2
     for e1, e2 in zip(expts, suite):
         # experiment suite puts in groups of length 1
@@ -59,7 +59,7 @@ def test_tomo_experiment_pre_grouped():
         ],
     ]
 
-    suite = TomographyExperiment(settings=expts, program=Program(X(0), Y(1)))
+    suite = Experiment(settings=expts, program=Program(X(0), Y(1)))
     assert len(suite) == 2  # number of groups
     for es1, es2 in zip(expts, suite):
         for e1, e2 in zip(es1, es2):
@@ -69,7 +69,7 @@ def test_tomo_experiment_pre_grouped():
 
 
 def test_tomo_experiment_empty():
-    suite = TomographyExperiment([], program=Program(X(0)))
+    suite = Experiment([], program=Program(X(0)))
     assert len(suite) == 0
     assert str(suite.program) == "X 0\n"
 
@@ -86,7 +86,7 @@ def test_experiment_deser(tmpdir):
         ],
     ]
 
-    suite = TomographyExperiment(settings=expts, program=Program(X(0), Y(1)))
+    suite = Experiment(settings=expts, program=Program(X(0), Y(1)))
     to_json(f"{tmpdir}/suite.json", suite)
     suite2 = read_json(f"{tmpdir}/suite.json")
     assert suite == suite2
@@ -120,7 +120,7 @@ def test_generate_experiment_program():
     # simplest example
     p = Program()
     s = ExperimentSetting(in_state=sZ(0), out_operator=sZ(0))
-    e = TomographyExperiment(settings=[s], program=p, symmetrization=0)
+    e = Experiment(settings=[s], program=p, symmetrization=0)
     exp = e.generate_experiment_program()
     test_exp = Program()
     ro = test_exp.declare("ro", "BIT")
@@ -131,7 +131,7 @@ def test_generate_experiment_program():
     # 2Q exhaustive symmetrization
     p = Program()
     s = ExperimentSetting(in_state=sZ(0) * sZ(1), out_operator=sZ(0) * sZ(1))
-    e = TomographyExperiment(settings=[s], program=p)
+    e = Experiment(settings=[s], program=p)
     exp = e.generate_experiment_program()
     test_exp = Program()
     test_exp += parameterized_readout_symmetrization([0, 1])
@@ -145,7 +145,7 @@ def test_generate_experiment_program():
     p = Program()
     p.wrap_in_numshots_loop(1000)
     s = ExperimentSetting(in_state=sZ(0), out_operator=sZ(0))
-    e = TomographyExperiment(settings=[s], program=p, symmetrization=0)
+    e = Experiment(settings=[s], program=p, symmetrization=0)
     exp = e.generate_experiment_program()
     test_exp = Program()
     ro = test_exp.declare("ro", "BIT")
@@ -157,7 +157,7 @@ def test_generate_experiment_program():
     p = Program()
     p += RESET()
     s = ExperimentSetting(in_state=sZ(0), out_operator=sZ(0))
-    e = TomographyExperiment(settings=[s], program=p, symmetrization=0)
+    e = Experiment(settings=[s], program=p, symmetrization=0)
     exp = e.generate_experiment_program()
     test_exp = Program()
     test_exp += RESET()
@@ -169,7 +169,7 @@ def test_generate_experiment_program():
     # state preparation and measurement
     p = Program()
     s = ExperimentSetting(in_state=sY(0), out_operator=sX(0))
-    e = TomographyExperiment(settings=[s], program=p, symmetrization=0)
+    e = Experiment(settings=[s], program=p, symmetrization=0)
     exp = e.generate_experiment_program()
     test_exp = Program()
     test_exp += parameterized_single_qubit_state_preparation([0])
@@ -182,7 +182,7 @@ def test_generate_experiment_program():
     # multi-qubit state preparation and measurement
     p = Program()
     s = ExperimentSetting(in_state=sZ(0) * sY(1), out_operator=sZ(0) * sX(1))
-    e = TomographyExperiment(settings=[s], program=p, symmetrization=0)
+    e = Experiment(settings=[s], program=p, symmetrization=0)
     exp = e.generate_experiment_program()
     test_exp = Program()
     test_exp += parameterized_single_qubit_state_preparation([0, 1])
@@ -197,7 +197,7 @@ def test_generate_experiment_program():
 def test_build_experiment_setting_memory_map():
     p = Program()
     s = ExperimentSetting(in_state=sX(0), out_operator=sZ(0) * sY(1))
-    e = TomographyExperiment(settings=[s], program=p)
+    e = Experiment(settings=[s], program=p)
     memory_map = e.build_setting_memory_map(s)
     assert memory_map == {
         "preparation_alpha": [0.0],
@@ -212,7 +212,7 @@ def test_build_experiment_setting_memory_map():
 def test_build_symmetrization_memory_maps():
     p = Program()
     s = ExperimentSetting(in_state=sZ(0) * sZ(1), out_operator=sZ(0) * sZ(1))
-    e = TomographyExperiment(settings=[s], program=p)
+    e = Experiment(settings=[s], program=p)
     memory_maps = [
         {"symmetrization": [0.0, 0.0]},
         {"symmetrization": [0.0, np.pi]},

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -19,6 +19,7 @@ from pyquil.experiment._group import (
     group_settings_greedy as group_experiments_greedy,
 )
 from pyquil.experiment._main import (
+    Experiment,
     OperatorEncoder,
     TomographyExperiment,
 )
@@ -124,7 +125,7 @@ def _local_pauli_eig_meas(op: str, idx: QubitDesignator) -> Program:
 
 
 def _generate_experiment_programs(
-    tomo_experiment: TomographyExperiment, active_reset: bool = False
+    tomo_experiment: Experiment, active_reset: bool = False
 ) -> Tuple[List[Program], List[List[int]]]:
     """
     Generate the programs necessary to estimate the observables in a TomographyExperiment.
@@ -186,7 +187,7 @@ def _generate_experiment_programs(
 
 def measure_observables(
     qc: QuantumComputer,
-    tomo_experiment: TomographyExperiment,
+    tomo_experiment: Experiment,
     n_shots: Optional[int] = None,
     progress_callback: Optional[Callable[[int, int], None]] = None,
     active_reset: Optional[bool] = None,
@@ -419,7 +420,7 @@ def _stats_from_measurements(
 
 
 def _calibration_program(
-    qc: QuantumComputer, tomo_experiment: TomographyExperiment, setting: ExperimentSetting
+    qc: QuantumComputer, tomo_experiment: Experiment, setting: ExperimentSetting
 ) -> Program:
     """
     Program required for calibration in a tomography-like experiment.

--- a/pyquil/simulation/tests/test_reference_density.py
+++ b/pyquil/simulation/tests/test_reference_density.py
@@ -6,7 +6,7 @@ import pyquil.simulation.matrices as qmats
 from pyquil import Program
 from pyquil.api import QuantumComputer
 from pyquil.device import NxDevice
-from pyquil.experiment import ExperimentSetting, TomographyExperiment, zeros_state
+from pyquil.experiment import ExperimentSetting, Experiment, zeros_state
 from pyquil.gates import CNOT, H, I, MEASURE, PHASE, RX, RY, RZ, X
 from pyquil.operator_estimation import measure_observables
 from pyquil.paulis import sI, sX, sY, sZ
@@ -324,7 +324,7 @@ def test_for_negative_probabilities():
 
     # make TomographyExperiment
     expt_settings = [ExperimentSetting(zeros_state([0]), pt) for pt in [sI(0), sX(0), sY(0), sZ(0)]]
-    experiment_1q = TomographyExperiment(settings=expt_settings, program=prog)
+    experiment_1q = Experiment(settings=expt_settings, program=prog)
 
     # make a quantum computer object
     device = NxDevice(nx.complete_graph(1))

--- a/pyquil/simulation/tests/test_reference_density.py
+++ b/pyquil/simulation/tests/test_reference_density.py
@@ -322,7 +322,7 @@ def test_for_negative_probabilities():
     # trivial program to do state tomography on
     prog = Program(I(0))
 
-    # make TomographyExperiment
+     # make an Experiment
     expt_settings = [ExperimentSetting(zeros_state([0]), pt) for pt in [sI(0), sX(0), sY(0), sZ(0)]]
     experiment_1q = Experiment(settings=expt_settings, program=prog)
 

--- a/pyquil/simulation/tests/test_reference_density.py
+++ b/pyquil/simulation/tests/test_reference_density.py
@@ -322,7 +322,7 @@ def test_for_negative_probabilities():
     # trivial program to do state tomography on
     prog = Program(I(0))
 
-     # make an Experiment
+    # make an Experiment
     expt_settings = [ExperimentSetting(zeros_state([0]), pt) for pt in [sI(0), sX(0), sY(0), sZ(0)]]
     experiment_1q = Experiment(settings=expt_settings, program=prog)
 

--- a/pyquil/tests/test_operator_estimation.py
+++ b/pyquil/tests/test_operator_estimation.py
@@ -720,7 +720,7 @@ def test_bit_flip_channel_fidelity(forest, use_seed):
     p = Program(Pragma("PRESERVE_BLOCK"), I(0), Pragma("END_PRESERVE_BLOCK"))
     p.define_noisy_gate("I", [0], kraus_ops)
 
-    # prepare TomographyExperiment
+    # prepare Experiment
     process_exp = Experiment(settings=expt_list, program=p)
     # list to store experiment results
     expts = []


### PR DESCRIPTION
Description
-----------

I prefer the shorter name, and these hybrid/tomography-like experiments are the focus of our quantum cloud platform.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
