### PR TITLE
Mutli qubit forked modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ Changelog
 
 -   Add a section to `CONTRIBUTING.md` about publishing packages to conda-forge
     (@appleby, gh-1186).
--   `controlled` modifier now accepts either a Sequence of control qubits or a single control qubit. Previously, only a single control qubit was supported (@adamglos92, gh-1196)
+-   The `controlled` modifier now accepts either a Sequence of control qubits or a
+    single control qubit. Previously, only a single control qubit was supported
+    (@adamglos92, gh-1196)
+-   The `forked` modifier now accepts either a Sequence of control qubits or a
+    single control qubit. Previously, only a single control qubit was supported
+    (@appleby, gh-1198)
 
 ### Bugfixes
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -207,8 +207,8 @@ class Gate(AbstractInstruction):
         Add the CONTROLLED modifier to the gate with the given control qubit or Sequence of control
         qubits.
         """
-        control_qubit = control_qubit if isinstance(control_qubit, Sequence) else [control_qubit]
-        for qubit in control_qubit:
+        control_qubits = control_qubit if isinstance(control_qubit, Sequence) else [control_qubit]
+        for qubit in control_qubits:
             qubit = unpack_qubit(qubit)
             self.modifiers.insert(0, "CONTROLLED")
             self.qubits.insert(0, qubit)

--- a/pyquil/tests/test_gates.py
+++ b/pyquil/tests/test_gates.py
@@ -116,6 +116,8 @@ def test_controlled_gate():
     assert g.out() == "CONTROLLED X 1 0"
     g = X(0).controlled(1).controlled(2)
     assert g.out() == "CONTROLLED CONTROLLED X 2 1 0"
+    g = X(0).controlled([1])
+    assert g.out() == "CONTROLLED X 1 0"
     g = X(0).controlled([1, 2])
     assert g.out() == "CONTROLLED CONTROLLED X 2 1 0"
     # for backwards compatibility

--- a/pyquil/tests/test_gates.py
+++ b/pyquil/tests/test_gates.py
@@ -137,6 +137,27 @@ def test_forked_gate():
     assert g.out() == "FORKED RX(0,1.0) 1 0"
     g = RX(0.0, 0).forked(1, [1.0]).forked(2, [2.0, 3.0])
     assert g.out() == "FORKED FORKED RX(0,1.0,2.0,3.0) 2 1 0"
+    g = RX(0.0, 0).forked([1], [1.0])
+    assert g.out() == "FORKED RX(0,1.0) 1 0"
+    g = RX(0.0, 0).forked([1, 2], [1.0, 2.0, 3.0])
+    assert g.out() == "FORKED FORKED RX(0,1.0,2.0,3.0) 2 1 0"
+    # for backwards compatibility
+    g = RX(0.0, 0).forked(fork_qubit=1, alt_params=[1.0])
+    assert g.out() == "FORKED RX(0,1.0) 1 0"
+    g = RX(0.0, 0).forked([], [])
+    assert g.out() == "RX(0) 0"
+
+    # alt_params not a Sequence
+    with pytest.raises(TypeError):
+        RX(0.0, 0).forked(1, {1.0})
+
+    # too many alt_params
+    with pytest.raises(ValueError):
+        RX(0.0, 0).forked(1, [1.0, 2.0])
+
+    # too few alt_params
+    with pytest.raises(ValueError):
+        RX(0.0, 0).forked([1, 2], [1.0, 2.0])
 
 
 def test_dagger_controlled_gate():


### PR DESCRIPTION
Description
-----------

Allow the caller to pass a `Sequence` of control qubits to `Gate.forked`.

This mirrors the recent change to `Gate.controlled` in #1196.


Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
