### PR TITLE
Fix comment not edited for code change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog
 
 -   Fixed the QCS access request link in the README (@amyfbrown, gh-1171).
 -   Fix the SDK download link and instructions in the docs (@amyfbrown, gh-1173).
+-   Fix error in comment in Noise and Quantum Computation page (@jlapeyre gh-1180)
 
 [v2.17](https://github.com/rigetti/pyquil/compare/v2.16.0...v2.17.0) (January 30, 2020)
 ---------------------------------------------------------------------------------------

--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -527,7 +527,7 @@ good starting point.**
         p.inst(MEASURE(0, 0))
         p.inst(MEASURE(1, 1))
 
-        # overload identity I on qc 0
+        # overload CZ on qc 0
         p.define_noisy_gate("CZ", [0, 1], corrupted_CZ)
         p.wrap_in_numshots_loop(trials)
         qc.qam.random_seed = jj


### PR DESCRIPTION
Fixes #1174

Description
-----------

In the docs, code was copied and edited for a new example. The corresponding comment in the code was copied, but not edited. This PR fixes the comment.

Checklist
---------

- [ x] The above description motivates these changes.
- [ x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

