### PR TITLE
Pauli string parsing

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -44,6 +44,7 @@ from pyquil.quilatom import (
     ExpressionDesignator,
     MemoryReference,
 )
+from .paulis_parser import parse_pauli_str
 
 from .quil import Program
 from .gates import H, RZ, RX, CNOT, X, PHASE, QUANTUM_GATES
@@ -423,43 +424,7 @@ class PauliTerm(object):
     @classmethod
     def from_compact_str(cls, str_pauli_term: str) -> "PauliTerm":
         """Construct a PauliTerm from the result of str(pauli_term)"""
-        # split into str_coef, str_op at first '*'' outside parenthesis
-        try:
-            str_coef, str_op = re.split(r"\*(?![^(]*\))", str_pauli_term, maxsplit=1)
-        except ValueError:
-            raise ValueError(
-                "Could not separate the pauli string into "
-                f"coefficient and operator. {str_pauli_term} does"
-                " not match <coefficient>*<operator>"
-            )
-
-        # parse the coefficient into either a float or complex
-        str_coef = str_coef.replace(" ", "")
-        try:
-            coef: Union[float, complex] = float(str_coef)
-        except ValueError:
-            try:
-                coef = complex(str_coef)
-            except ValueError:
-                raise ValueError(f"Could not parse the coefficient {str_coef}")
-
-        op = sI() * coef
-        if str_op == "I":
-            assert isinstance(op, PauliTerm)
-            return op
-
-        # parse the operator
-        str_op = re.sub(r"\*", "", str_op)
-        if not re.match(r"^(([XYZ])(\d+))+$", str_op):
-            raise ValueError(
-                fr"Could not parse operator string {str_op}. It should match ^(([XYZ])(\d+))+$"
-            )
-
-        for factor in re.finditer(r"([XYZ])(\d+)", str_op):
-            op *= cls(factor.group(1), int(factor.group(2)))
-
-        assert isinstance(op, PauliTerm)
-        return op
+        return parse_pauli_str(str_pauli_term)
 
     def pauli_string(self, qubits: Optional[Iterable[int]] = None) -> str:
         """

--- a/pyquil/paulis_parser.py
+++ b/pyquil/paulis_parser.py
@@ -11,6 +11,7 @@ PAULI_GRAMMAR = r"""
 
 ?pauli_term: operator_term
            | coefficient "*" pauli_term -> op_term_with_coefficient
+           | coefficient pauli_term -> op_term_with_coefficient
            | pauli_term "*" coefficient -> coefficient_with_op_term
            | pauli_term "*" pauli_term -> op_term_with_op_term
            | pauli_term pauli_term -> op_term_with_op_term

--- a/pyquil/paulis_parser.py
+++ b/pyquil/paulis_parser.py
@@ -27,9 +27,10 @@ PAULI_GRAMMAR = r"""
 ?coefficient: NUMBER
             | complex -> to_complex
 
-?complex: "(" NUMBER "+" NUMBER "j" ")"
+?complex: "(" SIGNED_NUMBER "+" NUMBER "j" ")"
 
 %import common.INT
+%import common.SIGNED_NUMBER
 %import common.NUMBER
 %import common.WS_INLINE
 

--- a/pyquil/paulis_parser.py
+++ b/pyquil/paulis_parser.py
@@ -1,0 +1,108 @@
+
+from functools import lru_cache
+from typing import Callable
+
+from lark import Lark, Token, Transformer, v_args
+
+PAULI_GRAMMAR = """
+
+?start: operator_term
+      | coefficient "*" operator_term -> op_term_with_coefficient
+
+?operator_term: operator_with_index
+             | "I"                 -> op_i
+
+?operator_with_index: operator_taking_index INT -> op_with_index
+
+?operator_taking_index: "X"        -> op_x
+                      | "Y"        -> op_y
+                      | "Z"        -> op_z
+                      
+?coefficient: NUMBER
+            | complex -> to_complex
+
+?complex: "(" NUMBER "+" NUMBER "j" ")"
+
+%import common.INT
+%import common.NUMBER
+%import common.WS_INLINE
+
+%ignore WS_INLINE
+"""
+
+
+@v_args(inline=True)
+class PauliTree(Transformer):
+    """ The imports here are lazy to prevent cyclic import issues """
+
+    def __init__(self):
+        self.vars = {}
+
+    def op_x(self):
+        from pyquil.paulis import sX
+        return sX
+
+    def op_y(self):
+        from pyquil.paulis import sY
+        return sY
+
+    def op_z(self):
+        from pyquil.paulis import sZ
+        return sZ
+
+    def op_i(self):
+        from pyquil.paulis import sI
+        return sI(0)
+
+    def op_with_index(self, op: Callable, index: Token):
+        return op(int(index.value))
+
+    def op_term_with_coefficient(self, coeff, op):
+        coeff = coeff if isinstance(coeff, complex) else float(coeff.value)
+        return coeff * op
+
+    def to_complex(self, *args):
+        assert len(args[0].children) == 2, "Parsing error"
+        real, imag = args[0].children
+        return float(real.value) + float(imag.value) * 1j
+
+
+@lru_cache(maxsize=None)
+def pauli_parser() -> Lark:
+    """
+    This returns the parser object for Pauli compact string
+    parsing, however it will only ever instantiate one parser
+    per python process, and will re-use it for all subsequent
+    calls to `from_compact_str`.
+
+    :return: An instance of a Lark parser for Pauli strings
+    """
+    return Lark(PAULI_GRAMMAR, parser='lalr', transformer=PauliTree())
+
+
+def parse_pauli_str(data: str):
+    """
+    Examples of Pauli Strings:
+
+    => (1.5 + 0.5j)*X0*Z2+.7*Z1
+    => "(1.5 + 0.5j)*X0*Z2+.7*I"
+
+    A Pauli Term is a product of Pauli operators operating on
+    different qubits - the operator can be one of "X", "Y", "Z", "I",
+    including an index (ie. the qubit index such as 0, 1 or 2) and
+    the coefficient multiplying the operator, eg. `1.5 * Z1`.
+
+    Note: "X", "Y" and "Z" are always followed by the qubit index,
+          but "I" being the identity is not.
+
+    So we need to support
+    """
+    parser = pauli_parser()
+    return parser.parse(data)
+
+
+if __name__ == '__main__':
+    from pyquil.paulis import sI, sX, sY, sZ
+    assert parse_pauli_str("I") == sI(0)
+    assert parse_pauli_str("Z1") == sZ(1)
+    assert parse_pauli_str("Z1") == (1.0 + 0j) * sZ(1)

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -777,8 +777,6 @@ def test_pauli_term_from_str():
     # tests that should _not_ fail are in test_pauli_sum_from_str
     with pytest.raises(UnexpectedToken):
         PauliTerm.from_compact_str("10")
-    with pytest.raises(UnexpectedToken):
-        PauliTerm.from_compact_str("1.0X0")
     with pytest.raises(UnexpectedCharacters):
         PauliTerm.from_compact_str("(1.0+9i)*X0")
     with pytest.raises(UnexpectedCharacters, match="Expecting:"):

--- a/pyquil/tests/test_paulis.py
+++ b/pyquil/tests/test_paulis.py
@@ -23,6 +23,7 @@ from operator import mul
 
 import numpy as np
 import pytest
+from lark import UnexpectedCharacters, UnexpectedToken
 
 from pyquil.gates import RX, RZ, CNOT, H, X, PHASE
 from pyquil.paulis import (
@@ -749,7 +750,7 @@ def test_str():
 
 
 def test_from_str():
-    with pytest.raises(ValueError):
+    with pytest.raises(UnexpectedCharacters):
         PauliTerm.from_compact_str("1*A0→1*Z0")
 
 
@@ -774,15 +775,13 @@ def test_qubit_validation():
 
 def test_pauli_term_from_str():
     # tests that should _not_ fail are in test_pauli_sum_from_str
-    with pytest.raises(ValueError):
-        PauliTerm.from_compact_str("X0")
-    with pytest.raises(ValueError):
+    with pytest.raises(UnexpectedToken):
         PauliTerm.from_compact_str("10")
-    with pytest.raises(ValueError):
+    with pytest.raises(UnexpectedToken):
         PauliTerm.from_compact_str("1.0X0")
-    with pytest.raises(ValueError):
+    with pytest.raises(UnexpectedCharacters):
         PauliTerm.from_compact_str("(1.0+9i)*X0")
-    with pytest.raises(ValueError):
+    with pytest.raises(UnexpectedCharacters, match="Expecting:"):
         PauliTerm.from_compact_str("(1.0+0j)*A0")
 
 

--- a/pyquil/tests/test_paulis_parser.py
+++ b/pyquil/tests/test_paulis_parser.py
@@ -43,6 +43,10 @@ def test_pauli_sums_parsing():
     result = parse_pauli_str("0.5*X0 + (0.5+0j)*Z2")
     assert result == 0.5 * sX(0) + (0.5 + 0j) * sZ(2)
 
+    # test case from test_setting using _generate_random_paulis
+    result = parse_pauli_str("(-0.5751426877923431+0j)*Y0X1X3")
+    assert result == (-0.5751426877923431+0j)*sY(0)*sX(1)*sX(3)
+
 
 def test_complex_number_parsing():
     assert parse_pauli_str("(1+0j) * X1") == (1.0 + 0j) * sX(1)

--- a/pyquil/tests/test_paulis_parser.py
+++ b/pyquil/tests/test_paulis_parser.py
@@ -106,9 +106,9 @@ def test_pauli_terms_parsing():
     result = parse_pauli_str(".5*X0")
     assert result == 0.5 * sX(0)
 
-    # TODO: do we want to support even shorter notation like ??
-    # result = parse_pauli_str(".5X0")
-    # assert result == 0.5 * sX(0)
+    # we can now support even shorter notation like this
+    result = parse_pauli_str(".5X0")
+    assert result == 0.5 * sX(0)
 
     # Obviously the coefficients can also be complex, so we need to
     # support this:

--- a/pyquil/tests/test_paulis_parser.py
+++ b/pyquil/tests/test_paulis_parser.py
@@ -1,0 +1,99 @@
+from lark import UnexpectedCharacters, UnexpectedToken
+from pytest import raises
+
+from pyquil.paulis import (
+    sI,
+    sX,
+    sY,
+    sZ,
+)
+from pyquil.paulis_parser import parse_pauli_str
+
+
+def test_paulis_parser_basic_sanity():
+    pass
+
+
+def test_complex_number_parsing():
+    assert parse_pauli_str("(1+0j) * X1") == (1.0 + 0j) * sX(1)
+    assert parse_pauli_str("(1.1 + 0.1j) * Z2") == (1.1 + 0.1j) * sZ(2)
+    assert parse_pauli_str("(0 + 1j) * Y1") == (0 + 1j) * sY(1)
+
+    with raises(UnexpectedCharacters, match="Expecting:"):
+        # If someone uses 'i' instead of 'j' we get a useful message
+        # in an UnexpectedToken exception stating what's acceptable
+        parse_pauli_str("(1 + 0i) * X1")
+
+
+def test_pauli_terms_parsing():
+    # A PauliTerm consists of: operator, index, coefficient,
+    # where the index and coefficient are sometimes optional
+    # Eg. in the simplest case we just have I, which is fine
+    assert parse_pauli_str("I") == sI(0)
+
+    # ...but just having the operator without an index is
+    # *not* ok for X, Y or Z...
+    with raises(UnexpectedToken):
+        parse_pauli_str("X")
+    with raises(UnexpectedToken):
+        parse_pauli_str("Y")
+    with raises(UnexpectedToken):
+        parse_pauli_str("Z")
+
+    # ...these operators require an index to be included as well
+    assert parse_pauli_str("X0") == sX(0)
+    assert parse_pauli_str("X1") == sX(1)
+    assert parse_pauli_str("Y0") == sY(0)
+    assert parse_pauli_str("Y1") == sY(1)
+    assert parse_pauli_str("Z0") == sZ(0)
+    assert parse_pauli_str("Z1") == sZ(1)
+    assert parse_pauli_str("Z2") == sZ(2)
+
+    # The other optional item for a pauli term is the coefficient,
+    # which in the simplest case could just be this:
+    result = parse_pauli_str("1.5 * Z1")
+    assert result == 1.5 * sZ(1)
+
+    # the simple cases should also be the same as a complex coefficient
+    # with 1. and 0j
+    result = parse_pauli_str("Z1")
+    assert result == (1.0 + 0j) * sZ(1)
+
+    # we also need to support short-hand versions of floats like this:
+    result = parse_pauli_str(".5 * Z0")
+    assert result == 0.5 * sZ(0)
+
+    # ...and just to check it parses the same without whitespace
+    result = parse_pauli_str(".5*X0")
+    assert result == 0.5 * sX(0)
+
+    # TODO: do we want to support even shorter notation like ??
+    # result = parse_pauli_str(".5X0")
+    # assert result == 0.5 * sX(0)
+
+    # Obviously the coefficients can also be complex, so we need to
+    # support this:
+    result = parse_pauli_str("(0 + 1j) * Z0")
+    assert result == (0 + 1j) * sZ(0)
+
+    result = parse_pauli_str("(1.0 + 0j) * X0")
+    assert result == (1.0 + 0j) * sX(0)
+
+
+def test_pauli_parser_parentheses():
+    """ TODO: check that nested parentheses (ie. for coefficients) are
+        parsed and executed in the correct order
+    """
+    pass
+
+
+def test_pauli_sum_parsing():
+    """ TODO: check that multiple PauliTerms are parsed and executed
+        correctly
+    """
+    pass
+
+
+if __name__ == '__main__':
+    import pytest
+    pytest.main([__file__])


### PR DESCRIPTION
First attempt at fixing #1007, with potential fixes/benefits for #1008

- The initial requirement was to allow for Pauli strings that contain only operators, eg. `X0`, however this functionality and some of the other requests (ie. #1008) were also symptoms of the fact that regex was being used, rather than a fully-fledged parser.
- The `lark` library was already being used elsewhere in this project and was in the requirements file, so I've replaced the regexp usage with a custom lark parser (defined as a short python string rather than a separate file, just for brevity) to take care of converting the Pauli strings to the correct python objects.
- This has wider benefits, and has allowed the use of shorthand such as `0.7X1` to represent `0.7 * X1`, which was one of the 'expected fail' unit-tests previously (now moved to 'expected pass'), as well as allowing just `X0` / `X1` as Pauli short strings (also moved from expected fail to expected pass).
- The `from_custom_str` method for `PauliTerm` has been entirely replaced by the new parser, but I stopped short of replacing the `from_custom_str` on `PauliSum`, because the API currently expects a list of `PauliTerm` objects to be summed; this behaviour is now usable with the new parsing code, but it would be a wider-ranging API change to use the parser instead of the one remaining regex in `PauliSum`, because of the change from a list of terms to a single term, which I decided was not an appropriate decision to make in this PR.
- There's an interesting nuance to the parser in that we want to support `0.5X1` (ie. coefficient first, operator second), but we don't want to support `X10.5` (ie. coefficient second) because the operator has a numeric value as the last digit, so this is obviously ambiguous. As a result the lark parser has a slightly larger than expected `?pauli_term:` section, rather than supporting all permutations of operators and coefficients up front.
- This also includes a full suite of unit-tests for the new parser and usage for `PauliTerm`/`PauliSum` classes, as well as checking expected error messages for bad inputs.

Checklist
---------
- [X] The above description motivates these changes.
- [X] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).
