### PR TITLE
Add rewrite_arithmetic handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 
 ### Improvements and Changes
 
+-   Added a PyQuil only `rewrite_arithmetic` handler, deprecating the previous
+    RPC call to `quilc` in `native_quil_to_executable` (@kilimanjaro, gh-1210).
+
 ### Bugfixes
 
 [v2.19](https://github.com/rigetti/pyquil/compare/v2.18.0...v2.19.0) (March 26, 2020)

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -29,8 +29,6 @@ from rpcq.messages import (
     TargetDevice,
     PyQuilExecutableResponse,
     ParameterSpec,
-    RewriteArithmeticRequest,
-    RewriteArithmeticResponse,
 )
 from urllib.parse import urljoin
 
@@ -38,6 +36,7 @@ from pyquil.api._base_connection import ForestSession
 from pyquil.api._qac import AbstractCompiler
 from pyquil.api._error_reporting import _record_call
 from pyquil.api._errors import UserMessageError
+from pyquil.api._rewrite_arithmetic import rewrite_arithmetic
 from pyquil.device._main import AbstractDevice, Device
 from pyquil.parser import parse_program
 from pyquil.quil import Program
@@ -336,11 +335,7 @@ class QPUCompiler(AbstractCompiler):
                 "but be careful!"
             )
 
-        arithmetic_request = RewriteArithmeticRequest(quil=nq_program.out())
-        arithmetic_response: RewriteArithmeticResponse = cast(
-            RewriteArithmeticResponse,
-            self.quilc_client.call("rewrite_arithmetic", arithmetic_request),
-        )
+        arithmetic_response = rewrite_arithmetic(nq_program)
 
         request = BinaryExecutableRequest(
             quil=arithmetic_response.quil, num_shots=nq_program.num_shots

--- a/pyquil/api/_rewrite_arithmetic.py
+++ b/pyquil/api/_rewrite_arithmetic.py
@@ -1,0 +1,98 @@
+from numbers import Real
+
+from pyquil import Program
+from pyquil.quilatom import MemoryReference, Expression
+from pyquil.quilbase import (
+    Declare,
+    Gate,
+)
+from rpcq.messages import ParameterSpec, ParameterAref, RewriteArithmeticResponse
+
+
+def rewrite_arithmetic(prog: Program) -> RewriteArithmeticResponse:
+    """Rewrite compound arithmetic expressions.
+
+    The basic motivation is that a parametric program may have gates with
+    compound arguments which cannot be evaluated natively on the underlying
+    control hardware. The solution provided here is to translate a program like
+
+      DECLARE theta REAL
+      DECLARE beta REAL
+      RZ(3 * theta) 0
+      RZ(beta+theta) 0
+
+    into something like
+
+      DECLARE theta REAL
+      DECLARE beta REAL
+      DECLARE __P REAL[2]
+      RZ(__P[0]) 0
+      RZ(__P[1]) 0
+
+    along with a "recalculation table" mapping new memory references to their
+    corresponding arithmetic expressions,
+
+      {
+        ParameterAref('__P', 0): "((3.0)*theta[0])",
+        ParameterAref('__P', 1): "(beta[0]+theta[0])"
+      }
+
+    When executing the parametric program with specific values for `theta` and
+    `beta`, the PyQuil client will patch in values for `__P` by evaluating the
+    expressions in the recalculation table.
+
+    :param prog: A program.
+    :returns: A RewriteArithmeticResponse, containing the updated program along
+      with its memory descriptors and a recalculation table.
+
+    """
+
+    def spec(inst: Declare) -> ParameterSpec:
+        return ParameterSpec(type=inst.memory_type, length=inst.memory_size)
+
+    def aref(ref: MemoryReference) -> ParameterAref:
+        return ParameterAref(name=ref.name, index=ref.offset)
+
+    updated = prog.copy_everything_except_instructions()
+    old_descriptors = {inst.name: spec(inst) for inst in prog if isinstance(inst, Declare)}
+    recalculation_table = {}
+    seen_exprs = {}
+
+    # generate a unique name. it's nice to do this in a deterministic fashion
+    # rather than globbing in a UUID
+    suffix = len(old_descriptors)
+    while f"__P{suffix}" in old_descriptors:
+        suffix += 1
+    mref_name = f"__P{suffix}"
+    mref_idx = 0
+
+    for inst in prog:
+        if isinstance(inst, Gate):
+            new_params = []
+            for param in inst.params:
+                if isinstance(param, (Real, MemoryReference)):
+                    new_params.append(param)
+                elif isinstance(param, Expression):
+                    expr = str(param)
+                    if expr in seen_exprs:
+                        new_params.append(seen_exprs[expr])
+                    else:
+                        new_mref = MemoryReference(mref_name, mref_idx)
+                        seen_exprs[expr] = new_mref
+                        mref_idx += 1
+                        recalculation_table[aref(new_mref)] = expr
+                        new_params.append(new_mref)
+                else:
+                    raise ValueError(f"Unknown parameter type {type(param)} in {inst}.")
+            updated.inst(Gate(inst.name, new_params, inst.qubits))
+        else:
+            updated.inst(inst)
+
+    if mref_idx > 0:
+        updated._instructions.insert(0, Declare(mref_name, "REAL", mref_idx))
+
+    return RewriteArithmeticResponse(
+        quil=updated.out(),
+        original_memory_descriptors=old_descriptors,
+        recalculation_table=recalculation_table,
+    )

--- a/pyquil/api/tests/test_rewrite_arithmetic.py
+++ b/pyquil/api/tests/test_rewrite_arithmetic.py
@@ -1,0 +1,66 @@
+from pyquil.quil import Program
+from pyquil.api._rewrite_arithmetic import rewrite_arithmetic
+from rpcq.messages import (
+    ParameterAref,
+    ParameterSpec,
+    RewriteArithmeticResponse,
+)
+
+
+def test_rewrite_arithmetic_no_params():
+    prog = Program("X 0")
+    response = rewrite_arithmetic(prog)
+    assert response == RewriteArithmeticResponse(quil=Program("X 0").out())
+
+
+def test_rewrite_arithmetic_simple_mref():
+    prog = Program("DECLARE theta REAL", "RZ(theta) 0")
+    response = rewrite_arithmetic(prog)
+    assert response == RewriteArithmeticResponse(
+        original_memory_descriptors={"theta": ParameterSpec(length=1, type="REAL")},
+        quil=Program("DECLARE theta REAL[1]", "RZ(theta[0]) 0").out(),
+        recalculation_table={},
+    )
+
+
+def test_rewrite_arithmetic_duplicate_exprs():
+    prog = Program(
+        "DECLARE theta REAL",
+        "RZ(theta*1.5) 0",
+        "RX(theta*1.5) 0",  # this is not a native gate, but it is a protoquil program
+    )
+
+    response = rewrite_arithmetic(prog)
+
+    assert response == RewriteArithmeticResponse(
+        original_memory_descriptors={"theta": ParameterSpec(length=1, type="REAL")},
+        recalculation_table={ParameterAref(index=0, name="__P1"): "theta[0]*1.5"},
+        quil=Program(
+            "DECLARE __P1 REAL[1]", "DECLARE theta REAL[1]", "RZ(__P1[0]) 0", "RX(__P1[0]) 0"
+        ).out(),
+    )
+
+
+def test_rewrite_arithmetic_mixed():
+    prog = Program(
+        "DECLARE theta REAL", "DECLARE beta REAL", "RZ(3 * theta) 0", "RZ(beta+theta) 0",
+    )
+    response = rewrite_arithmetic(prog)
+    assert response.original_memory_descriptors == {
+        "theta": ParameterSpec(length=1, type="REAL"),
+        "beta": ParameterSpec(length=1, type="REAL"),
+    }
+    assert response.recalculation_table == {
+        ParameterAref(index=0, name="__P2"): "3*theta[0]",
+        ParameterAref(index=1, name="__P2"): "beta[0] + theta[0]",
+    }
+    assert (
+        response.quil
+        == Program(
+            "DECLARE __P2 REAL[2]",
+            "DECLARE theta REAL[1]",
+            "DECLARE beta REAL[1]",
+            "RZ(__P2[0]) 0",
+            "RZ(__P2[1]) 0",
+        ).out()
+    )

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -28,7 +28,13 @@ import numpy as np
 import pytest
 import requests_mock
 from rpcq import Server
-from rpcq.messages import BinaryExecutableRequest, BinaryExecutableResponse
+from rpcq.messages import (
+    BinaryExecutableRequest,
+    BinaryExecutableResponse,
+    ParameterAref,
+    ParameterSpec,
+    RewriteArithmeticResponse,
+)
 
 from pyquil.api import QVMConnection, QPUCompiler, get_qc, QVMCompiler
 from pyquil.api._base_connection import (
@@ -36,6 +42,7 @@ from pyquil.api._base_connection import (
     validate_qubit_list,
     prepare_register_list,
 )
+from pyquil.api._rewrite_arithmetic import rewrite_arithmetic
 from pyquil.device import ISA, NxDevice
 from pyquil.gates import CNOT, H, MEASURE, PHASE, Z, RZ, RX, CZ
 from pyquil.paulis import PauliTerm
@@ -343,3 +350,62 @@ def test_local_conjugate_request(benchmarker):
 def test_apply_clifford_to_pauli(benchmarker):
     response = benchmarker.apply_clifford_to_pauli(Program("H 0"), PauliTerm("I", 0, 0.34))
     assert response == PauliTerm("I", 0, 0.34)
+
+
+def test_rewrite_arithmetic_no_params():
+    prog = Program("X 0")
+    response = rewrite_arithmetic(prog)
+    assert response == RewriteArithmeticResponse(quil=Program("X 0").out())
+
+
+def test_rewrite_arithmetic_simple_mref():
+    prog = Program("DECLARE theta REAL", "RZ(theta) 0")
+    response = rewrite_arithmetic(prog)
+    assert response == RewriteArithmeticResponse(
+        original_memory_descriptors={"theta": ParameterSpec(length=1, type="REAL")},
+        quil=Program("DECLARE theta REAL[1]", "RZ(theta[0]) 0").out(),
+        recalculation_table={},
+    )
+
+
+def test_rewrite_arithmetic_duplicate_exprs():
+    prog = Program(
+        "DECLARE theta REAL",
+        "RZ(theta*1.5) 0",
+        "RX(theta*1.5) 0",  # this is not a native gate, but it is a protoquil program
+    )
+
+    response = rewrite_arithmetic(prog)
+
+    assert response == RewriteArithmeticResponse(
+        original_memory_descriptors={"theta": ParameterSpec(length=1, type="REAL")},
+        recalculation_table={ParameterAref(index=0, name="__P1"): "theta[0]*1.5"},
+        quil=Program(
+            "DECLARE __P1 REAL[1]", "DECLARE theta REAL[1]", "RZ(__P1[0]) 0", "RX(__P1[0]) 0"
+        ).out(),
+    )
+
+
+def test_rewrite_arithmetic_mixed():
+    prog = Program(
+        "DECLARE theta REAL", "DECLARE beta REAL", "RZ(3 * theta) 0", "RZ(beta+theta) 0",
+    )
+    response = rewrite_arithmetic(prog)
+    assert response.original_memory_descriptors == {
+        "theta": ParameterSpec(length=1, type="REAL"),
+        "beta": ParameterSpec(length=1, type="REAL"),
+    }
+    assert response.recalculation_table == {
+        ParameterAref(index=0, name="__P2"): "3*theta[0]",
+        ParameterAref(index=1, name="__P2"): "beta[0] + theta[0]",
+    }
+    assert (
+        response.quil
+        == Program(
+            "DECLARE __P2 REAL[2]",
+            "DECLARE theta REAL[1]",
+            "DECLARE beta REAL[1]",
+            "RZ(__P2[0]) 0",
+            "RZ(__P2[1]) 0",
+        ).out()
+    )

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -31,9 +31,6 @@ from rpcq import Server
 from rpcq.messages import (
     BinaryExecutableRequest,
     BinaryExecutableResponse,
-    ParameterAref,
-    ParameterSpec,
-    RewriteArithmeticResponse,
 )
 
 from pyquil.api import QVMConnection, QPUCompiler, get_qc, QVMCompiler
@@ -42,7 +39,6 @@ from pyquil.api._base_connection import (
     validate_qubit_list,
     prepare_register_list,
 )
-from pyquil.api._rewrite_arithmetic import rewrite_arithmetic
 from pyquil.device import ISA, NxDevice
 from pyquil.gates import CNOT, H, MEASURE, PHASE, Z, RZ, RX, CZ
 from pyquil.paulis import PauliTerm
@@ -350,62 +346,3 @@ def test_local_conjugate_request(benchmarker):
 def test_apply_clifford_to_pauli(benchmarker):
     response = benchmarker.apply_clifford_to_pauli(Program("H 0"), PauliTerm("I", 0, 0.34))
     assert response == PauliTerm("I", 0, 0.34)
-
-
-def test_rewrite_arithmetic_no_params():
-    prog = Program("X 0")
-    response = rewrite_arithmetic(prog)
-    assert response == RewriteArithmeticResponse(quil=Program("X 0").out())
-
-
-def test_rewrite_arithmetic_simple_mref():
-    prog = Program("DECLARE theta REAL", "RZ(theta) 0")
-    response = rewrite_arithmetic(prog)
-    assert response == RewriteArithmeticResponse(
-        original_memory_descriptors={"theta": ParameterSpec(length=1, type="REAL")},
-        quil=Program("DECLARE theta REAL[1]", "RZ(theta[0]) 0").out(),
-        recalculation_table={},
-    )
-
-
-def test_rewrite_arithmetic_duplicate_exprs():
-    prog = Program(
-        "DECLARE theta REAL",
-        "RZ(theta*1.5) 0",
-        "RX(theta*1.5) 0",  # this is not a native gate, but it is a protoquil program
-    )
-
-    response = rewrite_arithmetic(prog)
-
-    assert response == RewriteArithmeticResponse(
-        original_memory_descriptors={"theta": ParameterSpec(length=1, type="REAL")},
-        recalculation_table={ParameterAref(index=0, name="__P1"): "theta[0]*1.5"},
-        quil=Program(
-            "DECLARE __P1 REAL[1]", "DECLARE theta REAL[1]", "RZ(__P1[0]) 0", "RX(__P1[0]) 0"
-        ).out(),
-    )
-
-
-def test_rewrite_arithmetic_mixed():
-    prog = Program(
-        "DECLARE theta REAL", "DECLARE beta REAL", "RZ(3 * theta) 0", "RZ(beta+theta) 0",
-    )
-    response = rewrite_arithmetic(prog)
-    assert response.original_memory_descriptors == {
-        "theta": ParameterSpec(length=1, type="REAL"),
-        "beta": ParameterSpec(length=1, type="REAL"),
-    }
-    assert response.recalculation_table == {
-        ParameterAref(index=0, name="__P2"): "3*theta[0]",
-        ParameterAref(index=1, name="__P2"): "beta[0] + theta[0]",
-    }
-    assert (
-        response.quil
-        == Program(
-            "DECLARE __P2 REAL[2]",
-            "DECLARE theta REAL[1]",
-            "DECLARE beta REAL[1]",
-            "RZ(__P2[0]) 0",
-            "RZ(__P2[1]) 0",
-        ).out()
-    )


### PR DESCRIPTION
Description
-----------

When compiling native quil programs, the first step is to do "arithmetic rewriting", which turns compound gate parameters into simple memory references. The motivation for this is that the underlying hardware can do a certain amount of arithmetic, but not everything (multiplication and division are done via arithmetic shifts, and so are restricted to powers of two, also real arithmetic is done with fixed point numbers which results in a loss of precision, and so on). 

This arithmetic rewriting is actually quite simple, but presently requires a call to the quilc client. This is a bit annoying, as `native_quil_to_executable` does not otherwise need quilc, and in my personal experience this dependency can be a bit burdensome when developing/testing `native_quil_to_executable` functionality. This PR deprecates this call with a simple and explicit `rewrite_arithmetic` function.

In the long term we will need to reconsider entirely this approach (if we are to allow for run-time updates to parameter values), but for now this is how things are.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
