### PR TITLE
Fix #1169; Add updated named link for QCS access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog
 
 ### Bugfixes
 
+-   Fixed the QCS access request link in the README (@amyfbrown, gh-1171).
+
 [v2.17](https://github.com/rigetti/pyquil/compare/v2.16.0...v2.17.0) (January 30, 2020)
 ---------------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PyQuil serves three main functions:
 - Compiling and simulating Quil programs using the [Quil Compiler](https://github.com/rigetti/quilc)
   (quilc) and the [Quantum Virtual Machine](https://github.com/rigetti/qvm) (QVM)
 - Executing Quil programs on real quantum processors (QPUs) using
-  [Quantum Cloud Services](https://www.rigetti.com/qcs) (QCS)
+  [Quantum Cloud Services][qcs-paper] (QCS)
 
 PyQuil has a ton of other features, which you can learn more about in the
 [docs](http://pyquil.readthedocs.io/en/latest/). However, you can also keep reading
@@ -102,7 +102,7 @@ the statistics of which are consistent with a two-qubit entangled state.
 
 Using the Forest SDK, you can simulate the operation of a real quantum processor (QPU). If you
 would like to run on the real QPUs in our lab in Berkeley, you can sign up for an account
-on [Quantum Cloud Services](https://www.rigetti.com/qcs) (QCS)!
+on [Quantum Cloud Services][qcs-request-access] (QCS)!
 
 Joining the Forest community
 ----------------------------
@@ -188,6 +188,7 @@ PyQuil is licensed under the
 [pepy-repo]: https://pepy.tech/project/pyquil
 [pypi-badge]: https://img.shields.io/pypi/v/pyquil.svg
 [pypi-repo]: https://pypi.org/project/pyquil/
+[qcs-request-access]: https://qcs.rigetti.com/request-access
 [slack-badge]: https://img.shields.io/badge/slack-rigetti--forest-812f82.svg?
 [zenodo-badge]: https://zenodo.org/badge/DOI/10.5281/zenodo.3604432.svg
 [zenodo-doi]: https://doi.org/10.5281/zenodo.3604432


### PR DESCRIPTION
Description
-----------
This pull request fixes #1169 by adding a named, updated QCS signup link. 

Checklist
---------

- [x] The above description motivates these changes.
- [x] ~There is a unit test that covers these changes.~ not applicable
- [x] ~All new and existing tests pass locally and on [Travis CI][travis].~ not applicable
- [x] ~Parameters and return values have type hints with [PEP 484 syntax][pep-484].~ not applicable
- [x] ~Functions and classes have useful [Sphinx-style][sphinx] docstrings.~ not applicable
- [x] ~All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.~ not applicable
- [x] ~(New Feature) The [docs][docs] have been updated accordingly.~ not applicable
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
