### PR TITLE
Fix: Better error messages for references to undefined memory locations

### DIFF
--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -310,6 +310,10 @@ support at support@rigetti.com."""
 
         # Fill in our patch table
         for k, v in self._variables_shim.items():
+            if k.name not in patch_values:
+                raise KeyError(f"{k.name} is not one of the valid memory descriptors: {patch_values.keys()}")
+            if k.index >= len(patch_values[k.name]):
+                raise IndexError(f"{k.name} has more parameter values ({k.index}) than expected ({len(patch[k.name])})")
             patch_values[k.name][k.index] = v
 
         return patch_values


### PR DESCRIPTION
Description
-----------

Provide a better error message when `qc.run(binary, memory_map=...)` includes:
* reference to undefined memory name; or
* more parameter values than are expected

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
