### PR TITLE
Add pypi push to makefile

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,6 +117,23 @@ docker-branch:
 docker-stable:
   extends: .docker-stable
 
+# upload the source distribution of this master commit to TestPyPI
+upload-pypi:
+  extends: .python
+  stage: deploy
+  image: python:3.6
+  only:
+    refs:
+      - /^v(\d+\.)?(\d+\.)?(\d+)$/
+  except:
+    refs:
+      - branches
+  script:
+    - make version > VERSION.txt
+    - make dist
+    - make TWINE_REPOSITORY_URL=pypi upload
+  allow_failure: false
+
 # test that the latest Docker image doesn't error when performing simple tasks
 test-docker:
   stage: test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ COMMIT_HASH=$(shell git rev-parse --short HEAD)
 DEFAULT_QUILC_URL=tcp://localhost:5555
 DEFAULT_QVM_URL=http://localhost:5000
 DOCKER_TAG=rigetti/forest:$(COMMIT_HASH)
+TWINE_REPOSITORY_URL=https://test.pypi.org/legacy/
 
 .PHONY: all
 all: dist
@@ -74,7 +75,7 @@ test:
 
 .PHONY: upload
 upload:
-	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+	twine upload --repository-url "${TWINE_REPOSITORY_URL}"  dist/*
 
 .PHONY: version
 version:


### PR DESCRIPTION
Description
-----------

Add pypi push for version releases

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
