### PR TITLE
Remove HALT from valid protoquil instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog
 
 -   Fixed the QCS access request link in the README (@amyfbrown, gh-1171).
 -   Fix the SDK download link and instructions in the docs (@amyfbrown, gh-1173).
+-   Removed HALT from valid Protoquil / supported Quil. (@kilimanjaro, gh-1176).
 
 [v2.17](https://github.com/rigetti/pyquil/compare/v2.16.0...v2.17.0) (January 30, 2020)
 ---------------------------------------------------------------------------------------

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -68,7 +68,6 @@ from pyquil.quilbase import (
     JumpUnless,
     JumpWhen,
     Declare,
-    Halt,
     Reset,
     ResetQubit,
     DefPermutationGate,
@@ -1125,7 +1124,7 @@ def validate_supported_quil(program: Program) -> None:
     """
     gates_seen = False
     measured_qubits: Set[int] = set()
-    for i, instr in enumerate(program.instructions):
+    for instr in program.instructions:
         if isinstance(instr, Pragma) or isinstance(instr, Declare):
             continue
         elif isinstance(instr, Gate):

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -1109,7 +1109,7 @@ def validate_protoquil(program: Program) -> None:
 
     :param program: The Quil program to validate.
     """
-    valid_instruction_types = tuple([Pragma, Declare, Halt, Gate, Reset, ResetQubit, Measurement])
+    valid_instruction_types = tuple([Pragma, Declare, Gate, Reset, ResetQubit, Measurement])
     for instr in program.instructions:
         if not isinstance(instr, valid_instruction_types):
             # Instructions like MOVE, NOT, JUMP, JUMP-UNLESS will fail here
@@ -1129,9 +1129,6 @@ def validate_supported_quil(program: Program) -> None:
     for i, instr in enumerate(program.instructions):
         if isinstance(instr, Pragma) or isinstance(instr, Declare):
             continue
-        elif isinstance(instr, Halt):
-            if i != len(program.instructions) - 1:
-                raise ValueError(f"Cannot have instructions after HALT")
         elif isinstance(instr, Gate):
             gates_seen = True
             if any(q.index in measured_qubits for q in instr.qubits):

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -609,8 +609,7 @@ class Program(object):
         """
         Whether the program can be compiled to the hardware to execute on a QPU. These Quil
         programs are more restricted than Protoquil: for instance, RESET must be before any
-        gates or MEASUREs, MEASURE on a qubit must be after any gates on that qubit, and
-        no instructions can occur after HALT.
+        gates or MEASUREs, and MEASURE on a qubit must be after any gates on that qubit.
 
         :return: True if the Program is supported Quil, False otherwise
         """
@@ -1120,7 +1119,7 @@ def validate_supported_quil(program: Program) -> None:
     """
     Ensure that a program is supported Quil which can run on any QPU, otherwise raise a ValueError.
     We support a global RESET before any gates, and MEASUREs on each qubit after any gates
-    on that qubit. PRAGMAs and DECLAREs are always allowed, and a final HALT instruction is allowed.
+    on that qubit. PRAGMAs and DECLAREs are always allowed.
 
     :param program: The Quil program to validate.
     """

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -1235,7 +1235,6 @@ I 0
 CZ 2 3
 MEASURE 2 ro[2]
 MEASURE 3 ro[3]
-HALT
 """
         )
     )
@@ -1252,7 +1251,6 @@ CZ 2 3
 MEASURE 2 ro[2]
 X 3
 MEASURE 3 ro[3]
-HALT
 """
         )
     )


### PR DESCRIPTION
Description
-----------

PyQuil considers `HALT` to be a valid protoquil function. Neither the compiler nor the `native_quil_to_executable` handler agree with this, e.g.

```
erik-macbook:magicl erik$ echo "H 0" | quilc 2>/dev/null
RZ(pi/2) 0                              # Entering rewiring: #(0 1 2 3 4 5 6 7)
RX(pi/2) 0
RZ(pi/2) 0
HALT                                    # Exiting rewiring: #(0 1 2 3 4 5 6 7)
erik-macbook:magicl erik$ echo "H 0" | quilc -P 2>/dev/null
RZ(pi/2) 0                              # Entering rewiring: #(0 1 2 3 4 5 6 7)
RX(pi/2) 0
RZ(pi/2) 0                              # Exiting rewiring: #(0 1 2 3 4 5 6 7)
```

This PR just removes `HALT` from the list of accepted protoquil instructions.

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
