### PR TITLE
Fix broken link to example now in forest-tutorials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog
 
 -   Fixed the QCS access request link in the README (@amyfbrown, gh-1171).
 -   Fix the SDK download link and instructions in the docs (@amyfbrown, gh-1173).
--   Fix broken link to example now in forest-tutorials (@jlapeyre, gh-1181)
+-   Fix broken link to example now in forest-tutorials (@jlapeyre, gh-1181).
 
 [v2.17](https://github.com/rigetti/pyquil/compare/v2.16.0...v2.17.0) (January 30, 2020)
 ---------------------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog
 
 -   Fixed the QCS access request link in the README (@amyfbrown, gh-1171).
 -   Fix the SDK download link and instructions in the docs (@amyfbrown, gh-1173).
+-   Fix broken link to example now in forest-tutorials (@jlapeyre, gh-1181)
 
 [v2.17](https://github.com/rigetti/pyquil/compare/v2.16.0...v2.17.0) (January 30, 2020)
 ---------------------------------------------------------------------------------------

--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -778,7 +778,7 @@ This section provides the necessary theoretical foundation for
 accurately modeling noisy quantum measurements on superconducting
 quantum processors. It relies on some of the abstractions (density
 matrices, Kraus maps) introduced in our notebook on `gate noise
-models <GateNoiseModels.ipynb>`__.
+models <https://github.com/rigetti/forest-tutorials/notebooks/GateNoiseModels.ipynb>`__.
 
 The most general type of measurement performed on a single qubit at a
 single time can be characterized by some set :math:`\mathcal{O}` of


### PR DESCRIPTION
The examples folder was moved to a new repo. This PR updates
a link to point to the new repo.

Closes #1175

Checklist
---------

- [ x] The above description motivates these changes.
- [ ] ~There is a unit test that covers these changes.~
- [ ] ~All new and existing tests pass locally and on [Travis CI][travis].~
- [ ] ~Parameters and return values have type hints with [PEP 484 syntax][pep-484].~
- [ ] ~Functions and classes have useful [Sphinx-style][sphinx] docstrings.~
- [ ] ~All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.~
- [ ] ~(New Feature) The [docs][docs] have been updated accordingly.~
- [x ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] ~The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).~


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
