### PR TITLE
Fix spurious PHASE and conditional in exponential_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog
 -   Fixed the QCS access request link in the README (@amyfbrown, gh-1171).
 -   Fix the SDK download link and instructions in the docs (@amyfbrown, gh-1173).
 -   Removed HALT from valid Protoquil / supported Quil. (@kilimanjaro, gh-1176).
+-   Fix spurious PHASE and conditional in exponential_map (@jlapeyre, gh-1182).
 
 [v2.17](https://github.com/rigetti/pyquil/compare/v2.16.0...v2.17.0) (January 30, 2020)
 ---------------------------------------------------------------------------------------

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -45,7 +45,7 @@ from pyquil.quilatom import (
 )
 
 from .quil import Program
-from .gates import H, RZ, RX, CNOT, X, PHASE, QUANTUM_GATES
+from .gates import H, RZ, RX, CNOT, QUANTUM_GATES
 from numbers import Number
 from collections import OrderedDict
 import warnings
@@ -920,21 +920,20 @@ def exponential_map(term: PauliTerm) -> Callable[[float], Program]:
     if not np.isclose(np.imag(term.coefficient), 0.0):
         raise TypeError("PauliTerm coefficient must be real")
 
-    coeff = term.coefficient.real
     term.coefficient = term.coefficient.real
 
-    def exp_wrap(param: float) -> Program:
-        prog = Program()
-        if is_identity(term):
-            prog.inst(X(0))
-            prog.inst(PHASE(-param * coeff, 0))
-            prog.inst(X(0))
-            prog.inst(PHASE(-param * coeff, 0))
-        elif is_zero(term):
-            pass
-        else:
+    if is_zero(term) or is_identity(term):
+
+        def exp_wrap(param: float) -> Program:
+            prog = Program()
+            return prog
+
+    else:
+
+        def exp_wrap(param: float) -> Program:
+            prog = Program()
             prog += _exponentiate_general_case(term, param)
-        return prog
+            return prog
 
     return exp_wrap
 

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -24,7 +24,7 @@ from operator import mul
 import numpy as np
 import pytest
 
-from pyquil.gates import RX, RZ, CNOT, H, X, PHASE
+from pyquil.gates import RX, RZ, CNOT, H
 from pyquil.paulis import (
     PauliTerm,
     PauliSum,
@@ -421,14 +421,20 @@ def test_exponentiate_identity():
     generator = PauliTerm("I", 1, 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([X(0), PHASE(-1.0, 0), X(0), PHASE(-1.0, 0)])
+    result_prog = Program()
     assert prog == result_prog
 
     generator = PauliTerm("I", 10, 0.08)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([X(0), PHASE(-0.08, 0), X(0), PHASE(-0.08, 0)])
+    result_prog = Program()
     assert prog == result_prog
+
+    pop = 0.0 * sX(0)
+    expprog = exponential_map(pop)
+    assert expprog(0.5) == Program()
+    pop.coefficient = 1.0
+    assert expprog(0.5) == Program()
 
 
 def test_trotterize():

--- a/pyquil/tests/test_paulis_with_placeholders.py
+++ b/pyquil/tests/test_paulis_with_placeholders.py
@@ -24,7 +24,7 @@ from operator import mul
 import numpy as np
 import pytest
 
-from pyquil.gates import RX, RZ, CNOT, H, X, PHASE
+from pyquil.gates import RX, RZ, CNOT, H
 from pyquil.paulis import (
     PauliTerm,
     PauliSum,
@@ -398,14 +398,14 @@ def test_exponentiate_identity():
     generator = PauliTerm("I", q[1], 1.0)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([X(q[0]), PHASE(-1.0, q[0]), X(q[0]), PHASE(-1.0, q[0])])
-    assert address_qubits(prog) == address_qubits(result_prog)
+    result_prog = Program()
+    assert prog == result_prog
 
     generator = PauliTerm("I", q[10], 0.08)
     para_prog = exponential_map(generator)
     prog = para_prog(1)
-    result_prog = Program().inst([X(q[0]), PHASE(-0.08, q[0]), X(q[0]), PHASE(-0.08, q[0])])
-    assert address_qubits(prog) == address_qubits(result_prog)
+    result_prog = Program()
+    assert prog == result_prog
 
 
 def test_trotterize():


### PR DESCRIPTION
* exponential_map of the identity applies a PHASE gate and
its inverse. This was apparently for debugging purposes. This
PR replaces the PHASE gates with an empty Program.

* This PR moves conditionals on data that is closed over from
inside the closure to outside. That is, the gate that is exponentiated
is checked when the closure is created, but not when it is executed.

Closes #1055. This PR obsoletes PR #373.

Checklist
---------

- [ x] The above description motivates these changes.
- [ x] There is a unit test that covers these changes.
- [x ] All new and existing tests pass locally and on [Travis CI][travis].
- [x ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).
