### PR TITLE
Add py.typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 Changelog
 =========
 
-[v2.24.0](https://github.com/rigetti/pyquil/compare/v2.23.1..master) (In development)
+[next](https://github.com/rigetti/pyquil/compare/v2.23.1..master) (In development)
 ------------------------------------------------------------------------------------
 
 ### Announcements
 
 ### Improvements and Changes
+
+- Include a `py.typed` so that libraries that depend on pyquil can validate their typing against it (@notmgsk, #1256)
 
 ### Bugfixes
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/rigetti/pyquil.git",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    package_data={"pyquil": ["py.typed"]},
     license="Apache-2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Description
-----------

By including a py.typed in the top-level of the package, any packages that depend on pyquil can validate their types against it with mypy.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
