### PR TITLE
Use numeric base classes for type checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ Changelog
 
 [v2.21](https://github.com/rigetti/pyquil/compare/v2.20.0..master) (in development)
 
+### Announcements
+
+### Improvements and Changes
+
+### Bugfixes
+
+-   Use numeric abstract base classes for type checking (@kilimanjaro, gh-1219).
+
 [v2.20](https://github.com/rigetti/pyquil/compare/v2.19.0..v2.20.0) (June 5, 2020)
 ------------------------------------------------------------------------------------
 

--- a/pyquil/operator_estimation.py
+++ b/pyquil/operator_estimation.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 from math import pi
+from numbers import Complex
 from typing import Callable, Generator, List, Mapping, Union, Tuple, Optional, cast
 
 import numpy as np
@@ -308,7 +309,7 @@ def measure_observables(
         for setting in settings:
             # Get the term's coefficient so we can multiply it in later.
             coeff = setting.out_operator.coefficient
-            assert isinstance(coeff, complex)
+            assert isinstance(coeff, Complex)
             if not np.isclose(coeff.imag, 0):
                 raise ValueError(f"{setting}'s out_operator has a complex coefficient.")
             coeff = coeff.real

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -46,7 +46,7 @@ from pyquil.quilatom import (
 
 from .quil import Program
 from .gates import H, RZ, RX, CNOT, X, PHASE, QUANTUM_GATES
-from numbers import Number
+from numbers import Number, Complex
 from collections import OrderedDict
 import warnings
 
@@ -211,7 +211,7 @@ class PauliTerm(object):
             )
 
     def __hash__(self) -> int:
-        assert isinstance(self.coefficient, complex)
+        assert isinstance(self.coefficient, Complex)
         return hash(
             (
                 round(self.coefficient.real * HASH_PRECISION),
@@ -634,7 +634,7 @@ class PauliSum(object):
         :param other: a PauliSum, PauliTerm or Number object
         :return: A new PauliSum object given by the multiplication.
         """
-        if not isinstance(other, (Expression, int, complex, float, PauliTerm, PauliSum)):
+        if not isinstance(other, (Expression, Number, PauliTerm, PauliSum)):
             raise ValueError(
                 "Cannot multiply PauliSum by term that is not a Number, PauliTerm, or PauliSum"
             )
@@ -697,7 +697,7 @@ class PauliSum(object):
         """
         if isinstance(other, PauliTerm):
             other_sum = PauliSum([other])
-        elif isinstance(other, (Expression, int, complex, float)):
+        elif isinstance(other, (Expression, Number)):
             other_sum = PauliSum([other * ID()])
         else:
             other_sum = other
@@ -915,7 +915,7 @@ def exponential_map(term: PauliTerm) -> Callable[[float], Program]:
     :param term: A pauli term to exponentiate
     :returns: A function that takes an angle parameter and returns a program.
     """
-    assert isinstance(term.coefficient, (float, complex))
+    assert isinstance(term.coefficient, Complex)
 
     if not np.isclose(np.imag(term.coefficient), 0.0):
         raise TypeError("PauliTerm coefficient must be real")
@@ -1001,7 +1001,7 @@ def _exponentiate_general_case(pauli_term: PauliTerm, param: float) -> Program:
     # building rotation circuit
     quil_prog += change_to_z_basis
     quil_prog += cnot_seq
-    assert isinstance(pauli_term.coefficient, (float, complex)) and highest_target_index is not None
+    assert isinstance(pauli_term.coefficient, Complex) and highest_target_index is not None
     quil_prog.inst(RZ(2.0 * pauli_term.coefficient * param, highest_target_index))
     quil_prog += reverse_hack(cnot_seq)
     quil_prog += change_to_original_basis
@@ -1071,10 +1071,10 @@ def is_zero(pauli_object: PauliDesignator) -> bool:
     :returns: True if PauliTerm is zero, False otherwise
     """
     if isinstance(pauli_object, PauliTerm):
-        assert isinstance(pauli_object.coefficient, (float, complex))
+        assert isinstance(pauli_object.coefficient, Complex)
         return bool(np.isclose(pauli_object.coefficient, 0))
     elif isinstance(pauli_object, PauliSum):
-        assert isinstance(pauli_object.terms[0].coefficient, (float, complex))
+        assert isinstance(pauli_object.terms[0].coefficient, Complex)
         return len(pauli_object.terms) == 1 and np.isclose(pauli_object.terms[0].coefficient, 0)
     else:
         raise TypeError("is_zero only checks PauliTerms and PauliSum objects!")


### PR DESCRIPTION
Description
-----------

For Pauli and operator estimation code, there are a few type assertions that can fail. For example, `isinstance(1.0, complex)` is false, since `1.0` is just a float. However, in the Python numeric hierarchy it still supports the usual operations for complex numbers, e.g. `(1.0).real == 1.0` and `(1.0).imag == 0.0`. 

This PR replaces explicit `isinstance` checks on float, complex types with either a check against `numbers.Number` or `numbers.Complex` (the latter specifically when we want to use operations defined for complex numbers.

This wasn't covered by the existing tests, and I don't feel like adding a new one. It came to my attention somewhere in the bowels of `forest-benchmarking` (where a Pauli term got a coefficient of `1.0` -- the horror!).

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
