### PR TITLE
Actually track metadata in experiment manipulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changelog
 
 - Replace references to non-existent ``endpoint`` init arg when constructing
   ``QPUCompiler``s in ``test_qpu.py`` (@appleby, gh-1164).
+- Preserve program metadata when constructing and manipulationg Experiment
+  objects (@kilimanjaro, gh-1160).
 
 [v2.16](https://github.com/rigetti/pyquil/compare/v2.15.0...v2.16.0) (January 10, 2020)
 ---------------------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changelog
 
 - Replace references to non-existent ``endpoint`` init arg when constructing
   ``QPUCompiler``s in ``test_qpu.py`` (@appleby, gh-1164).
-- Preserve program metadata when constructing and manipulationg Experiment
+- Preserve program metadata when constructing and manipulating `Experiment`
   objects (@kilimanjaro, gh-1160).
 
 [v2.16](https://github.com/rigetti/pyquil/compare/v2.15.0...v2.16.0) (January 10, 2020)

--- a/pyquil/experiment/_group.py
+++ b/pyquil/experiment/_group.py
@@ -173,7 +173,9 @@ def group_settings_clique_removal(experiments: Experiment) -> Experiment:
 
         new_cliqs += [new_cliq]
 
-    return Experiment(new_cliqs, program=experiments.program)
+    return Experiment(
+        new_cliqs, program=experiments.program, symmetrization=experiments.symmetrization,
+    )
 
 
 def _max_weight_operator(ops: Iterable[PauliTerm]) -> Union[None, PauliTerm]:
@@ -284,7 +286,11 @@ def group_settings_greedy(tomo_expt: Experiment) -> Experiment:
     """
     diag_sets = _max_tpb_overlap(tomo_expt)
     grouped_expt_settings_list = list(diag_sets.values())
-    grouped_tomo_expt = Experiment(grouped_expt_settings_list, program=tomo_expt.program)
+    grouped_tomo_expt = Experiment(
+        grouped_expt_settings_list,
+        program=tomo_expt.program,
+        symmetrization=tomo_expt.symmetrization,
+    )
     return grouped_tomo_expt
 
 

--- a/pyquil/experiment/_main.py
+++ b/pyquil/experiment/_main.py
@@ -54,7 +54,7 @@ from pyquil.experiment._symmetrization import SymmetrizationLevel
 from pyquil.gates import RESET
 from pyquil.paulis import PauliTerm
 from pyquil.quil import Program
-from pyquil.quilbase import DefPermutationGate, Reset, ResetQubit
+from pyquil.quilbase import Reset, ResetQubit
 
 
 log = logging.getLogger(__name__)
@@ -87,15 +87,12 @@ def _remove_reset_from_program(program: Program) -> Program:
     :param program: Program to remove RESET(s) from.
     :return: Trimmed Program.
     """
-    definitions = [gate for gate in program.defined_gates]
+    p = program.copy_everything_except_instructions()
 
-    p = Program(*[inst for inst in program if not isinstance(inst, Reset)])
+    for inst in program:
+        if not isinstance(inst, (Reset, ResetQubit)):
+            p.inst(inst)
 
-    for definition in definitions:
-        if isinstance(definition, DefPermutationGate):
-            p.inst(DefPermutationGate(definition.name, list(definition.permutation)))
-        else:
-            p.defgate(definition.name, definition.matrix, definition.parameters)
     return p
 
 


### PR DESCRIPTION
Description
-----------

This fixes two small bugs, in which `Experiment` objects lost meaningful metadata. Specifically:
- `num_shots` was not being preserved when `RESET` instructions were stripped
- `symmetrization` was not preserved when grouping instructions

This fixes both of these issues.

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
