### PR TITLE
Fix parsing all comment types

### DIFF
--- a/pyquil/_parser/grammar.lark
+++ b/pyquil/_parser/grammar.lark
@@ -1,6 +1,7 @@
 quil : (all_instr _NEWLINE?)*
 
-?all_instr : def_gate
+?all_instr : COMMENT
+           | def_gate
            | def_circuit
            | def_frame
            | def_waveform
@@ -40,6 +41,8 @@ quil : (all_instr _NEWLINE?)*
        | classical_binary
        | classical_comparison
        | include
+
+COMMENT : "#" /[^\n]*/ NEWLINE
 
 def_gate : "DEFGATE" name [ variables ] ":" matrix -> def_gate_matrix
          | "DEFGATE" name "AS" "MATRIX" [ variables ] ":" matrix -> def_gate_matrix

--- a/pyquil/tests/test_parser.py
+++ b/pyquil/tests/test_parser.py
@@ -673,25 +673,26 @@ def test_parse_defgate_as_pauli():
 
 @pytest.mark.parametrize(
     "program",
-    ["""# comment on first line
+    [
+        """# comment on first line
 H 0
 """,
-     """H 0 # mid-line comment on first line
+        """H 0 # mid-line comment on first line
 H 0
 """,
-     """H 0
+        """H 0
 # comment on second line
 H 0
 """,
-     """H 0
+        """H 0
 H 0 # mid-line comment on second line
 """,
-     """H 0
+        """H 0
 # comment on last line with newline
 """,
-     """H 0
+        """H 0
 # comment on last line without newline""",
-     ]
+    ],
 )
 def test_parse_comments(program):
-    p = Program(program)
+    Program(program)

--- a/pyquil/tests/test_parser.py
+++ b/pyquil/tests/test_parser.py
@@ -18,6 +18,7 @@ from lark import Token, UnexpectedToken
 import numpy as np
 import pytest
 
+from pyquil import Program
 from pyquil.gates import (
     ADD,
     AND,
@@ -668,3 +669,29 @@ def test_parse_defgate_as_pauli():
         parse("DEFGATE RY(%theta) 0 AS PAULI-SUM:\n    Y(-%theta/2) q")
 
     assert excp.value.token == Token("INT", "0")
+
+
+@pytest.mark.parametrize(
+    "program",
+    ["""# comment on first line
+H 0
+""",
+     """H 0 # mid-line comment on first line
+H 0
+""",
+     """H 0
+# comment on second line
+H 0
+""",
+     """H 0
+H 0 # mid-line comment on second line
+""",
+     """H 0
+# comment on last line with newline
+""",
+     """H 0
+# comment on last line without newline""",
+     ]
+)
+def test_parse_comments(program):
+    p = Program(program)


### PR DESCRIPTION
Description
-----------

An oddity in the parser was causing lines beginning with the comment character (`#`) to error, though mid-line comments were fine. Easiest solution was just to create a new terminal in the production rules to account for this case.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
