### PR TITLE
Pin numpy to 1.19.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # runtime deps
-numpy
+numpy==1.19.*
 scipy
 lark
 requests


### PR DESCRIPTION
Fixes CI type-check failure due to numpy 1.20.x
