### PR TITLE
Add __repr__ magic method for Program class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,9 @@ Changelog
 -   Compile to XY gates as well as CZ gates on dummy QVMs (@ecpeterson, gh-1151).
 -   `QAM.write_memory` now accepts either a `Sequence` of values or a single
     value (@tommy-moffat, gh-1114).
--   Added type hints for all remaining top-level files (@karalekas, gh-1150).
+-   Finished type hints for all remaining top-level files (@karalekas, gh-1150).
 -   Added type annotations to the whole `pyquil.api` module (@karalekas, gh-1157).
+-   Implemented `__repr__` magic method of `Program` class (@karalekas, gh-1159).
 
 ### Bugfixes
 

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -737,6 +737,18 @@ class Program(object):
             )
         )
 
+    def __repr__(self) -> str:
+        string = f"shots: {self.num_shots}\n"
+        string += "program: \n   "
+        string += "\n   ".join(
+            itertools.chain(
+                (str(dg) for dg in self._defined_gates),
+                (str(instr) for instr in self.instructions),
+                [""],
+            )
+        )
+        return string
+
 
 def _what_type_of_qubit_does_it_use(
     program: Program,


### PR DESCRIPTION
Description
-----------

Bout time.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
