### PR TITLE
Fix QuantumComputer.experiment for QVMs that require executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changelog
 
 -   Fix flakiness in `test_run` in `pyquil/test/test_quantum_computer.py`
     (@appleby, gh-1190).
+-   Fix a bug in QuantumComputer.experiment that resulted in a TypeError being
+    raised when called multiple times on the same experiment when the underlying QAM
+    was a QVM based on a physical device (@appleby, gh-1188).
 
 [v2.18](https://github.com/rigetti/pyquil/compare/v2.17.0...v2.18.0) (March 3, 2020)
 ------------------------------------------------------------------------------------

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -446,7 +446,9 @@ def test_qc_compile():
     qc.compiler = DummyCompiler()
     prog = Program()
     prog += H(0)
-    prog1 = qc.compile(prog)
+    exe = qc.compile(prog)
+    prog1 = Program(exe.program)
+    assert isinstance(exe, PyQuilExecutableResponse)
     assert prog1 == prog
 
 

--- a/pyquil/tests/utils.py
+++ b/pyquil/tests/utils.py
@@ -1,7 +1,10 @@
 import os
 
+from rpcq.messages import PyQuilExecutableResponse
+
 from pyquil.parser import parse
 from pyquil.api._qac import AbstractCompiler
+from pyquil.api._compiler import _extract_attribute_dictionary_from_program
 from pyquil import Program
 
 
@@ -24,4 +27,7 @@ class DummyCompiler(AbstractCompiler):
         return program
 
     def native_quil_to_executable(self, nq_program: Program):
-        return nq_program
+        return PyQuilExecutableResponse(
+            program=nq_program.out(),
+            attributes=_extract_attribute_dictionary_from_program(nq_program),
+        )


### PR DESCRIPTION
Description
-----------

#### Fix QuantumComputer.experiment for QVMs that require executables

For `QVM`s based on real devices, `QVM.requires_executable` will be true, which means `QVM.load` will reject non-binary "executables", but will unpack the underlying `Program` object from a `PyQuilExecutableResponse` and save that in `self._executable`.

Since `QuatumComputer.experiment` attempts to re-use the saved executable as long as the experiment hasn't changed, it needs to be re-compiled into a `PyQuilExecutableResponse` again before being handed off to `QVM.load`.

Fixes https://github.com/rigetti/forest-tutorials/issues/2

#### Make DummyCompiler.native_quil_to_executable return the correct type
Respect the declared return type of `AbstractCompiler.native_quil_to_executable` and return a `PyQuilExecutableResponse` from `DummyCompiler.native_quil_to_executable` rather than a bare `Program`.

#### Add test_qc_expectation_on_qvm_that_requires_executable

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
