### PR TITLE
Support controlled gates in PyQVM

### DIFF
--- a/pyquil/simulation/_numpy.py
+++ b/pyquil/simulation/_numpy.py
@@ -22,6 +22,7 @@ from pyquil.paulis import PauliTerm, PauliSum
 from pyquil.pyqvm import AbstractQuantumSimulator
 from pyquil.quilbase import Gate
 from pyquil.simulation.matrices import QUANTUM_GATES
+from pyquil.simulation.tools import lifted_gate
 
 # The following function is lovingly copied from the Cirq project
 # https://github.com/quantumlib/Cirq
@@ -149,11 +150,7 @@ def _get_gate_tensor_and_qubits(gate: Gate) -> Tuple[np.ndarray, List[int]]:
     :param gate: the instruction
     :return: tensor, qubit_inds.
     """
-    if len(gate.params) > 0:
-        matrix = QUANTUM_GATES[gate.name](*gate.params)
-    else:
-        matrix = QUANTUM_GATES[gate.name]
-
+    matrix = lifted_gate(gate, n_qubits=len(gate.qubits))
     qubit_inds = [q.index for q in gate.qubits]
 
     # e.g. 2-qubit matrix is 4x4; turns into (2,2,2,2) tensor.


### PR DESCRIPTION
Really this hands off matrix calculation to
`pyquil.simulation.tools.lifted_gate()` which has better support for
the various gate modifiers.

Description
-----------

Insert your PR description here. Thanks for [contributing][contributing] to pyQuil! 🙂

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
