### PR TITLE
Bump RPCQ dependency to 3.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests
 networkx >= 2.0.0
 
 # rigetti packages
-rpcq >= 3.0.0
+rpcq >= 3.6.0
 
 # optional latex deps
 ipython

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         "lark",
         "requests",
         "networkx>=2.0.0",
-        "rpcq>=3.0.0",
+        "rpcq>=3.6.0",
         # dependency of contextvars, which we vendor
         "immutables==0.6",
     ],


### PR DESCRIPTION
Description
-----------

This version introduces support for passing along client-side timeouts
to the server, where the server can then use that timeout to interrupt
jobs.

Checklist
---------

- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
