### PR TITLE
Add memory_map argument to run_symmetrized_readout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog
 -   Fix the SDK download link and instructions in the docs (@amyfbrown, gh-1173).
 -   Removed HALT from valid Protoquil / supported Quil. (@kilimanjaro, gh-1176).
 -   Fix error in comment in Noise and Quantum Computation page (@jlapeyre gh-1180)
+-   Add `memory_map` argument to `run_symmetrized_readout` (@amyfbrown, gh-1184).
 
 [v2.17](https://github.com/rigetti/pyquil/compare/v2.16.0...v2.17.0) (January 30, 2020)
 ---------------------------------------------------------------------------------------

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -285,6 +285,7 @@ class QuantumComputer:
         trials: int,
         symm_type: int = 3,
         meas_qubits: Optional[List[int]] = None,
+        memory_map: Optional[Mapping[str, Sequence[Union[int, float]]]] = None
     ) -> np.ndarray:
         r"""
         Run a quil program in such a way that the readout error is made symmetric. Enforcing
@@ -366,7 +367,7 @@ class QuantumComputer:
                 f"chosen."
             )
 
-        results = _measure_bitstrings(self, sym_programs, meas_qubits, num_shots_per_prog)
+        results = _measure_bitstrings(self, sym_programs, meas_qubits, num_shots_per_prog, memory_map=memory_map)
 
         return _consolidate_symmetrization_outputs(results, flip_arrays)
 
@@ -1146,7 +1147,7 @@ def _consolidate_symmetrization_outputs(
 
 
 def _measure_bitstrings(
-    qc: QuantumComputer, programs: List[Program], meas_qubits: List[int], num_shots: int = 600
+    qc: QuantumComputer, programs: List[Program], meas_qubits: List[int], num_shots: int = 600, memory_map: Optional[Mapping[str, Sequence[Union[int, float]]]] = None
 ) -> List[np.ndarray]:
     """
     Wrapper for appending measure instructions onto each program, running the program,
@@ -1170,7 +1171,7 @@ def _measure_bitstrings(
         prog.wrap_in_numshots_loop(num_shots)
         prog = qc.compiler.quil_to_native_quil(prog)
         exe = qc.compiler.native_quil_to_executable(prog)
-        shots = qc.run(exe)
+        shots = qc.run(exe, memory_map=memory_map)
         results.append(shots)
     return results
 

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -285,7 +285,7 @@ class QuantumComputer:
         trials: int,
         symm_type: int = 3,
         meas_qubits: Optional[List[int]] = None,
-        memory_map: Optional[Mapping[str, Sequence[Union[int, float]]]] = None
+        memory_map: Optional[Mapping[str, Sequence[Union[int, float]]]] = None,
     ) -> np.ndarray:
         r"""
         Run a quil program in such a way that the readout error is made symmetric. Enforcing
@@ -340,6 +340,8 @@ class QuantumComputer:
         :param symm_type: the type of symmetrization
         :param meas_qubits: An advanced feature. The groups of measurement qubits. Only these
             qubits will be symmetrized over, even if the program acts on other qubits.
+        :param memory_map: The mapping of declared parameters to their values. The values
+            are a list of floats or integers.
         :return: A numpy array of shape (trials, len(ro-register)) that contains 0s and 1s.
         """
         if not isinstance(symm_type, int):
@@ -367,7 +369,9 @@ class QuantumComputer:
                 f"chosen."
             )
 
-        results = _measure_bitstrings(self, sym_programs, meas_qubits, num_shots_per_prog, memory_map=memory_map)
+        results = _measure_bitstrings(
+            self, sym_programs, meas_qubits, num_shots_per_prog, memory_map=memory_map
+        )
 
         return _consolidate_symmetrization_outputs(results, flip_arrays)
 
@@ -1147,7 +1151,11 @@ def _consolidate_symmetrization_outputs(
 
 
 def _measure_bitstrings(
-    qc: QuantumComputer, programs: List[Program], meas_qubits: List[int], num_shots: int = 600, memory_map: Optional[Mapping[str, Sequence[Union[int, float]]]] = None
+    qc: QuantumComputer,
+    programs: List[Program],
+    meas_qubits: List[int],
+    num_shots: int = 600,
+    memory_map: Optional[Mapping[str, Sequence[Union[int, float]]]] = None,
 ) -> List[np.ndarray]:
     """
     Wrapper for appending measure instructions onto each program, running the program,
@@ -1157,6 +1165,8 @@ def _measure_bitstrings(
     :param programs: a list of programs to run
     :param meas_qubits: groups of qubits to measure for each program
     :param num_shots: the number of shots to run for each program
+    :param memory_map: The mapping of declared parameters to their values. The values
+            are a list of floats or integers.
     :return: a len(programs) long list of num_shots by num_meas_qubits bit arrays of results for
         each program.
     """


### PR DESCRIPTION
Description
-----------

This pull request resolves #1183 by adding an optional `memory_map` argument to `QuantumComputer.run_symmetrized_readout` so that parametric programs can have their readout symmetrized. 

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
