### PR TITLE
Mark test_run as flaky and rerun once on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Changelog
 
 ### Bugfixes
 
+-   Fix flakiness in `test_run` in `pyquil/test/test_quantum_computer.py`
+    (@appleby, gh-1190).
+
 [v2.18](https://github.com/rigetti/pyquil/compare/v2.17.0...v2.18.0) (March 3, 2020)
 ------------------------------------------------------------------------------------
 

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -198,6 +198,9 @@ def test_device_stuff():
     assert isa.edges[0].targets == (0, 4)
 
 
+# We sometimes narrowly miss the np.mean(parity) < 0.15 assertion, below. Alternatively, that upper
+# bound could be relaxed.
+@pytest.mark.flaky(reruns=1)
 def test_run(forest):
     device = NxDevice(nx.complete_graph(3))
     qc = QuantumComputer(


### PR DESCRIPTION
We sometimes narrowly miss the `np.mean(parity) < 0.15` assertion in this test.

See

  https://travis-ci.org/github/rigetti/pyquil/jobs/661211565#L1258

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
