### PR TITLE
Update ANTLR requirement to >= 4.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # runtime deps
 numpy
 scipy
-antlr4-python3-runtime >= 4.7.2, < 4.8
+antlr4-python3-runtime >= 4.8
 requests
 networkx >= 2.0.0
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         # note to developers: this should be a subset of requirements.txt
         "numpy",
         "scipy",
-        "antlr4-python3-runtime>=4.7.2,<4.8",
+        "antlr4-python3-runtime>=4.8",
         "requests",
         "networkx>=2.0.0",
         "rpcq>=3.0.0",


### PR DESCRIPTION
Since January of this year, antlr has been at version 4.8, and this is now the default version installed by various package managers (e.g. homebrew). I don't see a reason why the PyQuil parser shouldn't use this latest version, but for the sake of visibility I thought I would make this PR rather than pushing changes directly.