### PR TITLE
Use the job template YAMLs from rigetti/gitlab-pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,9 @@
-# other GitLab CI YAML files to pull jobs and job templates from
+# other GitLab CI YAML files to pull jobs and job templates from -- note that there is an
+# additional "forest" directory here, as the GitLab version of the repo is used by include
 include:
-  - project: rigetti/gitlab-pipelines
+  - project: rigetti/forest/gitlab-pipelines
     file: docker.gitlab-ci.yml
-  - project: rigetti/gitlab-pipelines
+  - project: rigetti/forest/gitlab-pipelines
     file: python.gitlab-ci.yml
 
 # global build variables

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,17 @@
+# other GitLab CI YAML files to pull jobs and job templates from
 include:
-  - project: rigetti/ci
-    file: pipelines/docker.gitlab-ci.yml
+  - project: rigetti/gitlab-pipelines
+    file: docker.gitlab-ci.yml
+  - project: rigetti/gitlab-pipelines
+    file: python.gitlab-ci.yml
 
+# global build variables
 variables:
   IMAGE: rigetti/forest
   QVM_URL: "http://qvm:5000"
   QUILC_URL: "tcp://quilc:5555"
 
+# Docker images to spin up along with the various CI jobs
 services:
   - name: rigetti/qvm
     alias: qvm
@@ -15,93 +20,97 @@ services:
     alias: quilc
     command: ["-R"]
 
+####################################################################################################
+# EVERY-COMMIT JOBS
+####################################################################################################
+
+# build the Sphinx documentation
+# for all Python jobs, see rigetti/gitlab-pipelines/python.gitlab-ci.yml
 build-docs:
+  extends: .python
   image: python:3.6
-  tags:
-    - github
   script:
     - apt-get update && apt-get install -y pandoc
-    - make install
-    - make requirements
     - make docs
 
+# validate code format against Black
 check-format:
-  image: python:3.7
-  tags:
-    - github
+  extends: .python
   script:
-    - make install
-    - make requirements
     - make check-format
 
+# validate code style against flake8
 check-style:
-  image: python:3.7
-  tags:
-    - github
+  extends: .python
   script:
-    - make install
-    - make requirements
     - make check-style
 
+# perform static type checking with mypy
 check-types:
-  image: python:3.7
-  tags:
-    - github
+  extends: .python
   script:
-    - make install
-    - make requirements
     - make check-types
 
+# run the unit tests with Python 3.6
 test-py36:
+  extends: .python
   image: python:3.6
-  tags:
-    - github
   script:
-    - make install
-    - make requirements
+    - make test
+
+# run the unit tests with Python 3.7, and report coverage
+test-py37:
+  extends: .python
+  script:
     - make test
   coverage: '/TOTAL.*\s(\d+)%/'
 
-test-py37:
-  image: python:3.7
-  tags:
-    - github
-  script:
-    - make install
-    - make requirements
-    - make test
-
+# run the unit tests with Python 3.8
 test-py38:
+  extends: .python
   image: python:3.8
-  tags:
-    - github
   script:
-    - make install
-    - make requirements
     - make test
 
 ####################################################################################################
 # MASTER-ONLY JOBS
 ####################################################################################################
 
+# create a Docker image from this master commit (see rigetti/gitlab-pipelines/docker.gitlab-ci.yml)
+docker-edge:
+  extends: .docker-edge
+
+# upload the source distribution of this master commit to TestPyPI
 upload-testpypi:
+  extends: .python
   stage: deploy
   image: python:3.6
-  tags:
-    - github
   only:
     refs:
       - master
   script:
     - make version > VERSION.txt
-    - make install && make dist
-    - make requirements && make upload
+    - make dist
+    - make upload
   allow_failure: true
+
+####################################################################################################
+# BRANCH-ONLY JOBS
+####################################################################################################
+
+# create a Docker image from this branch commit (see rigetti/gitlab-pipelines/docker.gitlab-ci.yml)
+docker-branch:
+  extends: .docker-branch
 
 ####################################################################################################
 # RELEASE-ONLY JOBS
 ####################################################################################################
 
+# create a Docker image from this release (see rigetti/gitlab-pipelines/docker.gitlab-ci.yml)
+docker-stable:
+  extends: .docker-stable
+
+# test that the latest Docker image doesn't error when performing simple tasks
 test-docker:
   stage: test
   image: docker:stable
@@ -114,6 +123,7 @@ test-docker:
   script:
     - docker run --rm $IMAGE:edge python -c "from pyquil import get_qc; qvm = get_qc('9q-qvm')"
 
+# test that installing from TestPyPI completes successfully
 install-testpypi:
   stage: test
   image: python:3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changelog
 
 -   Pin the `antlr4-python3-runtime` package to below `v4.8` (@karalekas, gh-1163).
 -   Expand upon the [acknowledgements](ACKNOWLEDGEMENTS.md) (@karalekas, gh-1165).
+-   Use the [gitlab-pipelines](https://github.com/rigetti/gitlab-pipelines)
+    repository's template YAMLs in the `.gitlab-ci.yml`, and add a section to
+    `CONTRIBUTING.md` about the CI/CD pipelines (@karalekas, gh-1166).
 
 ### Bugfixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,7 +299,7 @@ unheard of for software to build on two CI/CD services as a sort of "double chec
 
 The configuration for GitLab CI is contained in the [`.gitlab-ci.yml`](.gitlab-ci.yml).
 GitLab, like Travis (which is configured in [`.travis.yml`](.travis.yml)), builds the docs,
-performs various style checks, run the unit tests on a variety of Python versions. However,
+performs various style checks, and runs the unit tests on a variety of Python versions. However,
 it has additional responsibilities that Travis does not. For example, GitLab builds the
 [`rigetti/forest`][docker-forest] Docker image, handles release-related activities, and
 also pushes a source distribution to [Test PyPI][test-pypi] on every commit to master. At


### PR DESCRIPTION
Description
-----------

Previously, the `include`-d pipelines in the GitLab CI YAML were in private repositories, and difficult to reason about. This PR takes advantage of the now-public [gitlab-pipelines](https://github.com/rigetti/gitlab-pipelines) repository's template YAMLs, and adds a section to the contributing guide about
managing the CI/CD pipelines.

Checklist
---------

- [x] The above description motivates these changes.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
