### PR TITLE
Compiler doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@ Changelog
 =========
 
 [v2.21](https://github.com/rigetti/pyquil/compare/v2.20.0..master) (in development)
+------------------------------------------------------------------------------------
+
+### Announcements
+
+### Improvements and Changes
+
+-   Documentation for Compiler, Advanced Usage, and Troubleshooting sections updated
+    (@notmgsk, gh-1220).
+
+### Bugfixes
 
 [v2.20](https://github.com/rigetti/pyquil/compare/v2.19.0..v2.20.0) (June 5, 2020)
 ------------------------------------------------------------------------------------

--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -12,19 +12,14 @@ PyQuil Configuration Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Network endpoints for the Rigetti Forest infrastructure and information pertaining to QPU access are
-stored in a pair of configuration files. These files are located by default at ``~/.qcs_config`` and ``~/.forest_config``.
-The location can be changed by setting the environment variables ``QCS_CONFIG`` or ``FOREST_CONFIG`` to point to the new
-location. When running on a QMI, the configuration files are automatically managed so as to
-point to the correct endpoints.
+stored in configuration files located by default at ``~/.qcs_config`` and ``~/.forest_config``.
+The file paths can be customized by setting the environment variables ``QCS_CONFIG`` or 
+``FOREST_CONFIG``, respectively.
 
-Authentication credentials for Forest server are read from ``~/.qcs/user_auth_token``. You may download
-user auth credentials at https://qcs.rigetti.com/auth/token. When running on a QMI, authentication credentials
-are read from ``~/.qcs/qmi_auth_token``.
+These files are present on your QMI, and the default configuration will work for most users.
 
-When running locally, configuration files are not necessary. Thus, the average
-user will not have to do any work to get their configuration files set up.
-
-If for some reason you want to use an atypical configuration, you may need to modify these files.
+Authentication credentials for Forest server are read from ``~/.qcs/user_auth_token``
+(note: no file extension). You can download this token from https://qcs.rigetti.com/auth/token.
 
 .. exec on engage
 
@@ -42,42 +37,99 @@ The default QCS config file on any QMI looks similar to the following:
 
 where
 
- -  ``url`` is the endpoint that pyQuil hits for device information and for the 2.0 endpoints,
- -  ``user_id`` stores a Forest 2.0 user ID, and
+ -  ``url`` is the endpoint that pyQuil uses for device information
  -  ``exec_on_engage`` specifies the shell command that the QMI will launch when the QMI becomes QPU-engaged. It
     would have no effect if you are running locally, but is important if you are running on the QMI. By default, it runs the
     ``exec_on_engage.sh`` shell script. It's best to leave the configuration as is, and edit that script.
     More documentation about ``exec_on_engage.sh`` can be found in the QCS docs
     `here <https://www.rigetti.com/qcs-docs>`_.
 
-The Forest config file on any QMI has these contents, with specific IP addresses filled in:
-
-::
-
-    # .forest_config
-    [Rigetti Forest]
-    qpu_endpoint_address = None
-    qvm_address = http://10.1.165.XX:5000
-    compiler_server_address = tcp://10.1.165.XX:5555
-
-where
-
- -  ``qpu_endpoint_address`` is the endpoint where pyQuil will try to communicate with the QPU orchestrating service
-    during QPU-engagement. It may not appear until your QMI engages, and furthermore will have no effect if you are
-    running locally. It's best to leave this alone. If you obtain access to one of our QPUs, we will fill it in for you.
- -  ``qvm_address`` is the endpoint where pyQuil will try to communicate with the Rigetti Quantum Virtual Machine.
-    On a QMI, this points to the provided QVM instance. On a local installation, this should be set to the server endpoint
-    for a locally running QVM instance. However, pyQuil will use the default value ``http://localhost:5000`` if this file
-    isn't found, which is the correct endpoint when you run the QVM locally with ``qvm -S``.
- -  ``compiler_server_address``: This is the endpoint where pyQuil will try to communicate with the compiler server. On a
-    QMI, this points to a provided compiler server instance. On a local installation, this should be set to the server
-    endpoint for a locally running ``quilc`` instance. However, pyQuil will use the default value ``tcp://localhost:5555``
-    if this isn't set, which is the correct endpoint when you run ``quilc`` locally with ``quilc -S``.
-
 .. note::
-
+     
      PyQuil itself reads these values out using the helper class ``pyquil._config.PyquilConfig``. PyQuil users should not
      ever need to touch this class directly.
+
+If you'd like to change your pyQuil configuration, you can do so in your runtime environment or by
+editing these configuration files. All configuration options derive their values from one of three
+places, in decreasing order of precedence:
+
+1. The runtime environment, set using `export <https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#export>`_
+   in Unix-based platforms, and `setx <https://ss64.com/nt/setx.html>`_ in Windows.
+2. QCS configuration files noted above: ``.qcs_config`` and ``.forest_config``, or their
+   user-configured file paths. The two are not interchangeable; each config value will be looked up
+   in exactly one of these files.
+3. The default values specified in ``pyquil.api._config``. These should not be changed by any Pyquil
+   user, as doing so may lead to difficult-to-debug behavior.
+
+These are all the configuration options available to you, and where they can be set:
+
+.. list-table:: PyQuil Configuration Options
+   :widths: 50 50 50
+   :header-rows: 1
+
+   * - Setting
+     - Environment
+     - Configuration File
+   * - Forest Server URL
+
+       Source of device information
+     - ``FOREST_URL``
+     - ``.qcs_config``
+
+       Key: ``url``
+   * - Dispatch URL
+
+       Provides QPU engagement authorization
+     - ``FOREST_DISPATCH_URL``
+     - ``.qcs_config``
+
+       Key: ``dispatch_url``
+   * - User Authentication Token Path
+
+       File path to the authentication token
+       obtained from `qcs <https://qcs.rigetti.com/auth/token>`_.
+     - ``USER_AUTH_TOKEN_PATH``
+     - ``.qcs_config``
+
+       Key: ``user_auth_token_path``
+   * - QCS URL
+
+       QCS website
+     - ``QCS_URL``
+     - ``.qcs_config``
+
+       Key: ``qcs_url``
+   * - QPU URL
+
+       Send binaries to the QPU
+     - ``QPU_URL``
+     - ``.forest_config``
+
+       Key: ``qpu_endpoint_address``
+   * - QVM URL
+
+       Simulator
+     - ``QCS_URL``
+     - ``.forest_config``
+
+       Key: ``qvm_address``
+   * - QPU Compiler URL
+
+       Send native Quil and receive a binary
+     - ``QPU_COMPILER_URL``
+     - ``.forest_config``
+
+       Key: ``qpu_compiler_address``
+   * - Local Compiler URL
+
+       Send Quil and receive native Quil
+     - ``QUILC_URL``
+     - ``.forest_config``
+
+       Key: ``qpu_compiler_address``
+
+The configuration options omitted from this table but present in ``pyquil.api._config`` are
+deprecated and should not be used.
 
 Using Qubit Placeholders
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -18,8 +18,9 @@ hardware.
 Interacting with the Compiler
 -----------------------------
 
-After :ref:`downloading the SDK <sdkinstall>`, the Quil Compiler, ``quilc`` is available on your local machine.
-You can initialize a local ``quilc`` server by typing ``quilc -S`` into your terminal. You should see the following message.
+After :ref:`downloading the SDK <sdkinstall>`, the Quil Compiler, ``quilc`` is available on your
+local machine. You can initialize a local ``quilc`` server by typing ``quilc -R`` into your
+terminal. You should see the following message.
 
 .. code:: text
 
@@ -114,25 +115,27 @@ the previous example snippet is identical to the following:
 Legal compiler input
 --------------------
 
-The QPU is not able to execute all possible Quil programs.  At present, a Quil program qualifies for execution if has the following form:
+The QPU is not able to execute all possible Quil programs. At present, a Quil program qualifies for
+execution if has the following form:
 
-* The program may or may not begin with a ``RESET`` instruction.  (If provided, the QPU will actively
-  reset the state of the quantum device to the ground state before program execution.  If omitted,
-  the QPU will wait for a relaxation period to pass before program execution instead.)
-* This is then followed by a block of native quantum gates.  A gate is native if it is of the form
-  ``RZ(θ)`` for any value ``θ``, ``RX(k*π/2)`` for an integer ``k``, or ``CZ q0 q1`` for ``q0``, ``q1``
-  a pair of qubits participating in a qubit-qubit interaction.
+* The program may begin with a ``RESET`` instruction. (If provided, the QPU will actively reset the
+  state of the quantum device to the ground state before program execution. If omitted, the QPU will
+  wait for a relaxation period to pass before program execution instead.)
+* This is then followed by a block of native quantum gates. A gate is native if it is of the form
+  ``RZ(θ)`` for any value ``θ``, ``RX(k*π/2)`` for an integer ``k``, or ``CZ q0 q1`` for ``q0``,
+  ``q1`` a pair of qubits participating in a qubit-qubit interaction. Some devices provide the
+  ``XY(θ) q0 q1`` two qubit gate.
 * This is then followed by a block of ``MEASURE`` instructions.
 
 To instruct the compiler to produce Quil code that can be executed on a QPU, you can use the
-``protoquil`` keyword in a call to `compiler.quil_to_native_quil(program, protoquil=True)` or
-`qc.compile(program, protoquil=True)`.
+``protoquil`` keyword in a call to ``compiler.quil_to_native_quil(program, protoquil=True)`` or
+``qc.compile(program, protoquil=True)``.
 
 .. note::
 
    If your compiler server is started with the protoquil option ``-P`` (as is the case for your QMI
-   compiler) then specifying ``protoquil=False`` will override the server and force disable
-   protoquil. Specifying ``protoquil=None`` defers to the server.
+   compiler) then specifying ``protoquil=False`` will override the server and forcefully disable
+   protoquil. Specifying ``protoquil=None`` defers to the server's choice.
 
 Compilation metadata
 --------------------
@@ -142,8 +145,8 @@ will return both the compiled program and a dictionary of statistics for the com
 dictionary contains the keys
 
 - ``final_rewiring``: see section below on rewirings.
-- ``gate_depth``: the longest subsequence of compiled instructions whereadjaction instructions share
-  resources.
+- ``gate_depth``: the longest subsequence of compiled instructions where adjaction instructions
+  share resources.
 - ``multiqubit_gate_depth``: like ``gate_depth`` but restricted to multi-qubit gates.
 - ``gate_volume``: total number of gates in the compiled program.
 - ``program_duration``: program duration with parallel executation of gates (using hard-coded values
@@ -334,12 +337,11 @@ behavior. The possible options are:
   quick initial scan of the entire program.
 
 .. note::
-   ``NAIVE`` rewiring is the default, and for the most part, it
-   follows the "Do What I Mean" (DWIM) principle. It is the least
-   sophisticated, but attempts to follow what the user has constructed
-   with their program. Choosing another rewiring, such as ``PARTIAL``,
-   may lead to higher-performing programs because the compiler has
-   more freedom to optimize the layout of the gates on the qubits.
+
+``PARTIAL`` rewiring is the default, and for the most part, it attempts to produce a program whose
+overall fidelity is maximized. This can lead to programs using qubits not in the original program,
+which may or may not be what you want. Choosing another rewiring, such as ``NAIVE``, may produce
+more intuitive compilation results though with poorer program fidelity.
   
 Common Error Messages
 ---------------------
@@ -349,6 +351,8 @@ follow:
 
 + ``! ! ! Error: Matrices do not lie in the same projective class.`` The compiler attempted to
   decompose an operator as native Quil instructions, and the resulting instructions do not match the
-  original operator.  This can happen when the original operator is not a unitary matrix, and could
+  original operator. This can happen when the original operator is not a unitary matrix, and could
   indicate an invalid ``DEFGATE`` block. In some rare circumstances, it can also happen due to
-  floating point precision issues.
+  floating point precision issues. In the latter case, the issue is resolved simply by recompiling
+  the program. If you issue cannot be solved, please contact support@rigetti.com or post an issue to
+  `the github project page. <https://github.com/rigetti/quilc/issues>`_

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -18,7 +18,7 @@ hardware.
 Interacting with the Compiler
 -----------------------------
 
-After :ref:`downloading the SDK <sdkinstall>`, the Quil Compiler, ``quilc`` is available on your
+After :ref:`installing the SDK <sdkinstall>`, the Quil Compiler, ``quilc`` is available on your
 local machine. You can initialize a local ``quilc`` server by typing ``quilc -R`` into your
 terminal. You should see the following message.
 
@@ -145,7 +145,7 @@ will return both the compiled program and a dictionary of statistics for the com
 dictionary contains the keys
 
 - ``final_rewiring``: see section below on rewirings.
-- ``gate_depth``: the longest subsequence of compiled instructions where adjaction instructions
+- ``gate_depth``: the longest subsequence of compiled instructions where adjacent instructions
   share resources.
 - ``multiqubit_gate_depth``: like ``gate_depth`` but restricted to multi-qubit gates.
 - ``gate_volume``: total number of gates in the compiled program.

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -337,11 +337,10 @@ behavior. The possible options are:
   quick initial scan of the entire program.
 
 .. note::
-
-``PARTIAL`` rewiring is the default, and for the most part, it attempts to produce a program whose
-overall fidelity is maximized. This can lead to programs using qubits not in the original program,
-which may or may not be what you want. Choosing another rewiring, such as ``NAIVE``, may produce
-more intuitive compilation results though with poorer program fidelity.
+   ``PARTIAL`` rewiring is the default, and for the most part, it attempts to produce a program whose
+   overall fidelity is maximized. This can lead to programs using qubits not in the original program,
+   which may or may not be what you want. Choosing another rewiring, such as ``NAIVE``, may produce
+   more intuitive compilation results though with poorer program fidelity.
   
 Common Error Messages
 ---------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,6 +81,7 @@ Contents
    compiler
    noise
    advanced_usage
+   troubleshooting
    exercises
    changes
    intro

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -1,0 +1,43 @@
+.. _troubleshooting:
+
+Troubleshooting
+===============
+
+If you're having any trouble running your Pyquil programs locally or on the QPU, please check the
+following things before sending a support request. It will save you time and make it easier for us
+to help!
+
+1. Ensure that your pyQuil version is up to date. If you're using ``pip``, you can do this with
+   ``pip freeze``. Within your script, you can use ``__version__``:
+
+   .. code:: python
+
+    import pyquil
+    print(pyquil.__version__)
+
+   You can update pyQuil with ``pip`` using ``pip install pyquil --upgrade``. You can find
+   the latest version available at
+   `our releases page <https://github.com/rigetti/pyquil/releases>`_ or
+   `on PyPi <https://pypi.org/project/pyquil/>`_.
+
+2. If the error appears to be authentication-related, or makes any mention of your
+   ``user_auth_token``, then please update your token following the directions at
+   https://qcs.rigetti.com/auth/token.
+
+3. Run your script with debug logging enabled. If you're running a script, you can enable that
+   using an environment variable:
+
+   .. code::
+
+    LOG_LEVEL=DEBUG pyquil my_script.py
+
+   .. code:: python
+
+    import logging
+    from pyquil.api._logger import logger
+
+    logger.setLevel(logging.DEBUG)
+
+If the problem still isn't clear, then we can help! Please send your debug log to us, 
+along with the contents of your ``~/.qcs_config`` and ``~/.forest_config`` files, at our
+`support page <https://rigetti.zendesk.com>`_. Thanks for using pyQuil!


### PR DESCRIPTION
Description
-----------

Fix some out-of-date information in the compiler docs.

Checklist
---------

- [x] The above description motivates these changes.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
