### PR TITLE
Make compiler connection check timeout user-configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 Changelog
 =========
 
-[v2.22.0](https://github.com/rigetti/pyquil/compare/v2.22.0..master) (in development)
+[v2.23.0](https://github.com/rigetti/pyquil/compare/v2.22.0..master) (In development)
 ------------------------------------------------------------------------------------
 
 ### Announcements
 
 ### Improvements and Changes
+
+- Compiler connection timeouts are now entirely user-configurable (@kalzoo, gh-1246)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changelog
 
 ### Bugfixes
 
-[v2.21.1](https://github.com/rigetti/pyquil/compare/v2.21.0..v2.22.0) (July 30, 2020)
+[v2.22.0](https://github.com/rigetti/pyquil/compare/v2.21.1..v2.22.0) (August 3, 2020)
 ------------------------------------------------------------------------------------
 
 ### Announcements
@@ -27,7 +27,7 @@ Changelog
 
 ### Announcements
 
--   This is just a cosmetic updated, to trigger a new docker build.
+-   This is just a cosmetic update, to trigger a new docker build.
 
 ### Improvements and Changes
 

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -462,8 +462,7 @@ class HTTPCompilerClient:
         indicating the cause of the failure. If present, that message is delivered to the user.
 
         :param payload: The rpcq message body.
-        :param rpc_timeout: The number of seconds to wait to read data back from the service
-            after connection.
+        :param rpc_timeout: The number of seconds to wait for each of 'connection' and 'response'.
             @see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
         """
         url = urljoin(self.endpoint, method)
@@ -473,7 +472,7 @@ class HTTPCompilerClient:
         else:
             body = None
 
-        response = self.session.post(url, json=body, timeout=(1, rpc_timeout))
+        response = self.session.post(url, json=body, timeout=rpc_timeout)
 
         try:
             response.raise_for_status()

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -281,7 +281,7 @@ class QPUCompiler(AbstractCompiler):
 
     def _connect_quilc(self) -> None:
         try:
-            quilc_version_dict = self.quilc_client.call("get_version_info", rpc_timeout=1)
+            quilc_version_dict = self.quilc_client.call("get_version_info")
             check_quilc_version(quilc_version_dict)
         except TimeoutError:
             raise QuilcNotRunning(f"No quilc server reachable at {self.quilc_client.endpoint}")
@@ -289,18 +289,16 @@ class QPUCompiler(AbstractCompiler):
     def _connect_qpu_compiler(self) -> None:
         assert self.qpu_compiler_client is not None
         try:
-            self.qpu_compiler_client.call("get_version_info", rpc_timeout=1)
+            self.qpu_compiler_client.call("get_version_info")
         except TimeoutError:
             raise QPUCompilerNotRunning(
                 f"No QPU compiler server reachable at {self.qpu_compiler_client.endpoint}"
             )
 
     def get_version_info(self) -> Dict[str, Any]:
-        quilc_version_info = self.quilc_client.call("get_version_info", rpc_timeout=1)
+        quilc_version_info = self.quilc_client.call("get_version_info")
         if self.qpu_compiler_client:
-            qpu_compiler_version_info = self.qpu_compiler_client.call(
-                "get_version_info", rpc_timeout=1
-            )
+            qpu_compiler_version_info = self.qpu_compiler_client.call("get_version_info")
             return {"quilc": quilc_version_info, "qpu_compiler": qpu_compiler_version_info}
         return {"quilc": quilc_version_info}
 
@@ -400,7 +398,7 @@ class QVMCompiler(AbstractCompiler):
             raise QuilcNotRunning(f"No quilc server running at {self.client.endpoint}")
 
     def get_version_info(self) -> Dict[str, Any]:
-        return cast(Dict[str, Any], self.client.call("get_version_info", rpc_timeout=1))
+        return cast(Dict[str, Any], self.client.call("get_version_info"))
 
     @_record_call
     def quil_to_native_quil(self, program: Program, *, protoquil: Optional[bool] = None) -> Program:

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -284,7 +284,11 @@ class QPUCompiler(AbstractCompiler):
             quilc_version_dict = self.quilc_client.call("get_version_info")
             check_quilc_version(quilc_version_dict)
         except TimeoutError:
-            raise QuilcNotRunning(f"No quilc server reachable at {self.quilc_client.endpoint}")
+            raise QuilcNotRunning(
+                f"Request to quilc at {self.quilc_client.endpoint} timed out. "
+                "This could mean that quilc is not running, is not reachable, or is "
+                "responding slowly."
+            )
 
     def _connect_qpu_compiler(self) -> None:
         assert self.qpu_compiler_client is not None
@@ -292,7 +296,9 @@ class QPUCompiler(AbstractCompiler):
             self.qpu_compiler_client.call("get_version_info")
         except TimeoutError:
             raise QPUCompilerNotRunning(
-                f"No QPU compiler server reachable at {self.qpu_compiler_client.endpoint}"
+                f"Request to the QPU Compiler at {self.qpu_compiler_client.endpoint} "
+                "timed out. "
+                "This could mean that the service is not reachable or is responding slowly."
             )
 
     def get_version_info(self) -> Dict[str, Any]:
@@ -395,7 +401,11 @@ class QVMCompiler(AbstractCompiler):
             version_dict = self.get_version_info()
             check_quilc_version(version_dict)
         except TimeoutError:
-            raise QuilcNotRunning(f"No quilc server running at {self.client.endpoint}")
+            raise QuilcNotRunning(
+                f"Request to quilc at {self.client.endpoint} timed out. "
+                "This could mean that quilc is not running, is not reachable, or is "
+                "responding slowly."
+            )
 
     def get_version_info(self) -> Dict[str, Any]:
         return cast(Dict[str, Any], self.client.call("get_version_info"))

--- a/pyquil/api/tests/data/user_auth_token_invalid.json
+++ b/pyquil/api/tests/data/user_auth_token_invalid.json
@@ -1,5 +1,4 @@
 {
   "access_token": "ok",
-  "refresh_token": "ok",
-  "scopish": "notwhatwe'relookingfor"
+  "refresh_token_invalid": "invalid"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ rpcq >= 3.0.0
 ipython
 
 # test deps
-black
+black==19.10b0
 coveralls
 flake8
 flake8-bugbear


### PR DESCRIPTION
Description
-----------

Closes #1245

- Clearer error messaging when the QPUCompiler or QVMCompiler times out in network calls
- No hard-coded timeout values of 1 second in connection to `quilc`
- No hard-coded timeout value of 1 second in connection to the translation service (within `HTTPCompilerClient`)

One downside to these changes is that a user may not have `quilc` running correctly, and now must wait for the default value of 10 seconds for the error message explaining that the service is not reachable. Given that this is either/or, it seems clearly better to apply the same user-configurable timeout everywhere (as in this PR) than to hard-code it to 1 second (as on master). This way, users can still work with a `quilc` running under high CPU load.

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
