### PR TITLE
For noiseless QVMs don't measure all qubits

### DIFF
--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -425,15 +425,15 @@ class QuantumComputer:
                 return q
             else:
                 raise TypeError(
-                    "Cannot run and measure program with " f"unaddressed QubitPlaceholders: {q}"
+                    f"Cannot run and measure program with unaddressed QubitPlaceholders: {q}"
                 )
 
         program = program.copy()
         validate_supported_quil(program)
         ro = program.declare("ro", "BIT", len(self.qubits()))
-        measure_all = isinstance(self.qam, QVM) and self.qam.noise_model is not None
-        qubits_to_measure = (
-            self.qubits() if not measure_all else map(unwrap_qubit, program.get_qubits())
+        measure_used = isinstance(self.qam, QVM) and self.qam.noise_model is None
+        qubits_to_measure = set(
+            map(unwrap_qubit, program.get_qubits()) if measure_used else self.qubits()
         )
         for i, q in enumerate(qubits_to_measure):
             program.inst(MEASURE(q, ro[i]))

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -47,7 +47,7 @@ from pyquil.noise import decoherence_noise_with_asymmetric_ro, NoiseModel
 from pyquil.paulis import PauliTerm
 from pyquil.pyqvm import PyQVM
 from pyquil.quil import Program, validate_supported_quil
-from pyquil.quilatom import Qubit, QubitDesignator
+from pyquil.quilatom import qubit_index
 
 
 ExecutableDesignator = Union[BinaryExecutableResponse, PyQuilExecutableResponse]
@@ -417,23 +417,12 @@ class QuantumComputer:
         :return: A dictionary keyed by qubit index where the corresponding value is a 1D array of
             measured bits.
         """
-
-        def unwrap_qubit(q: QubitDesignator) -> int:
-            if isinstance(q, Qubit):
-                return q.index
-            elif isinstance(q, int):
-                return q
-            else:
-                raise TypeError(
-                    f"Cannot run and measure program with unaddressed QubitPlaceholders: {q}"
-                )
-
         program = program.copy()
         validate_supported_quil(program)
         ro = program.declare("ro", "BIT", len(self.qubits()))
         measure_used = isinstance(self.qam, QVM) and self.qam.noise_model is None
         qubits_to_measure = set(
-            map(unwrap_qubit, program.get_qubits()) if measure_used else self.qubits()
+            map(qubit_index, program.get_qubits()) if measure_used else self.qubits()
         )
         for i, q in enumerate(qubits_to_measure):
             program.inst(MEASURE(q, ro[i]))

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -172,7 +172,7 @@ def qubit_index(qubit: QubitDesignator) -> int:
     """
     Get the index of a QubitDesignator.
 
-    :param qubit: the qubit desginator.
+    :param qubit: the qubit designator.
     :return: An int that is the qubit index.
     """
     if isinstance(qubit, Qubit):

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -168,6 +168,21 @@ def unpack_qubit(qubit: QubitDesignator) -> Union[Qubit, QubitPlaceholder]:
         raise TypeError("qubit should be an int or Qubit or QubitPlaceholder instance")
 
 
+def qubit_index(qubit: QubitDesignator) -> int:
+    """
+    Get the index of a QubitDesignator.
+
+    :param qubit: the qubit desginator.
+    :return: An int that is the qubit index.
+    """
+    if isinstance(qubit, Qubit):
+        return qubit.index
+    elif isinstance(qubit, int):
+        return qubit
+    else:
+        raise TypeError(f"Cannot unwrap unaddressed QubitPlaceholder: {qubit}")
+
+
 # Like the Tuple, the List must be length 2, where the first item is a string and the second an
 # int. However, specifying Union[str, int] as the generic type argument to List doesn't sufficiently
 # constrain the types, and mypy gets confused in unpack_classical_reg, below. Hence, just specify

--- a/pyquil/tests/test_quantum_computer.py
+++ b/pyquil/tests/test_quantum_computer.py
@@ -473,6 +473,22 @@ def test_run_and_measure(local_qvm_quilc):
     assert bitstring_array.shape == (trials, len(qc.qubits()))
 
 
+def test_run_and_measure_noiseless_qvm():
+    """ Test that run_and_measure works as expected on a noiseless QVM. """
+    qc = get_qc("9q-square-qvm")
+    prog = Program(X(0))
+    trials = 1
+    bitstrings = qc.run_and_measure(prog, trials)
+    bitstring_array = np.vstack([bitstrings[q] for q in qc.qubits()]).T
+    # Test for appropriate shape
+    assert bitstring_array.shape == (trials, len(qc.qubits()))
+    # Test that X(0) flipped qubit 0.
+    assert bitstring_array[0, 0] == 1
+    # Test that all remaining qubits were measured and found to be in
+    # state |0>.
+    assert all(bitstring_array[0][1:] == np.zeros(len(qc.qubits()) - 1))
+
+
 def test_qvm_compile_pickiness(forest):
     p = Program(Declare("ro", "BIT"), X(0), MEASURE(0, MemoryReference("ro")))
     p.wrap_in_numshots_loop(1000)


### PR DESCRIPTION
Description
-----------

`QuantumComputer.run_and_measure` inserts `MEASURE` instructions for all qubits into the program before it is sent for execution by the QPU or QVM. When the target is the QVM this may lead to memory exhaustion: the QVM allocates enough memory to track a wavefunction for the number of qubits used in the program. For a larger number of qubits (around 32), one will use over 1GB of memory which causes the QVM to (rather ungraciously) crash. This PR fixes that by measuring only the qubits used in the program **if and only if** the target is the QVM **and** there is no associated noise model.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
