### PR TITLE
do not issue warning if scope is array

### DIFF
--- a/pyquil/api/_config.py
+++ b/pyquil/api/_config.py
@@ -173,7 +173,7 @@ class PyquilConfig(object):
 
     def _parse_auth_tokens(self) -> None:
         self.user_auth_token = _parse_auth_token(
-            self.user_auth_token_path, ["access_token", "refresh_token", "scope"]
+            self.user_auth_token_path, ["access_token", "refresh_token"]
         )
         self.qmi_auth_token = _parse_auth_token(
             self.qmi_auth_token_path, ["access_token", "refresh_token"]


### PR DESCRIPTION

-----------

Okta at times sends back an array rather than string with its OAuth2 tokens. This is causing Pyquil to emit a warning because it type checks the shape. This has no downstream effects of the user so I've taken the scope check out completely.

```
get_qc('Aspen-8')
WARNING - Failed to parse auth token at /home/jovyan/.qcs/user_auth_token.
WARNING - Invalid ['scope'].
WARNING - Failed to parse auth token at /home/jovyan/.qcs/user_auth_token.
WARNING - Invalid ['scope'].
```

Checklist
---------

- [X] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
