### PR TITLE
Use exact text of Apache 2 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2019 Rigetti Computing (rigetti.com)
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This text is supposed to be copied verbatim (as it's instructions for others to apply the license). Otherwise 4a requires copying this form of the license around.
