### PR TITLE
Update SDK link and download instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 ### Bugfixes
 
 -   Fixed the QCS access request link in the README (@amyfbrown, gh-1171).
+-   Fix the SDK download link and instructions in the docs (@amyfbrown, gh-1173).
 
 [v2.17](https://github.com/rigetti/pyquil/compare/v2.16.0...v2.17.0) (January 30, 2020)
 ---------------------------------------------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@
 Welcome to the Docs for the Forest SDK!
 =======================================
 
-The Rigetti Forest `Software Development Kit <http://rigetti.com/forest>`_ includes pyQuil, the Rigetti Quil Compiler
+The Rigetti Forest `Software Development Kit <https://qcs.rigetti.com/sdk-downloads>`_ includes pyQuil, the Rigetti Quil Compiler
 (quilc), and the Quantum Virtual Machine (qvm).
 
 **Longtime users of Rigetti Forest will notice a few changes.** First, the SDK now contains a downloadable compiler and a
@@ -54,7 +54,7 @@ in pyquil's docs:
    concert with traditional processors to run hybrid quantum-classical algorithms. For references on problems addressable
    with near-term quantum computers, see `Quantum Computing in the NISQ era and beyond <https://arxiv.org/abs/1801.00862>`_.
 
-Our flagship product `Quantum Cloud Services <https://rigetti.com/qcs>`_ offers users an on-premise, dedicated access
+Our flagship product `Quantum Cloud Services <https://qcs.rigetti.com/request-access>`_ offers users an on-premise, dedicated access
 point to our quantum computers. This access point is a fully-configured VM, which we call a Quantum Machine Image. A QMI
 is bundled with the same downloadable SDK mentioned above, and a command line interface (CLI), which is used for
 scheduling compute time on our quantum computers. To sign up for our waitlist, please click the link above. If you'd like
@@ -62,7 +62,7 @@ to access to our quantum computers for research, please email support@rigetti.co
 
 .. note::
 
-    To join our user community, connect to the `Rigetti Slack workspace <https://rigetti-forest.slack.com>`_ using `this invite <https://join.slack.com/t/rigetti-forest/shared_invite/enQtNTUyNTE1ODg3MzE2LWExZWU5OTE4YTJhMmE2NGNjMThjOTM1MjlkYTA5ZmUxNTJlOTVmMWE0YjA3Y2M2YmQzNTZhNTBlMTYyODRjMzA>`_.
+    To join our user community, connect to the `Rigetti Slack workspace <https://rigetti-forest.slack.com>`_ using `this invite <https://rigetti-forest.slack.com/join/shared_invite/enQtNTUyNTE1ODg3MzE2LWQwNzBlMjZlMmNlN2M5MzQyZDlmOGViODQ5ODI0NWMwNmYzODY4YTc2ZjdjOTNmNzhiYTk2YjVhNTE2NTRkODY>`_.
 
 Contents
 --------

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -49,7 +49,7 @@ The QVM and the compiler are packed as program binaries that are accessed throug
 support for direct command-line interaction, as well as a server mode. The :ref:`server mode <server>` is required for use with pyQuil.
 
 `Download the Forest SDK here <https://qcs.rigetti.com/sdk-downloads>`__, where you can find links
-for macOS, Linux (.deb), Linux (.rpm), and Linux (bare-bones).
+for Windows, macOS, Linux (.deb), Linux (.rpm), and Linux (bare-bones).
 
 All installation mechanisms, except the bare-bones package, require administrative privileges to install. To use the QVM
 and Quil Compiler from the bare-bones package, you will have to install the prerequisite dependencies on your own.
@@ -59,9 +59,23 @@ and Quil Compiler from the bare-bones package, you will have to install the prer
    You can also find the open source code for `quilc <http://github.com/rigetti/quilc>`__ and `qvm <http://github.com/rigetti/qvm>`__
    on GitHub, where you can find instructions for compiling, installing, and contributing to the compiler and QVM.
 
+Installing on Windows
+---------------------
+Download the Windows distribution by clicking on the appropriate link on the `SDK download page <https://qcs.rigetti.com/sdk-downloads>`__.
+Open the file ``forest-sdk.msi`` by double clicking on it in your Downloads folder, and follow the system prompts.
+
+Upon successful installation, one should be able to open a new terminal window and run the following two commands:
+
+::
+
+    qvm --version
+    quilc --version
+
+To uninstall the Forest SDK, search for "Add or remove programs" in the Windows search bar. Click on "Add or remove programs" and, in the resulting window, search for "Forest SDK for Windows" in the list of applications and click on "Uninstall" to remove it.
+
 Installing on macOS
 -------------------
-Download the macOS distribution by clicking on the appropriate link on the `SDK download page<https://qcs.rigetti.com/sdk-downloads>`__.
+Download the macOS distribution by clicking on the appropriate link on the `SDK download page <https://qcs.rigetti.com/sdk-downloads>`__.
 Mount the file ``forest-sdk.dmg`` by double clicking on it in your Downloads folder. From there, open ``forest-sdk.pkg`` by
 double-clicking on it. Follow the installation instructions.
 
@@ -85,7 +99,7 @@ To uninstall, delete the following files:
 Installing the QVM and Compiler on Linux (deb)
 ----------------------------------------------
 
-Download the Debian distribution by clicking on the appropriate link on the `SDK download page<https://qcs.rigetti.com/sdk-downloads>`__. Unpack the tarball and change to that directory
+Download the Debian distribution by clicking on the appropriate link on the `SDK download page <https://qcs.rigetti.com/sdk-downloads>`__. Unpack the tarball and change to that directory
 by doing:
 
 ::
@@ -116,7 +130,7 @@ To uninstall, type:
 Installing the QVM and Compiler on Linux (rpm)
 ----------------------------------------------
 
-Download the RPM-based distribution by clicking on the appropriate link on the `SDK download page<https://qcs.rigetti.com/sdk-downloads>`__. Unpack the tarball and change to that
+Download the RPM-based distribution by clicking on the appropriate link on the `SDK download page <https://qcs.rigetti.com/sdk-downloads>`__. Unpack the tarball and change to that
 directory by doing:
 
 ::

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -48,7 +48,7 @@ The Forest 2.0 Downloadable SDK Preview currently contains:
 The QVM and the compiler are packed as program binaries that are accessed through the command line. Both of them provide
 support for direct command-line interaction, as well as a server mode. The :ref:`server mode <server>` is required for use with pyQuil.
 
-`Request the Forest SDK here <http://rigetti.com/forest>`__. You'll receive an email right away with the download links
+`Download the Forest SDK here <https://qcs.rigetti.com/sdk-downloads>`__, where you can find links
 for macOS, Linux (.deb), Linux (.rpm), and Linux (bare-bones).
 
 All installation mechanisms, except the bare-bones package, require administrative privileges to install. To use the QVM
@@ -61,7 +61,8 @@ and Quil Compiler from the bare-bones package, you will have to install the prer
 
 Installing on macOS
 -------------------
-Mount the file ``forest-sdk.dmg`` by double clicking on it in your email. From there, open ``forest-sdk.pkg`` by
+Download the macOS distribution by clicking on the appropriate link on the `SDK download page<https://qcs.rigetti.com/sdk-downloads>`__.
+Mount the file ``forest-sdk.dmg`` by double clicking on it in your Downloads folder. From there, open ``forest-sdk.pkg`` by
 double-clicking on it. Follow the installation instructions.
 
 Upon successful installation, one should be able to open a new terminal window and run the following two commands:
@@ -84,7 +85,7 @@ To uninstall, delete the following files:
 Installing the QVM and Compiler on Linux (deb)
 ----------------------------------------------
 
-Download the Debian distribution by clicking on the link in your email. Unpack the tarball and change to that directory
+Download the Debian distribution by clicking on the appropriate link on the `SDK download page<https://qcs.rigetti.com/sdk-downloads>`__. Unpack the tarball and change to that directory
 by doing:
 
 ::
@@ -115,7 +116,7 @@ To uninstall, type:
 Installing the QVM and Compiler on Linux (rpm)
 ----------------------------------------------
 
-Download the RPM-based distribution by clicking on the link in your email. Unpack the tarball and change to that
+Download the RPM-based distribution by clicking on the appropriate link on the `SDK download page<https://qcs.rigetti.com/sdk-downloads>`__. Unpack the tarball and change to that
 directory by doing:
 
 ::


### PR DESCRIPTION
Description
-----------

This pull request fixes #1172 by updating the SDK download link and instructions. 

It also updates a broken link for the Rigetti-Forest Slack workspace and a broken link for QCS access requests, and it provides installation instructions for Windows. 

Checklist
---------

- [x] The above description motivates these changes.
- [ ] ~There is a unit test that covers these changes.~ not applicable
- [ ] ~All new and existing tests pass locally and on [Travis CI][travis].~ not applicable
- [ ] ~Parameters and return values have type hints with [PEP 484 syntax][pep-484].~ not applicable
- [ ] ~Functions and classes have useful [Sphinx-style][sphinx] docstrings.~ not applicable
- [ ] ~All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.~ not applicable
- [ ] ~(New Feature) The [docs][docs] have been updated accordingly.~ not applicable
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
