### PR TITLE
Enhancement Controlled gates syntax sugar #1192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog
 
 -   Fixed the QCS access request link in the README (@amyfbrown, gh-1171).
 -   Fix the SDK download link and instructions in the docs (@amyfbrown, gh-1173).
+-   Fix broken link to example now in forest-tutorials (@jlapeyre, gh-1181).
 -   Removed HALT from valid Protoquil / supported Quil. (@kilimanjaro, gh-1176).
 -   Fix error in comment in Noise and Quantum Computation page (@jlapeyre gh-1180)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changelog
 
 -   Add a section to `CONTRIBUTING.md` about publishing packages to conda-forge
     (@appleby, gh-1186).
--   Controlled gates syntax sugar (@adamglos92, gh-1192)
+-   `controlled` modifier now accepts either a Sequence of control qubits or a single control qubit. Previously, only a single control qubit was supported (@adamglos92, gh-1192)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 
 -   Add a section to `CONTRIBUTING.md` about publishing packages to conda-forge
     (@appleby, gh-1186).
+-   Controlled gates syntax sugar (@adamglos92, gh-1192)
 
 ### Bugfixes
 

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -399,7 +399,7 @@ control qubit ``0`` and target qubit ``1``
 
 To produce the doubly-controlled NOT gate (``CCNOT``) with
 control qubits ``0`` and ``1`` and target qubit ``2`` you can stack
-the ``controlled`` modifier, or simply put a list of controlled qubits
+the ``controlled`` modifier, or simply pass a list of control qubits
 
 .. code:: python
 

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -397,6 +397,15 @@ control qubit ``0`` and target qubit ``1``
 
    prog = Program(X(1).controlled(0))
 
+To produce the doubly-controlled NOT gate (``CCNOT``) with
+control qubits ``0`` and ``1`` and target qubit ``2`` you can stack
+the ``controlled`` modifier, or simply put a list of controlled qubits
+
+.. code:: python
+
+   prog = Program(X(2).controlled(0).controlled(1))
+   prog = Program(X(2).controlled([0, 1]))
+
 You can achieve the oft-used `control-off` gate (flip the target qubit
 ``1`` if the control qubit ``0`` is zero) with
 

--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -778,7 +778,7 @@ This section provides the necessary theoretical foundation for
 accurately modeling noisy quantum measurements on superconducting
 quantum processors. It relies on some of the abstractions (density
 matrices, Kraus maps) introduced in our notebook on `gate noise
-models <GateNoiseModels.ipynb>`__.
+models <https://github.com/rigetti/forest-tutorials/notebooks/GateNoiseModels.ipynb>`__.
 
 The most general type of measurement performed on a single qubit at a
 single time can be characterized by some set :math:`\mathcal{O}` of

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -199,11 +199,23 @@ class Gate(AbstractInstruction):
                 _format_qubits_out(self.qubits),
             )
 
-    def controlled(self, control_qubit: QubitDesignator) -> "Gate":
+    def controlled(self, control_qubits: Union[QubitDesignator, list]) -> "Gate":
         """
         Add the CONTROLLED modifier to the gate with the given control qubit.
         """
-        control_qubit = unpack_qubit(control_qubit)
+        if isinstance(control_qubits, list):
+            if len(control_qubits) == 0:
+                return self
+            else:
+                control_qubit = unpack_qubit(control_qubits[0])
+
+                self.modifiers.insert(0, "CONTROLLED")
+                self.qubits.insert(0, control_qubit)
+
+                return self.controlled(control_qubits[1:])
+
+
+        control_qubit = unpack_qubit(control_qubits)
 
         self.modifiers.insert(0, "CONTROLLED")
         self.qubits.insert(0, control_qubit)

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -202,7 +202,7 @@ class Gate(AbstractInstruction):
     def controlled(self, control_qubits: Union[QubitDesignator, list]) -> "Gate":
         """
         Add the CONTROLLED modifier to the gate with the given control qubit or list of control
-	qubits.
+        qubits.
         """
         if isinstance(control_qubits, list):
             if len(control_qubits) == 0:

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -199,7 +199,7 @@ class Gate(AbstractInstruction):
                 _format_qubits_out(self.qubits),
             )
 
-    def controlled(self, control_qubits: Union[QubitDesignator, list]) -> "Gate":
+    def controlled(self, control_qubits: Union[QubitDesignator, List[QubitDesignator]]) -> "Gate":
         """
         Add the CONTROLLED modifier to the gate with the given control qubit or list of control
         qubits.

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -31,6 +31,7 @@ from typing import (
     Tuple,
     Union,
     TYPE_CHECKING,
+    Sequence,
 )
 from warnings import warn
 
@@ -199,28 +200,24 @@ class Gate(AbstractInstruction):
                 _format_qubits_out(self.qubits),
             )
 
-    def controlled(self, control_qubits: Union[QubitDesignator, List[QubitDesignator]]) -> "Gate":
+    def controlled(
+        self, control_qubit: Union[QubitDesignator, Sequence[QubitDesignator]]
+    ) -> "Gate":
         """
-        Add the CONTROLLED modifier to the gate with the given control qubit or list of control
+        Add the CONTROLLED modifier to the gate with the given control qubit or Sequence of control
         qubits.
         """
-        if isinstance(control_qubits, list):
-            if len(control_qubits) == 0:
-                return self
-            else:
-                control_qubit = unpack_qubit(control_qubits[0])
-
+        if isinstance(control_qubit, Sequence):
+            for qubit in control_qubit:
+                qubit = unpack_qubit(qubit)
                 self.modifiers.insert(0, "CONTROLLED")
-                self.qubits.insert(0, control_qubit)
-
-                return self.controlled(control_qubits[1:])
-
-        control_qubit = unpack_qubit(control_qubits)
-
-        self.modifiers.insert(0, "CONTROLLED")
-        self.qubits.insert(0, control_qubit)
-
-        return self
+                self.qubits.insert(0, qubit)
+            return self
+        else:
+            control_qubit = unpack_qubit(control_qubit)
+            self.modifiers.insert(0, "CONTROLLED")
+            self.qubits.insert(0, control_qubit)
+            return self
 
     def forked(self, fork_qubit: QubitDesignator, alt_params: List[ParameterDesignator]) -> "Gate":
         """

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -201,7 +201,7 @@ class Gate(AbstractInstruction):
 
     def controlled(self, control_qubits: Union[QubitDesignator, list]) -> "Gate":
         """
-        Add the CONTROLLED modifier to the gate with the given control qubit.
+        Add the CONTROLLED modifier to the gate with the given control qubit or list of control qubits.
         """
         if isinstance(control_qubits, list):
             if len(control_qubits) == 0:
@@ -213,7 +213,6 @@ class Gate(AbstractInstruction):
                 self.qubits.insert(0, control_qubit)
 
                 return self.controlled(control_qubits[1:])
-
 
         control_qubit = unpack_qubit(control_qubits)
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -201,7 +201,8 @@ class Gate(AbstractInstruction):
 
     def controlled(self, control_qubits: Union[QubitDesignator, list]) -> "Gate":
         """
-        Add the CONTROLLED modifier to the gate with the given control qubit or list of control qubits.
+        Add the CONTROLLED modifier to the gate with the given control qubit or list of control
+	qubits.
         """
         if isinstance(control_qubits, list):
             if len(control_qubits) == 0:

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -27,11 +27,11 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
     TYPE_CHECKING,
-    Sequence,
 )
 from warnings import warn
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -207,17 +207,12 @@ class Gate(AbstractInstruction):
         Add the CONTROLLED modifier to the gate with the given control qubit or Sequence of control
         qubits.
         """
-        if isinstance(control_qubit, Sequence):
-            for qubit in control_qubit:
-                qubit = unpack_qubit(qubit)
-                self.modifiers.insert(0, "CONTROLLED")
-                self.qubits.insert(0, qubit)
-            return self
-        else:
-            control_qubit = unpack_qubit(control_qubit)
+        control_qubit = control_qubit if isinstance(control_qubit, Sequence) else [control_qubit]
+        for qubit in control_qubit:
+            qubit = unpack_qubit(qubit)
             self.modifiers.insert(0, "CONTROLLED")
-            self.qubits.insert(0, control_qubit)
-            return self
+            self.qubits.insert(0, qubit)
+        return self
 
     def forked(self, fork_qubit: QubitDesignator, alt_params: List[ParameterDesignator]) -> "Gate":
         """

--- a/pyquil/tests/test_gates.py
+++ b/pyquil/tests/test_gates.py
@@ -118,6 +118,9 @@ def test_controlled_gate():
     assert g.out() == "CONTROLLED CONTROLLED X 2 1 0"
     g = X(0).controlled([1, 2])
     assert g.out() == "CONTROLLED CONTROLLED X 2 1 0"
+    # for backwards compatibility
+    g = X(0).controlled(**{"control_qubit": 1})
+    assert g.out() == "CONTROLLED X 1 0"
 
 
 def test_dagger_gate():

--- a/pyquil/tests/test_gates.py
+++ b/pyquil/tests/test_gates.py
@@ -116,6 +116,8 @@ def test_controlled_gate():
     assert g.out() == "CONTROLLED X 1 0"
     g = X(0).controlled(1).controlled(2)
     assert g.out() == "CONTROLLED CONTROLLED X 2 1 0"
+    g = X(0).controlled([1, 2])
+    assert g.out() == "CONTROLLED CONTROLLED X 2 1 0"
 
 
 def test_dagger_gate():

--- a/pyquil/tests/test_gates.py
+++ b/pyquil/tests/test_gates.py
@@ -119,7 +119,7 @@ def test_controlled_gate():
     g = X(0).controlled([1, 2])
     assert g.out() == "CONTROLLED CONTROLLED X 2 1 0"
     # for backwards compatibility
-    g = X(0).controlled(**{"control_qubit": 1})
+    g = X(0).controlled(control_qubit=1)
     assert g.out() == "CONTROLLED X 1 0"
 
 

--- a/pyquil/tests/test_gates.py
+++ b/pyquil/tests/test_gates.py
@@ -121,6 +121,8 @@ def test_controlled_gate():
     # for backwards compatibility
     g = X(0).controlled(control_qubit=1)
     assert g.out() == "CONTROLLED X 1 0"
+    g = X(0).controlled([])
+    assert g.out() == "X 0"
 
 
 def test_dagger_gate():


### PR DESCRIPTION
Description
-----------

Enhancement Controlled gates syntax sugar. Closes #1192.
It seems there is some failure in pyquil/simulation/tests/test_reference_density.py when I tested it locally, seems to be unrelated. I wasn't able to run it on Travis

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
