### PR TITLE
Fix QPUCompiler init args in test_qpu.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Changelog
 
 ### Bugfixes
 
+- Replace references to non-existent ``endpoint`` init arg when constructing
+  ``QPUCompiler``s in ``test_qpu.py`` (@appleby, gh-1164).
+
 [v2.16](https://github.com/rigetti/pyquil/compare/v2.15.0...v2.16.0) (January 10, 2020)
 ---------------------------------------------------------------------------------------
 

--- a/pyquil/tests/test_qpu.py
+++ b/pyquil/tests/test_qpu.py
@@ -27,7 +27,11 @@ def test_qpu_run():
             name="pyQuil test QC",
             qam=QPU(endpoint=config.qpu_url, user="pyQuil test suite"),
             device=device,
-            compiler=QPUCompiler(endpoint=config.compiler_url, device=device),
+            compiler=QPUCompiler(
+                quilc_endpoint=config.quilc_url,
+                qpu_compiler_endpoint=config.qpu_compiler_url,
+                device=device,
+            ),
         )
         bitstrings = qc.run_and_measure(program=Program(X(0)), trials=1000)
         assert bitstrings[0].shape == (1000,)
@@ -139,7 +143,12 @@ def mock_qpu():
 def qpu_compiler(test_device):
     try:
         config = PyquilConfig()
-        compiler = QPUCompiler(endpoint=config.qpu_compiler_url, device=test_device, timeout=0.5)
+        compiler = QPUCompiler(
+            quilc_endpoint=config.quilc_url,
+            qpu_compiler_endpoint=config.qpu_compiler_url,
+            device=test_device,
+            timeout=0.5,
+        )
         compiler.quil_to_native_quil(Program(I(0)))
         return compiler
     except Exception as e:


### PR DESCRIPTION
Description
-----------

`QPUCompiler` no longer accepts an `endpoint` init arg. Replace it with `quilc_endpoint` and `qpu_compiler_endpoint`.

This got the QPU tests working against a fake fridge on my local machine.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
