### PR TITLE
Fix noisy warnings and typing errata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,16 @@ Changelog
 ### Improvements and Changes
 
 - Include a `py.typed` so that libraries that depend on pyquil can validate their typing against it (@notmgsk, #1256)
+- Removed warnings expected in normal workflows that cannot be avoided
+  programmatically. This included the warning about passing native Quil to
+  `native_quil_to_executable`. Documentation has been updated to clarify
+  expected behavior (@mhodson-rigetti, gh-1267).
 
 ### Bugfixes
+
+- Fixed incorrect return type hint for the `exponential_map` function, which
+  now accepts both `float` and `MemoryReference` types for exponentiation
+  (@mhodson-rigetti, gh-1243).
 
 [v2.23.1](https://github.com/rigetti/pyquil/compare/v2.23.0..v2.23.1) (September 9, 2020)
 ------------------------------------------------------------------------------------

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -331,14 +331,6 @@ class QPUCompiler(AbstractCompiler):
 
         self._connect_qpu_compiler()
 
-        if nq_program.native_quil_metadata is None:
-            warnings.warn(
-                "It looks like you're trying to call `native_quil_to_binary` on a "
-                "Program that hasn't been compiled via `quil_to_native_quil`. This is "
-                "ok if you've hand-compiled your program to our native gateset, "
-                "but be careful!"
-            )
-
         arithmetic_response = rewrite_arithmetic(nq_program)
 
         request = BinaryExecutableRequest(

--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -15,7 +15,6 @@
 ##############################################################################
 from collections import defaultdict
 import uuid
-import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np

--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -192,7 +192,8 @@ support at support@rigetti.com."""
         an array of shape (trials, classical_addresses). The mapping of qubit to
         classical address is backed out from MEASURE instructions in the program, so
         only do measurements where there is a 1-to-1 mapping between qubits and classical
-        addresses.
+        addresses. If no MEASURE instructions are present in the program, a 0-by-0 array is
+        returned.
 
         :param run_priority: The priority with which to insert jobs into the QPU queue. Lower
                              integers correspond to higher priority. If not specified, the QPU
@@ -227,11 +228,6 @@ support at support@rigetti.com."""
         if results:
             bitstrings = _extract_bitstrings(ro_sources, results)
         elif not ro_sources:
-            warnings.warn(
-                "You are running a QPU program with no MEASURE instructions. "
-                "The result of this program will always be an empty array. Are "
-                "you sure you didn't mean to measure some of your qubits?"
-            )
             bitstrings = np.zeros((0, 0), dtype=np.int64)
         else:
             bitstrings = None

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -42,7 +42,7 @@ from pyquil.quilatom import (
     FormalArgument,
     Expression,
     ExpressionDesignator,
-    MemoryReference
+    MemoryReference,
 )
 
 from .quil import Program
@@ -933,7 +933,9 @@ def exponential_map(term: PauliTerm) -> Callable[[Union[float, MemoryReference]]
     return exp_wrap
 
 
-def exponentiate_commuting_pauli_sum(pauli_sum: PauliSum) -> Callable[[Union[float, MemoryReference]], Program]:
+def exponentiate_commuting_pauli_sum(
+    pauli_sum: PauliSum,
+) -> Callable[[Union[float, MemoryReference]], Program]:
     """
     Returns a function that maps all substituent PauliTerms and sums them into a program. NOTE: Use
     this function with care. Substituent PauliTerms should commute.
@@ -946,7 +948,7 @@ def exponentiate_commuting_pauli_sum(pauli_sum: PauliSum) -> Callable[[Union[flo
 
     fns = [exponential_map(term) for term in pauli_sum]
 
-    def combined_exp_wrap(param: float) -> Program:
+    def combined_exp_wrap(param: Union[float, MemoryReference]) -> Program:
         return Program([f(param) for f in fns])
 
     return combined_exp_wrap

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -600,7 +600,6 @@ class PauliSum(object):
         elif isinstance(other, PauliTerm):
             return self == PauliSum([other])
         elif len(self.terms) != len(other.terms):
-            warnings.warn(UnequalLengthWarning("These PauliSums have a different number of terms."))
             return False
 
         return set(self.terms) == set(other.terms)
@@ -790,7 +789,12 @@ class PauliSum(object):
 
 
 def simplify_pauli_sum(pauli_sum: PauliSum) -> PauliSum:
-    """Simplify the sum of Pauli operators according to Pauli algebra rules."""
+    """
+    Simplify the sum of Pauli operators according to Pauli algebra rules.
+
+    Warning: The simplified expression may re-order pauli operations, and may
+    impact the observed performance when running on the QPU.
+    """
 
     # You might want to use a defaultdict(list) here, but don't because
     # we want to do our best to preserve the order of terms.
@@ -809,17 +813,6 @@ def simplify_pauli_sum(pauli_sum: PauliSum) -> PauliSum:
             terms.append(first_term)
         else:
             coeff = sum(t.coefficient for t in term_list)
-            for t in term_list:
-                if list(t._ops.items()) != list(first_term._ops.items()):
-                    warnings.warn(
-                        "The term {} will be combined with {}, but they have different "
-                        "orders of operations. This doesn't matter for QVM or "
-                        "wavefunction simulation but may be important when "
-                        "running on an actual device.".format(
-                            t.id(sort_ops=False), first_term.id(sort_ops=False)
-                        )
-                    )
-
             if not np.isclose(coeff, 0.0):
                 terms.append(term_with_coeff(term_list[0], coeff))
     return PauliSum(terms)

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -42,6 +42,7 @@ from pyquil.quilatom import (
     FormalArgument,
     Expression,
     ExpressionDesignator,
+    MemoryReference
 )
 
 from .quil import Program
@@ -908,7 +909,7 @@ def exponentiate(term: PauliTerm) -> Program:
     return exponential_map(term)(1.0)
 
 
-def exponential_map(term: PauliTerm) -> Callable[[float], Program]:
+def exponential_map(term: PauliTerm) -> Callable[[Union[float, MemoryReference]], Program]:
     """
     Returns a function f(alpha) that constructs the Program corresponding to exp(-1j*alpha*term).
 
@@ -939,7 +940,7 @@ def exponential_map(term: PauliTerm) -> Callable[[float], Program]:
     return exp_wrap
 
 
-def exponentiate_commuting_pauli_sum(pauli_sum: PauliSum) -> Callable[[float], Program]:
+def exponentiate_commuting_pauli_sum(pauli_sum: PauliSum) -> Callable[[Union[float, MemoryReference]], Program]:
     """
     Returns a function that maps all substituent PauliTerms and sums them into a program. NOTE: Use
     this function with care. Substituent PauliTerms should commute.

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -452,7 +452,6 @@ class PyQVM(QAM):
             raise NotImplementedError("Need to implement in wf simulator")
 
         elif isinstance(instruction, Wait):
-            warnings.warn("WAIT does nothing for a noiseless simulator")
             self.program_counter += 1
 
         elif isinstance(instruction, Nop):

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -14,7 +14,6 @@
 #    limitations under the License.
 ##############################################################################
 import logging
-import warnings
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Sequence, Type, Union
 

--- a/pyquil/tests/test_api.py
+++ b/pyquil/tests/test_api.py
@@ -321,13 +321,10 @@ def test_quil_to_native_quil(compiler):
     )
 
 
-def test_native_quil_to_binary(server, mock_qpu_compiler):
+def test_native_quil_to_executable(server, mock_qpu_compiler):
     p = COMPILED_BELL_STATE.copy()
     p.wrap_in_numshots_loop(10)
-    # `native_quil_to_executable` will warn us that we haven't constructed our
-    # program via `quil_to_native_quil`.
-    with pytest.warns(UserWarning):
-        response = mock_qpu_compiler.native_quil_to_executable(p)
+    response = mock_qpu_compiler.native_quil_to_executable(p)
     assert response.program == COMPILED_BYTES_ARRAY
 
 

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -31,7 +31,6 @@ from pyquil.paulis import (
     exponential_map,
     exponentiate_commuting_pauli_sum,
     ID,
-    UnequalLengthWarning,
     exponentiate,
     trotterize,
     is_zero,

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -669,10 +669,8 @@ def test_term_with_coeff():
 def test_sum_equality():
     pauli_sum = sY(0) - sX(0)
     assert pauli_sum != 2 * pauli_sum
-    with pytest.warns(UnequalLengthWarning):
-        assert pauli_sum != pauli_sum + sZ(0)
-    with pytest.warns(UnequalLengthWarning):
-        assert pauli_sum + sZ(0) != pauli_sum
+    assert pauli_sum != pauli_sum + sZ(0)
+    assert pauli_sum + sZ(0) != pauli_sum
     assert pauli_sum != sY(1) - sX(1)
     assert pauli_sum == -1.0 * sX(0) + sY(0)
     assert pauli_sum == pauli_sum * 1.0
@@ -726,18 +724,14 @@ def test_simplify():
 def test_dont_simplify():
     t1 = sZ(0) * sZ(1)
     t2 = sZ(2) * sZ(3)
-    with pytest.warns(UnequalLengthWarning):
-        assert (t1 + t2) != 2 * sZ(0) * sZ(1)
+    assert (t1 + t2) != 2 * sZ(0) * sZ(1)
 
 
 def test_simplify_warning():
     t1 = sZ(0) * sZ(1)
     t2 = sZ(1) * sZ(0)
-    with pytest.warns(UserWarning) as e:
-        tsum = t1 + t2
-
+    tsum = t1 + t2
     assert tsum == 2 * sZ(0) * sZ(1)
-    assert str(e[0].message).startswith("The term Z1Z0 will be combined with Z0Z1")
 
 
 def test_pauli_string():

--- a/pyquil/tests/test_paulis_with_placeholders.py
+++ b/pyquil/tests/test_paulis_with_placeholders.py
@@ -31,7 +31,6 @@ from pyquil.paulis import (
     exponential_map,
     exponentiate_commuting_pauli_sum,
     ID,
-    UnequalLengthWarning,
     exponentiate,
     trotterize,
     is_zero,

--- a/pyquil/tests/test_paulis_with_placeholders.py
+++ b/pyquil/tests/test_paulis_with_placeholders.py
@@ -636,10 +636,8 @@ def test_sum_equality():
     q0, q1 = QubitPlaceholder.register(2)
     pauli_sum = sY(q0) - sX(q0)
     assert pauli_sum != 2 * pauli_sum
-    with pytest.warns(UnequalLengthWarning):
-        assert pauli_sum != pauli_sum + sZ(q0)
-    with pytest.warns(UnequalLengthWarning):
-        assert pauli_sum + sZ(q0) != pauli_sum
+    assert pauli_sum != pauli_sum + sZ(q0)
+    assert pauli_sum + sZ(q0) != pauli_sum
     assert pauli_sum != sY(q1) - sX(q1)
     assert pauli_sum == -1.0 * sX(q0) + sY(q0)
     assert pauli_sum == pauli_sum * 1.0
@@ -691,16 +689,12 @@ def test_dont_simplify():
     q = QubitPlaceholder.register(8)
     t1 = sZ(q[0]) * sZ(q[1])
     t2 = sZ(q[2]) * sZ(q[3])
-    with pytest.warns(UnequalLengthWarning):
-        assert (t1 + t2) != 2 * sZ(q[0]) * sZ(q[1])
+    assert (t1 + t2) != 2 * sZ(q[0]) * sZ(q[1])
 
 
 def test_simplify_warning():
     q = QubitPlaceholder.register(8)
     t1 = sZ(q[0]) * sZ(q[1])
     t2 = sZ(q[1]) * sZ(q[0])
-    with pytest.warns(UserWarning) as e:
-        tsum = t1 + t2
-
+    tsum = t1 + t2
     assert tsum == 2 * sZ(q[0]) * sZ(q[1])
-    assert "will be combined with" in str(e[0].message)


### PR DESCRIPTION
Description
-----------

Addressing issues #1243 and #1267 .

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
