### PR TITLE
Improve Documentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,11 +28,20 @@ services:
 # build the Sphinx documentation
 # for all Python jobs, see rigetti/gitlab-pipelines/python.gitlab-ci.yml
 build-docs:
+  artifacts:
+    paths:
+      - public
+    expire_in: 1 week
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    url: "https://rigetti.gitlab.io/-/forest/pyquil/-/jobs/$CI_JOB_ID/artifacts/public/index.html"
   extends: .python
   image: python:3.6
   script:
     - apt-get update && apt-get install -y pandoc
     - make docs
+    - cp -r docs/build/html public
+    - echo "Generated docs are now viewable at $CI_ENVIRONMENT_URL"
 
 # validate code format against Black
 check-format:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,24 +42,28 @@ build-docs:
     - make docs
     - cp -r docs/build/html public
     - echo "Generated docs are now viewable at $CI_ENVIRONMENT_URL"
+  services: []
 
 # validate code format against Black
 check-format:
   extends: .python
   script:
     - make check-format
+  services: []
 
 # validate code style against flake8
 check-style:
   extends: .python
   script:
     - make check-style
+  services: []
 
 # perform static type checking with mypy
 check-types:
   extends: .python
   script:
     - make check-types
+  services: []
 
 # run the unit tests with Python 3.6
 test-py36:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -832,7 +832,7 @@ constructing and running quantum programs. This release contains many
 major changes including:
 
 1.  The introduction of [Quantum Cloud
-    Services](https://www.rigetti.com/qcs). Access Rigetti\'s QPUs from
+    Services](https://qcs.rigetti.com). Access Rigetti\'s QPUs from
     co-located classical compute resources for minimal latency. The web
     API for running QVM and QPU jobs has been deprecated and cannot be
     accessed with pyQuil 2.0

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ dist:
 .PHONY: docs
 docs: CHANGELOG.md
 	pandoc --from=markdown --to=rst --output=docs/source/changes.rst CHANGELOG.md
+	make -C docs linkcheck
 	make -C docs html
 
 .PHONY: docker

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,9 +3,9 @@
 
 # You can set these variables from the command line.
 
- # (-W) treat warnings as errors but (--keep-going) continue to the end
- # (-b linkcheck) validate all external URLs as live
-SPHINXOPTS    = -W --keep-going -b linkcheck
+ # (-W) treat warnings as errors
+ # (--keep-going) continue to the end in case of warnings
+SPHINXOPTS    = -W --keep-going
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W # treat warnings as errors
+SPHINXOPTS    = -W -b linkcheck # treat warnings as errors, validate all external URLs
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,10 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W -b linkcheck # treat warnings as errors, validate all external URLs
+
+ # (-W) treat warnings as errors but (--keep-going) continue to the end
+ # (-b linkcheck) validate all external URLs as live
+SPHINXOPTS    = -W --keep-going -b linkcheck
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -778,7 +778,7 @@ This section provides the necessary theoretical foundation for
 accurately modeling noisy quantum measurements on superconducting
 quantum processors. It relies on some of the abstractions (density
 matrices, Kraus maps) introduced in our notebook on `gate noise
-models <https://github.com/rigetti/forest-tutorials/notebooks/GateNoiseModels.ipynb>`__.
+models <https://github.com/rigetti/forest-tutorials/blob/master/notebooks/GateNoiseModels.ipynb>`__.
 
 The most general type of measurement performed on a single qubit at a
 single time can be characterized by some set :math:`\mathcal{O}` of

--- a/docs/source/qvm.rst
+++ b/docs/source/qvm.rst
@@ -178,9 +178,9 @@ about the Wavefunction Simulator :ref:`here <wavefunction_simulator>`.
 The Quantum Processing Unit (QPU)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To access a QPU endpoint, you will have to `sign up <https://www.rigetti.com/>`_ for Quantum Cloud Services (QCS).
+To access a QPU endpoint, you will have to `sign up <https://qcs.rigetti.com/>`_ for Quantum Cloud Services (QCS).
 Documentation for getting started with your Quantum Machine Image (QMI) is found
-`here <https://www.rigetti.com/qcs/docs/intro-to-qcs>`_. Using QCS, you will ``ssh`` into your QMI, and reserve a
+`here <https://www.rigetti.com/qcs-docs>`_. Using QCS, you will ``ssh`` into your QMI, and reserve a
 QPU lattice for a particular time block.
 
 When your reservation begins, you will be authorized to access the QPU. A configuration file will be
@@ -268,8 +268,8 @@ All of this can be accomplished with :py:func:`~pyquil.api.get_qc`.
 
 For now, you will have to join QCS to get ``QPU_LATTICE_NAME`` by running the
 ``qcs lattices`` command from your QMI. Access to the QPU is only possible from a QMI, during a booked reservation.
-If this sounds unfamiliar, check out our `documentation for QCS <https://www.rigetti.com/qcs/docs/intro-to-qcs>`_
-and `join the waitlist <https://www.rigetti.com/>`_.
+If this sounds unfamiliar, check out our `documentation for QCS <https://www.rigetti.com/qcs-docs>`_
+and `join the waitlist <https://qcs.rigetti.com/>`_.
 
 For more information about creating and adding your own noise models, check out :ref:`noise`.
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -27,9 +27,11 @@ to help!
 3. Run your script with debug logging enabled. If you're running a script, you can enable that
    using an environment variable:
 
-   .. code::
+   .. code:: python
 
     LOG_LEVEL=DEBUG pyquil my_script.py
+
+   If you're running a notebook, then you can change the log level within your code:
 
    .. code:: python
 
@@ -38,6 +40,6 @@ to help!
 
     logger.setLevel(logging.DEBUG)
 
-If the problem still isn't clear, then we can help! Please send your debug log to us, 
-along with the contents of your ``~/.qcs_config`` and ``~/.forest_config`` files, at our
-`support page <https://rigetti.zendesk.com>`_. Thanks for using pyQuil!
+   If the problem still isn't clear, then we can help! Please send your debug log to us, 
+   along with the contents of your ``~/.qcs_config`` and ``~/.forest_config`` files, at our
+   `support page <https://rigetti.zendesk.com>`_. Thanks for using pyQuil!

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -828,7 +828,7 @@ def get_qc(
     QVMs you must use :py:func:`qc.compile` or :py:func:`qc.compiler.native_quil_to_executable`
     prior to :py:func:`qc.run`.
 
-    The Rigetti QVM must be downloaded from https://www.rigetti.com/forest and run as a server
+    The Rigetti QVM must be downloaded from https://qcs.rigetti.com/sdk-downloads and run as a server
     alongside your python program. To use pyQuil's built-in QVM, replace all ``"-qvm"`` suffixes
     with ``"-pyqvm"``::
 
@@ -969,7 +969,7 @@ def local_forest_runtime(
     """A context manager for local QVM and QUIL compiler.
 
     You must first have installed the `qvm` and `quilc` executables from
-    the forest SDK. [https://www.rigetti.com/forest]
+    the forest SDK. [https://qcs.rigetti.com/sdk-downloads]
 
     This context manager will ensure that the designated ports are not used, start up `qvm` and
     `quilc` proccesses if possible and terminate them when the context is exited.

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -828,9 +828,9 @@ def get_qc(
     QVMs you must use :py:func:`qc.compile` or :py:func:`qc.compiler.native_quil_to_executable`
     prior to :py:func:`qc.run`.
 
-    The Rigetti QVM must be downloaded from https://qcs.rigetti.com/sdk-downloads and run as a server
-    alongside your python program. To use pyQuil's built-in QVM, replace all ``"-qvm"`` suffixes
-    with ``"-pyqvm"``::
+    The Rigetti QVM must be downloaded from https://qcs.rigetti.com/sdk-downloads and run as a
+    server alongside your python program. To use pyQuil's built-in QVM, replace all ``"-qvm"``
+    suffixes with ``"-pyqvm"``::
 
         >>> qc = get_qc("5q-pyqvm")
 

--- a/pyquil/experiment/_result.py
+++ b/pyquil/experiment/_result.py
@@ -247,7 +247,7 @@ def ratio_variance(
     where we have dropped the covariance term as noted above.
 
     See the following for more details:
-      - https://doi.org/10.1002/(SICI)1097-0320(20000401)39:4<300::AID-CYTO8>3.0.CO;2-O
+      - https://doi.org/10.1002/(SICI)1097-0320(20000401)39:4%3C300::AID-CYTO8%3E3.0.CO;2-O
       - http://www.stat.cmu.edu/~hseltman/files/ratio.pdf
       - https://w.wiki/EMh
 


### PR DESCRIPTION
Description
-----------

This PR is a collective update and refresh of our ReadTheDocs documentation.

Includes:
* We now publish an internal per-commit preview build of the docs site on GitLab
* Enabled Sphinx link-checking, so we won't have any more dead URLs
* Cleaned up links which were pointing at the wrong part of Rigetti or QCS

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
