### PR TITLE
Allow run-time configuration of state-aware compilation

### DIFF
--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -79,7 +79,7 @@ The compiler connection is also available directly via the property ``qc.compile
 precise class of this object changes based on context (e.g., ``QPUCompiler``,
 ``QVMCompiler``), but it always conforms to the interface laid out by ``pyquil.api._qac``:
 
-* ``compiler.quil_to_native_quil(program, *, protoquil, state_aware``: This method converts a Quil
+* ``compiler.quil_to_native_quil(program, *, protoquil, state_aware)``: This method converts a Quil
   program into native Quil, according to the ISA that the compiler is initialized with. The input
   parameter is specified as a :py:class:`~pyquil.quil.Program` object. The optional ``protoquil``
   keyword argument instructs the compiler to restrict both its input and output to protoquil (Quil

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -79,14 +79,17 @@ The compiler connection is also available directly via the property ``qc.compile
 precise class of this object changes based on context (e.g., ``QPUCompiler``,
 ``QVMCompiler``), but it always conforms to the interface laid out by ``pyquil.api._qac``:
 
-* ``compiler.quil_to_native_quil(program, *, protoquil)``: This method converts a Quil program into
-  native Quil, according to the ISA that the compiler is initialized with.  The input parameter is
-  specified as a :py:class:`~pyquil.quil.Program` object. The optional ``protoquil`` keyword
-  argument instructs the compiler to restrict both its input and output to protoquil (Quil code that
-  can be executed on a QPU). If the server is started with the ``-P`` option, or you specify
-  ``protoquil=True`` the returned ``Program`` object will be equipped with a ``.metadata`` property
-  that gives extraneous information about the compilation output (e.g., gate depth, as well as many
-  others).  This call blocks until Quil compilation finishes.
+* ``compiler.quil_to_native_quil(program, *, protoquil, state_aware``: This method converts a Quil
+  program into native Quil, according to the ISA that the compiler is initialized with. The input
+  parameter is specified as a :py:class:`~pyquil.quil.Program` object. The optional ``protoquil``
+  keyword argument instructs the compiler to restrict both its input and output to protoquil (Quil
+  code that can be executed on a QPU). If the server is started with the ``-P`` option, or you
+  specify ``protoquil=True`` the returned ``Program`` object will be equipped with a ``.metadata``
+  property that gives extraneous information about the compilation output (e.g., gate depth, as well
+  as many others). If you provide ``state_aware=True`` the compiler will assume that your quantum
+  state begins in ``|00...0>`` which allows it to perform more aggressive techniques to reduce the
+  size of the program. For example the program ``CZ(0, 1)`` is compiled into a no-operation with
+  this flag enabled.  This call blocks until Quil compilation finishes.
 * ``compiler.native_quil_to_executable(nq_program)``: This method converts a native Quil program, which
   is promised to consist only of native gates for a given ISA, into an executable suitable for
   submission to one of a QVM or a QPU.  This call blocks until the executable is generated.
@@ -99,7 +102,7 @@ the previous example snippet is identical to the following:
 
     from pyquil.quil import Pragma, Program
     from pyquil.api import get_qc
-    from pyquil.gates import CNOT, H
+    from pyquil.gates import CZ, CNOT, H
 
     qc = get_qc("9q-square-qvm")
 
@@ -110,6 +113,9 @@ the previous example snippet is identical to the following:
 
     ep = qc.compiler.native_quil_to_executable(np)
     print(ep.program) # here ep is of type PyquilExecutableResponse, which is not always inspectable
+
+    p = Program(CZ(0, 1))
+    print(qc.compiler.quil_to_native_quil(p, state_aware=True).program) # Prints empty program
 
 
 Legal compiler input

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -305,11 +305,17 @@ class QPUCompiler(AbstractCompiler):
         return {"quilc": quilc_version_info}
 
     @_record_call
-    def quil_to_native_quil(self, program: Program, *, protoquil: Optional[bool] = None) -> Program:
+    def quil_to_native_quil(
+        self,
+        program: Program,
+        *,
+        protoquil: Optional[bool] = None,
+        state_aware: Optional[bool] = None,
+    ) -> Program:
         self._connect_quilc()
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
         response = self.quilc_client.call(
-            "quil_to_native_quil", request, protoquil=protoquil
+            "quil_to_native_quil", request, protoquil=protoquil, state_aware=state_aware
         ).asdict()
         nq_program = parse_program(response["quil"])
         nq_program.native_quil_metadata = response["metadata"]
@@ -403,10 +409,18 @@ class QVMCompiler(AbstractCompiler):
         return cast(Dict[str, Any], self.client.call("get_version_info", rpc_timeout=1))
 
     @_record_call
-    def quil_to_native_quil(self, program: Program, *, protoquil: Optional[bool] = None) -> Program:
+    def quil_to_native_quil(
+        self,
+        program: Program,
+        *,
+        protoquil: Optional[bool] = None,
+        state_aware: Optional[bool] = None,
+    ) -> Program:
         self.connect()
         request = NativeQuilRequest(quil=program.out(), target_device=self.target_device)
-        response = self.client.call("quil_to_native_quil", request, protoquil=protoquil).asdict()
+        response = self.client.call(
+            "quil_to_native_quil", request, protoquil=protoquil, state_aware=state_aware
+        ).asdict()
         nq_program = parse_program(response["quil"])
         nq_program.native_quil_metadata = response["metadata"]
         nq_program.num_shots = program.num_shots

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -455,7 +455,7 @@ class QuantumComputer:
         :param protoquil: Whether to restrict the input program to and the compiled program
             to protoquil (executable on QPU). A value of ``None`` means defer to server.
         :param state_aware: Perform compilation assuming the quantum state begins in a
-            well-known state (i.e. |000...0>).
+            well-known state (i.e. ``|000...0>``).
         :return: An executable binary suitable for passing to :py:func:`QuantumComputer.run`.
         """
         if protoquil_positional is not None:

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -433,6 +433,7 @@ class QuantumComputer:
         protoquil_positional: Optional[bool] = None,
         *,
         protoquil: Optional[bool] = None,
+        state_aware: Optional[bool] = None,
     ) -> ExecutableDesignator:
         """
         A high-level interface to program compilation.
@@ -453,6 +454,8 @@ class QuantumComputer:
         :param optimize: Whether to optimize the program to reduce the number of operations.
         :param protoquil: Whether to restrict the input program to and the compiled program
             to protoquil (executable on QPU). A value of ``None`` means defer to server.
+        :param state_aware: Perform compilation assuming the quantum state begins in a
+            well-known state (i.e. |000...0>).
         :return: An executable binary suitable for passing to :py:func:`QuantumComputer.run`.
         """
         if protoquil_positional is not None:
@@ -478,7 +481,9 @@ class QuantumComputer:
         quilc = all(flags)
 
         if quilc:
-            nq_program = self.compiler.quil_to_native_quil(program, protoquil=protoquil)
+            nq_program = self.compiler.quil_to_native_quil(
+                program, protoquil=protoquil, state_aware=state_aware
+            )
         else:
             nq_program = program
         binary = self.compiler.native_quil_to_executable(nq_program)


### PR DESCRIPTION
Description
-----------

Adds support for a `state_aware=True` keyword to the `qc.compile` and `qc.compiler.quil_to_native_quil` methods. This allows the compiler to perform more aggressive compilation techniques by assuming that the initial quantum state is `|00...00>`.

```python
from pyquil import get_qc, Program

qc = get_qc("2q-qvm")
p = Program("CZ 0 1")

print(qc.compile(p, state_aware=False).program)
print(qc.compile(p, state_aware=True).program)

CZ 0 1
HALT

HALT
```

Checklist
---------

- [x] The above description motivates these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
