### PR TITLE
Pin sphinx_autodoc_typehints version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,9 +23,9 @@ pytest-rerunfailures
 requests-mock
 
 # docs
-sphinx
+sphinx>=3.0.0
 sphinx_rtd_theme
-sphinx_autodoc_typehints==1.11.0
+sphinx_autodoc_typehints>=1.11.0
 ipykernel
 nbsphinx
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ requests-mock
 # docs
 sphinx
 sphinx_rtd_theme
-sphinx_autodoc_typehints
+sphinx_autodoc_typehints==1.11.0
 ipykernel
 nbsphinx
 


### PR DESCRIPTION
I guess there was a version change to some library in the readthedocs environment, which ended up causing a dependency mismatch. Bumping the sphinx versions to something more modern (they were rather out-of-date) fixes the readthedocs build.