### PR TITLE
Add XY to lists of native gates in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-[v2.21](https://github.com/rigetti/pyquil/compare/v2.20.0..master) (in development)
+[dev](https://github.com/rigetti/pyquil/compare/v2.20.0..master) (in development)
 ------------------------------------------------------------------------------------
 
 ### Announcements
@@ -11,6 +11,7 @@ Changelog
 -   Documentation for Compiler, Advanced Usage, and Troubleshooting sections updated
     (@notmgsk, gh-1220).
 -   Use numeric abstract base classes for type checking (@kilimanjaro, gh-1219).
+-   Add XY to docs (@notmgsk, gh-1226).
 
 ### Bugfixes
 

--- a/docs/source/apidocs/gates.rst
+++ b/docs/source/apidocs/gates.rst
@@ -16,12 +16,12 @@ can be created using the function documented in this section::
 Native gates for Rigetti QPUs
 -----------------------------
 
-Physical quantum processors can enact a subset of all named gates. Luckily,
-a small set of gates is universal for quantum computation, so all named gates
-can be enacted by suitable combinations of physically realizable gates. Rigetti's
-superconducting quantum processors can perform :py:func:`RX` with ``angle=+-pi/2`` or
-``angle=+-pi``, :py:func:`RZ` with an arbitrary angle, and :py:func:`CZ` interactions
-between neighboring qubits. Rigetti QPUs can natively measure in the computational (Z) basis.
+Physical quantum processors can enact a subset of all named gates. Luckily, a small set of gates is
+universal for quantum computation, so all named gates can be enacted by suitable combinations of
+physically realizable gates. Rigetti's superconducting quantum processors can perform :py:func:`RX`
+with ``angle=+-pi/2`` or ``angle=+-pi``, :py:func:`RZ` with an arbitrary angle, :py:func:`CZ` and
+parametric :py:func:`XY` interactions between neighboring qubits. Rigetti QPUs can natively measure
+in the computational (Z) basis.
 
 .. autosummary::
     :toctree: autogen
@@ -30,6 +30,7 @@ between neighboring qubits. Rigetti QPUs can natively measure in the computation
     RX
     RZ
     CZ
+    XY
     MEASURE
 
 
@@ -63,6 +64,7 @@ set (ISA). The full list of quantum gates and classical Quil instructions is enu
     :template: autosumm.rst
 
     CZ
+    XY
     CNOT
     CCNOT
     CPHASE00

--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -106,7 +106,7 @@ The following gates methods come standard with Quil and ``gates.py``:
 
 -  Phase gates: ``PHASE(theta)``, ``S``, ``T``
 
--  Controlled phase gates: ``CZ``, ``CPHASE00(alpha)``,
+-  Controlled phase gates: ``CZ``, ``XY``, ``CPHASE00(alpha)``,
    ``CPHASE01(alpha)``, ``CPHASE10(alpha)``, ``CPHASE(alpha)``
 
 -  Cartesian rotation gates: ``RX(theta)``, ``RY(theta)``, ``RZ(theta)``

--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -6,13 +6,15 @@ The Quil Compiler
 Expectations for Program Contents
 ---------------------------------
 
-The QPUs have much more limited natural gate sets than the standard gate set offered by pyQuil: on Rigetti QPUs, the
-gate operators are constrained to lie in ``RZ(θ)``, ``RX(k*π/2)``, and ``CZ``; and the
-gates are required to act on physically available hardware (for single-qubit gates, this means
-acting only on live qubits, and for qubit-pair gates, this means acting on neighboring qubits). However, as a programmer, it is often (though not always) desirable to to be able to write programs which don't take these details into account. This generally leads to more portable code if one isn't tied to a specific set of gates or QPU architecture.
-To ameliorate these limitations, the Rigetti software toolkit contains an optimizing compiler that
-translates arbitrary Quil to native Quil and native Quil to executables suitable for Rigetti
-hardware.
+The QPUs have much more limited natural gate sets than the standard gate set offered by pyQuil: on
+Rigetti QPUs, the gate operators are constrained to lie in ``RZ(θ)``, ``RX(k*π/2)``, ``CZ`` and
+``XY``; and the gates are required to act on physically available hardware (for single-qubit gates,
+this means acting only on live qubits, and for qubit-pair gates, this means acting on neighboring
+qubits). However, as a programmer, it is often (though not always) desirable to to be able to write
+programs which don't take these details into account. This generally leads to more portable code if
+one isn't tied to a specific set of gates or QPU architecture. To ameliorate these limitations, the
+Rigetti software toolkit contains an optimizing compiler that translates arbitrary Quil to native
+Quil and native Quil to executables suitable for Rigetti hardware.
 
 
 Interacting with the Compiler


### PR DESCRIPTION
Description
-----------

The doc lists Rigetti native gates, but does not include XY.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
