### PR TITLE
Temporarily allow coverage checks to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,6 +78,7 @@ test-coverage:
   extends: .python
   script:
     - make coverage
+  allow_failure: true
 
 ####################################################################################################
 # MASTER-ONLY JOBS

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ ipython
 black==19.10b0
 coveralls
 flake8
-flake8-bugbear
+flake8-bugbear==20.1.4
 mypy==0.740
 pytest
 pytest-cov


### PR DESCRIPTION
Description
-----------

Somehow we've become married to the travis-ci service in the coverage checks. The travis builds are not working (no credits) so the coverage fails, even though we're not that interested in it. Allow it to fail.

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
