### PR TITLE
Add default memory results for all declared regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog
 
 ### Bugfixes
 
+- Fix key error for unmeasured memory regions (@notmgsk, @ameyer-rigetti, #1156)
+
 [v2.28.0](https://github.com/rigetti/pyquil/compare/v2.27.0..v2.28.0) (January 26, 2021)
 ------------------------------------------------------------------------------------
 

--- a/pyquil/api/_base_connection.py
+++ b/pyquil/api/_base_connection.py
@@ -600,7 +600,7 @@ class ForestConnection:
         measurement_noise: Optional[Tuple[float, float, float]],
         gate_noise: Optional[Tuple[float, float, float]],
         random_seed: Optional[int],
-    ) -> np.ndarray:
+    ) -> Dict[str, np.ndarray]:
         """
         Run a Forest ``run`` job on a QVM.
 
@@ -611,7 +611,7 @@ class ForestConnection:
         )
         response = post_json(self.session, self.sync_endpoint + "/qvm", payload)
 
-        ram = response.json()
+        ram: Dict[str, np.ndarray] = {key: np.array(val) for key, val in response.json().items()}
 
         for k in ram.keys():
             ram[k] = np.array(ram[k])

--- a/pyquil/api/_qam.py
+++ b/pyquil/api/_qam.py
@@ -41,6 +41,8 @@ class QAM(ABC):
     pretend to be a QPI-compliant quantum computer.
     """
 
+    _memory_results: Dict[str, np.ndarray]
+
     @_record_call
     def __init__(self) -> None:
         self.reset()
@@ -63,7 +65,7 @@ class QAM(ABC):
         self._executable: Optional[
             Union[QuiltBinaryExecutableResponse, PyQuilExecutableResponse]
         ] = executable
-        self._memory_results: Optional[Dict[str, np.ndarray]] = defaultdict(lambda: None)
+        self._memory_results = defaultdict(lambda: None)
         self.status = "loaded"
         return self
 

--- a/pyquil/pyqvm.py
+++ b/pyquil/pyqvm.py
@@ -211,7 +211,7 @@ class PyQVM(QAM):
         # private implementation details
         self._qubit_to_ram: Optional[Dict[int, int]] = None
         self._ro_size: Optional[int] = None
-        self._memory_results: Optional[Dict[str, np.ndarray]] = None
+        self._memory_results = {}
 
         self.rs = np.random.RandomState(seed=seed)
         self.wf_simulator = quantum_simulator_type(n_qubits=n_qubits, rs=self.rs)
@@ -226,7 +226,7 @@ class PyQVM(QAM):
         # initialize program counter
         self.program = program
         self.program_counter = 0
-        self._memory_results = None
+        self._memory_results = {}
 
         # clear RAM, although it's not strictly clear if this should happen here
         self.ram = {}

--- a/pyquil/tests/test_quil.py
+++ b/pyquil/tests/test_quil.py
@@ -243,10 +243,26 @@ def test_prog_init():
     assert p.out() == ("DECLARE ro BIT[1]\nX 0\nMEASURE 0 ro[0]\n")
 
 
-def test_classical_regs():
+def test_classical_regs_implicit_ro():
     p = Program()
-    p.inst(Declare("ro", "BIT", 2), X(0)).measure(0, MemoryReference("ro", 1))
-    assert p.out() == ("DECLARE ro BIT[2]\nX 0\nMEASURE 0 ro[1]\n")
+    p.inst(Declare("reg", "BIT", 2), X(0)).measure(0, MemoryReference("reg", 1))
+    assert p.out() == "DECLARE reg BIT[2]\nX 0\nMEASURE 0 reg[1]\n"
+    assert p.declarations == {
+        "ro": Declare("ro", "BIT", 1),
+        "reg": Declare("reg", "BIT", 2),
+    }
+
+
+def test_classical_regs_explicit_ro():
+    p = Program()
+    p.inst(Declare("ro", "BIT", 2), Declare("reg", "BIT", 2), X(0)).measure(
+        0, MemoryReference("reg", 1)
+    )
+    assert p.out() == "DECLARE ro BIT[2]\nDECLARE reg BIT[2]\nX 0\nMEASURE 0 reg[1]\n"
+    assert p.declarations == {
+        "ro": Declare("ro", "BIT", 2),
+        "reg": Declare("reg", "BIT", 2),
+    }
 
 
 def test_simple_instructions():


### PR DESCRIPTION
Description
-----------

Fixes #1156 where unmeasured memory regions throw a key error when accessed. In particular, this allows one to use `read_memory()` for a declared memory region that has *not* been the target of a measurement. For example, prior to this change, the following was illegal
```
p = Program("DECLARE reg BIT", "X 0") # no measure
qc.run(qc.compile(p))
print(qc.qam.read_memory("reg") # key error
```
However, the same *is* supported for a register named "ro":
```
p = Program("DECLARE ro BIT", "X 0") # no measure
qc.run(qc.compile(p))
print(qc.qam.read_memory("ro") # no key error, empty results
```

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
