### PR TITLE
Allow np.array in DefPermutationGate

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -476,24 +476,25 @@ class DefPermutationGate(DefGate):
             raise TypeError("Gate name must be a string")
 
         if name in RESERVED_WORDS:
+            raise ValueError(f"Cannot use {name} for a gate name since it's a reserved word")
+
+        if not isinstance(permutation, (list, np.ndarray)):
             raise ValueError(
-                "Cannot use {} for a gate name since it's a reserved word".format(name)
+                f"Permutation must be a list or NumPy array, got value of type {type(permutation)}"
             )
 
-        if isinstance(permutation, list):
-            elts = len(permutation)
-        elif isinstance(permutation, np.ndarray):
-            elts, cols = permutation.shape
-            if cols != 1:
-                raise ValueError("Permutation must have shape (N, 1)")
-        else:
-            raise ValueError("Permutation must be a list or NumPy array")
+        permutation = np.asarray(permutation)
 
+        ndim = permutation.ndim
+        if 1 != ndim:
+            raise ValueError(f"Permutation must have dimension 1, got {permutation.ndim}")
+
+        elts = permutation.shape[0]
         if 0 != elts & (elts - 1):
-            raise ValueError("Dimension of permutation must be a power of 2, got {0}".format(elts))
+            raise ValueError(f"Dimension of permutation must be a power of 2, got {elts}")
 
         self.name = name
-        self.permutation = np.asarray(permutation)
+        self.permutation = permutation
         self.parameters = None
 
     def out(self) -> str:


### PR DESCRIPTION
Description
-----------

Closes #1223. `DefPermutationGate` supported a permutation of type `list` or `np.ndarray` of shape `(N, 1)`. Alas, something like `np.array([0, 1])` wasn't supported because its shape looks like `(N,)`. C'est la vie. Cast to `np.ndarray` early.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
