### PR TITLE
include dead attributes when no gates present

### DIFF
--- a/pyquil/external/rpcq.py
+++ b/pyquil/external/rpcq.py
@@ -31,7 +31,7 @@ class Qubit(BaseModel):
         exclude = kwargs.get("exclude") or set()
         if not self.dead:
             exclude.add("dead")
-        kwargs["exclude"] = {"dead"}
+        kwargs["exclude"] = exclude
         return super().dict(**kwargs)
 
 
@@ -44,7 +44,7 @@ class Edge(BaseModel):
         exclude = kwargs.get("exclude") or set()
         if not self.dead:
             exclude.add("dead")
-        kwargs["exclude"] = {"dead"}
+        kwargs["exclude"] = exclude
         return super().dict(**kwargs)
 
 

--- a/pyquil/external/tests/test_rpcq.py
+++ b/pyquil/external/tests/test_rpcq.py
@@ -1,0 +1,47 @@
+from pyquil.external.rpcq import Qubit, Edge, GateInfo, Supported1QGate, Supported2QGate
+
+
+def test_qubit_dead_serialization():
+    "test that the qubit is marked dead if it has no gates"
+    gate_info = GateInfo(
+        operator=Supported1QGate.RX,
+        parameters=[0.0],
+        arguments=[0],
+        fidelity=1e0,
+        duration=50,
+    )
+    qubit = Qubit(
+        id=0,
+        gates=[gate_info],
+    )
+    assert "dead" not in qubit.dict().keys()
+
+    qubit = Qubit(
+        id=0,
+        gates=[],
+        dead=True,
+    )
+    assert qubit.dict()['dead'] is True
+
+
+def test_edge_dead_serialization():
+    "test that the edge is marked dead if it has no gates"
+    gate_info = GateInfo(
+        operator=Supported2QGate.CZ,
+        parameters=[],
+        arguments=["_", "_"],
+        fidelity=0.89,
+        duration=200,
+    )
+    edge = Edge(
+        ids=[0, 1],
+        gates=[gate_info],
+    )
+    assert "dead" not in edge.dict().keys()
+
+    edge = Edge(
+        ids=[0, 1],
+        gates=[],
+        dead=True,
+    )
+    assert edge.dict()['dead'] is True

--- a/pyquil/quantum_processor/transformers/qcs_isa_to_compiler_isa.py
+++ b/pyquil/quantum_processor/transformers/qcs_isa_to_compiler_isa.py
@@ -76,6 +76,13 @@ def qcs_isa_to_compiler_isa(isa: InstructionSetArchitecture) -> CompilerISA:
 
             else:
                 raise QCSISAParseError("unexpected operation node count: {}".format(operation.node_count))
+    for qubit_id, qubit in device.qubits.items():
+        if len(qubit.gates) == 0:
+            qubit.dead = True
+
+    for edge_id, edge in device.edges.items():
+        if len(edge.gates) == 0:
+            edge.dead = True
 
     return device
 

--- a/pyquil/tests/data/compiler-isa-Aspen-8.json
+++ b/pyquil/tests/data/compiler-isa-Aspen-8.json
@@ -1,3846 +1,3852 @@
 {
-    "1Q": {
-        "0": {
-            "gates": [
-                {
-                    "arguments": [
-                        0
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        0
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        0
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        0
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        0
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        0
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.981,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 0,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.981,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 0,
-                    "target": null
-                }
-            ],
-            "id": 0
+  "1Q": {
+    "0": {
+      "gates": [
+        {
+          "arguments": [
+            0
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
         },
-        "1": {
-            "gates": [
-                {
-                    "arguments": [
-                        1
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        1
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        1
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        1
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        1
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        1
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.933,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 1,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.933,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 1,
-                    "target": null
-                }
-            ],
-            "id": 1
+        {
+          "arguments": [
+            0
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
         },
-        "10": {
-            "gates": [],
-            "id": 10
+        {
+          "arguments": [
+            0
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
         },
-        "11": {
-            "gates": [
-                {
-                    "arguments": [
-                        11
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        11
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        11
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        11
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        11
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        11
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.94,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 11,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.94,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 11,
-                    "target": null
-                }
-            ],
-            "id": 11
+        {
+          "arguments": [
+            0
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
         },
-        "12": {
-            "gates": [
-                {
-                    "arguments": [
-                        12
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        12
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        12
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        12
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        12
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        12
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.887,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 12,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.887,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 12,
-                    "target": null
-                }
-            ],
-            "id": 12
+        {
+          "arguments": [
+            0
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
         },
-        "13": {
-            "gates": [
-                {
-                    "arguments": [
-                        13
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        13
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        13
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        13
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        13
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        13
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.953,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 13,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.953,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 13,
-                    "target": null
-                }
-            ],
-            "id": 13
+        {
+          "arguments": [
+            0
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
         },
-        "14": {
-            "gates": [
-                {
-                    "arguments": [
-                        14
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        14
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        14
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        14
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        14
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        14
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.951,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 14,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.951,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 14,
-                    "target": null
-                }
-            ],
-            "id": 14
+        {
+          "duration": 2000.0,
+          "fidelity": 0.981,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 0,
+          "target": "_"
         },
-        "15": {
-            "gates": [
-                {
-                    "arguments": [
-                        15
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        15
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        15
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        15
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        15
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        15
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.964,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 15,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.964,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 15,
-                    "target": null
-                }
-            ],
-            "id": 15
-        },
-        "16": {
-            "gates": [
-                {
-                    "arguments": [
-                        16
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        16
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        16
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        16
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        16
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        16
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.959,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 16,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.959,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 16,
-                    "target": null
-                }
-            ],
-            "id": 16
-        },
-        "17": {
-            "gates": [
-                {
-                    "arguments": [
-                        17
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        17
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        17
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        17
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        17
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        17
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.919,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 17,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.919,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 17,
-                    "target": null
-                }
-            ],
-            "id": 17
-        },
-        "2": {
-            "gates": [
-                {
-                    "arguments": [
-                        2
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        2
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        2
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        2
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        2
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        2
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.984,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 2,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.984,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 2,
-                    "target": null
-                }
-            ],
-            "id": 2
-        },
-        "20": {
-            "gates": [
-                {
-                    "arguments": [
-                        20
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        20
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        20
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        20
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        20
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        20
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.962,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 20,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.962,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 20,
-                    "target": null
-                }
-            ],
-            "id": 20
-        },
-        "21": {
-            "gates": [
-                {
-                    "arguments": [
-                        21
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        21
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        21
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        21
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        21
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        21
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.921,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 21,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.921,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 21,
-                    "target": null
-                }
-            ],
-            "id": 21
-        },
-        "22": {
-            "gates": [
-                {
-                    "arguments": [
-                        22
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        22
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        22
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        22
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        22
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        22
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.95,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 22,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.95,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 22,
-                    "target": null
-                }
-            ],
-            "id": 22
-        },
-        "23": {
-            "gates": [
-                {
-                    "arguments": [
-                        23
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        23
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        23
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        23
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        23
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        23
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.883,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 23,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.883,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 23,
-                    "target": null
-                }
-            ],
-            "id": 23
-        },
-        "24": {
-            "gates": [
-                {
-                    "arguments": [
-                        24
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        24
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        24
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        24
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        24
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        24
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.815,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 24,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.815,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 24,
-                    "target": null
-                }
-            ],
-            "id": 24
-        },
-        "25": {
-            "gates": [
-                {
-                    "arguments": [
-                        25
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        25
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        25
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        25
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        25
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        25
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.95,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 25,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.95,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 25,
-                    "target": null
-                }
-            ],
-            "id": 25
-        },
-        "26": {
-            "gates": [
-                {
-                    "arguments": [
-                        26
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        26
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        26
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        26
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        26
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        26
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.962,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 26,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.962,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 26,
-                    "target": null
-                }
-            ],
-            "id": 26
-        },
-        "27": {
-            "gates": [
-                {
-                    "arguments": [
-                        27
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        27
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        27
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        27
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        27
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        27
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.868,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 27,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.868,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 27,
-                    "target": null
-                }
-            ],
-            "id": 27
-        },
-        "3": {
-            "gates": [
-                {
-                    "arguments": [
-                        3
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        3
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        3
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        3
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        3
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        3
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.977,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 3,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.977,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 3,
-                    "target": null
-                }
-            ],
-            "id": 3
-        },
-        "30": {
-            "gates": [
-                {
-                    "arguments": [
-                        30
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        30
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        30
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        30
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        30
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        30
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.933,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 30,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.933,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 30,
-                    "target": null
-                }
-            ],
-            "id": 30
-        },
-        "31": {
-            "gates": [],
-            "id": 31
-        },
-        "32": {
-            "gates": [
-                {
-                    "arguments": [
-                        32
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        32
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        32
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        32
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        32
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        32
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.957,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 32,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.957,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 32,
-                    "target": null
-                }
-            ],
-            "id": 32
-        },
-        "33": {
-            "gates": [
-                {
-                    "arguments": [
-                        33
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        33
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        33
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        33
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        33
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        33
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.934,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 33,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.934,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 33,
-                    "target": null
-                }
-            ],
-            "id": 33
-        },
-        "34": {
-            "gates": [
-                {
-                    "arguments": [
-                        34
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        34
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        34
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        34
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        34
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        34
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.944,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 34,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.944,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 34,
-                    "target": null
-                }
-            ],
-            "id": 34
-        },
-        "35": {
-            "gates": [
-                {
-                    "arguments": [
-                        35
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        35
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        35
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        35
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        35
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        35
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.951,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 35,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.951,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 35,
-                    "target": null
-                }
-            ],
-            "id": 35
-        },
-        "36": {
-            "gates": [
-                {
-                    "arguments": [
-                        36
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        36
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        36
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        36
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        36
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        36
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.907,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 36,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.907,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 36,
-                    "target": null
-                }
-            ],
-            "id": 36
-        },
-        "37": {
-            "gates": [
-                {
-                    "arguments": [
-                        37
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        37
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        37
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        37
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        37
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        37
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.963,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 37,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.963,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 37,
-                    "target": null
-                }
-            ],
-            "id": 37
-        },
-        "4": {
-            "gates": [
-                {
-                    "arguments": [
-                        4
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        4
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        4
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        4
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        4
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        4
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.973,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 4,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.973,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 4,
-                    "target": null
-                }
-            ],
-            "id": 4
-        },
-        "5": {
-            "gates": [
-                {
-                    "arguments": [
-                        5
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        5
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        5
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        5
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        5
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        5
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.96,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 5,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.96,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 5,
-                    "target": null
-                }
-            ],
-            "id": 5
-        },
-        "6": {
-            "gates": [
-                {
-                    "arguments": [
-                        6
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        6
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        6
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        6
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        6
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        6
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.985,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 6,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.985,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 6,
-                    "target": null
-                }
-            ],
-            "id": 6
-        },
-        "7": {
-            "gates": [
-                {
-                    "arguments": [
-                        7
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 1.0,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        0.0
-                    ]
-                },
-                {
-                    "arguments": [
-                        7
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        7
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -3.141592653589793
-                    ]
-                },
-                {
-                    "arguments": [
-                        7
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        7
-                    ],
-                    "duration": 50.0,
-                    "fidelity": 0.95,
-                    "operator": "RX",
-                    "operator_type": "gate",
-                    "parameters": [
-                        -1.5707963267948966
-                    ]
-                },
-                {
-                    "arguments": [
-                        7
-                    ],
-                    "duration": 0.01,
-                    "fidelity": 1.0,
-                    "operator": "RZ",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "_"
-                    ]
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.973,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 7,
-                    "target": "_"
-                },
-                {
-                    "duration": 2000.0,
-                    "fidelity": 0.973,
-                    "operator": "MEASURE",
-                    "operator_type": "measure",
-                    "qubit": 7,
-                    "target": null
-                }
-            ],
-            "id": 7
+        {
+          "duration": 2000.0,
+          "fidelity": 0.981,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 0,
+          "target": null
         }
+      ],
+      "id": 0
     },
-    "2Q": {
-        "0-1": {
-            "gates": [],
-            "ids": [
-                0,
-                1
-            ]
+    "1": {
+      "gates": [
+        {
+          "arguments": [
+            1
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
         },
-        "0-7": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.827373529811633,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                }
-            ],
-            "ids": [
-                0,
-                7
-            ]
+        {
+          "arguments": [
+            1
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
         },
-        "1-16": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.963810998363568,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.969188284497237,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                1,
-                16
-            ]
+        {
+          "arguments": [
+            1
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
         },
-        "1-2": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.827034240060698,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                1,
-                2
-            ]
+        {
+          "arguments": [
+            1
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
         },
-        "10-11": {
-            "gates": [],
-            "ids": [
-                10,
-                11
-            ]
+        {
+          "arguments": [
+            1
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
         },
-        "10-17": {
-            "gates": [],
-            "ids": [
-                10,
-                17
-            ]
+        {
+          "arguments": [
+            1
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
         },
-        "11-12": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.802429544672657,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.971066599707853,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                11,
-                12
-            ]
+        {
+          "duration": 2000.0,
+          "fidelity": 0.933,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 1,
+          "target": "_"
         },
-        "11-26": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.910436219297188,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.840193961279927,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                11,
-                26
-            ]
-        },
-        "12-13": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.814134152755118,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.881177283813748,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                12,
-                13
-            ]
-        },
-        "12-25": {
-            "gates": [],
-            "ids": [
-                12,
-                25
-            ]
-        },
-        "13-14": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.884225667854257,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.750306760959217,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                13,
-                14
-            ]
-        },
-        "14-15": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.858347094059726,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.711986884534236,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                14,
-                15
-            ]
-        },
-        "15-16": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.82929882121941,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.96238538049698,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                15,
-                16
-            ]
-        },
-        "16-17": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.956423059904334,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.913342572784603,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                16,
-                17
-            ]
-        },
-        "2-15": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.761104307092066,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.906865591126598,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                2,
-                15
-            ]
-        },
-        "2-3": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.678760499686747,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.750382622112465,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                2,
-                3
-            ]
-        },
-        "20-21": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.976491247349509,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.982300057787109,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                20,
-                21
-            ]
-        },
-        "20-27": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.976044970222359,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.974351481307288,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                20,
-                27
-            ]
-        },
-        "21-22": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.960196083923008,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                21,
-                22
-            ]
-        },
-        "21-36": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.894622255097713,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.9739098152627,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                21,
-                36
-            ]
-        },
-        "22-23": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.800349240495056,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.887800962505768,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                22,
-                23
-            ]
-        },
-        "22-35": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.945399033154115,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.940514040770703,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                22,
-                35
-            ]
-        },
-        "23-24": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.835462460003224,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                }
-            ],
-            "ids": [
-                23,
-                24
-            ]
-        },
-        "24-25": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.958532411524689,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.907485454888485,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                24,
-                25
-            ]
-        },
-        "25-26": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.980953668001148,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.975458993777444,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                25,
-                26
-            ]
-        },
-        "26-27": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.972299346504856,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.970333122588459,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                26,
-                27
-            ]
-        },
-        "3-4": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.844817114645156,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.951494807160403,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                3,
-                4
-            ]
-        },
-        "30-31": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.962505082735891,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                }
-            ],
-            "ids": [
-                30,
-                31
-            ]
-        },
-        "30-37": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.941529902941919,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                }
-            ],
-            "ids": [
-                30,
-                37
-            ]
-        },
-        "31-32": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.984330374008766,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.970416051000658,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                31,
-                32
-            ]
-        },
-        "32-33": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.991077236512742,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.989990859777998,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                32,
-                33
-            ]
-        },
-        "33-34": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.965154410047365,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.979827735266774,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                33,
-                34
-            ]
-        },
-        "34-35": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.976761456156647,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.969357194375034,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                34,
-                35
-            ]
-        },
-        "35-36": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.9701474597447,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.941981091837248,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                35,
-                36
-            ]
-        },
-        "36-37": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.970775336390861,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.958112387890874,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                36,
-                37
-            ]
-        },
-        "4-5": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.902989902621697,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.945615850027519,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                4,
-                5
-            ]
-        },
-        "5-6": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.957500836136268,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.96394809507086,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                5,
-                6
-            ]
-        },
-        "6-7": {
-            "gates": [
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.956503244436433,
-                    "operator": "CZ",
-                    "operator_type": "gate",
-                    "parameters": []
-                },
-                {
-                    "arguments": [
-                        "_",
-                        "_"
-                    ],
-                    "duration": 200.0,
-                    "fidelity": 0.986637648709386,
-                    "operator": "XY",
-                    "operator_type": "gate",
-                    "parameters": [
-                        "theta"
-                    ]
-                }
-            ],
-            "ids": [
-                6,
-                7
-            ]
+        {
+          "duration": 2000.0,
+          "fidelity": 0.933,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 1,
+          "target": null
         }
+      ],
+      "id": 1
+    },
+    "10": {
+      "dead": true,
+      "gates": [],
+      "id": 10
+    },
+    "11": {
+      "gates": [
+        {
+          "arguments": [
+            11
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            11
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            11
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            11
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            11
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            11
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.94,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 11,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.94,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 11,
+          "target": null
+        }
+      ],
+      "id": 11
+    },
+    "12": {
+      "gates": [
+        {
+          "arguments": [
+            12
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            12
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            12
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            12
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            12
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            12
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.887,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 12,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.887,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 12,
+          "target": null
+        }
+      ],
+      "id": 12
+    },
+    "13": {
+      "gates": [
+        {
+          "arguments": [
+            13
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            13
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            13
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            13
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            13
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            13
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.953,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 13,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.953,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 13,
+          "target": null
+        }
+      ],
+      "id": 13
+    },
+    "14": {
+      "gates": [
+        {
+          "arguments": [
+            14
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            14
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            14
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            14
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            14
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            14
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.951,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 14,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.951,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 14,
+          "target": null
+        }
+      ],
+      "id": 14
+    },
+    "15": {
+      "gates": [
+        {
+          "arguments": [
+            15
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            15
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            15
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            15
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            15
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            15
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.964,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 15,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.964,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 15,
+          "target": null
+        }
+      ],
+      "id": 15
+    },
+    "16": {
+      "gates": [
+        {
+          "arguments": [
+            16
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            16
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            16
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            16
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            16
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            16
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.959,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 16,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.959,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 16,
+          "target": null
+        }
+      ],
+      "id": 16
+    },
+    "17": {
+      "gates": [
+        {
+          "arguments": [
+            17
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            17
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            17
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            17
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            17
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            17
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.919,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 17,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.919,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 17,
+          "target": null
+        }
+      ],
+      "id": 17
+    },
+    "2": {
+      "gates": [
+        {
+          "arguments": [
+            2
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            2
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            2
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            2
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            2
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            2
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.984,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 2,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.984,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 2,
+          "target": null
+        }
+      ],
+      "id": 2
+    },
+    "20": {
+      "gates": [
+        {
+          "arguments": [
+            20
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            20
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            20
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            20
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            20
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            20
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.962,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 20,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.962,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 20,
+          "target": null
+        }
+      ],
+      "id": 20
+    },
+    "21": {
+      "gates": [
+        {
+          "arguments": [
+            21
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            21
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            21
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            21
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            21
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            21
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.921,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 21,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.921,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 21,
+          "target": null
+        }
+      ],
+      "id": 21
+    },
+    "22": {
+      "gates": [
+        {
+          "arguments": [
+            22
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            22
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            22
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            22
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            22
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            22
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.95,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 22,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.95,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 22,
+          "target": null
+        }
+      ],
+      "id": 22
+    },
+    "23": {
+      "gates": [
+        {
+          "arguments": [
+            23
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            23
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            23
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            23
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            23
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            23
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.883,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 23,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.883,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 23,
+          "target": null
+        }
+      ],
+      "id": 23
+    },
+    "24": {
+      "gates": [
+        {
+          "arguments": [
+            24
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            24
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            24
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            24
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            24
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            24
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.815,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 24,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.815,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 24,
+          "target": null
+        }
+      ],
+      "id": 24
+    },
+    "25": {
+      "gates": [
+        {
+          "arguments": [
+            25
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            25
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            25
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            25
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            25
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            25
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.95,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 25,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.95,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 25,
+          "target": null
+        }
+      ],
+      "id": 25
+    },
+    "26": {
+      "gates": [
+        {
+          "arguments": [
+            26
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            26
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            26
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            26
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            26
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            26
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.962,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 26,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.962,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 26,
+          "target": null
+        }
+      ],
+      "id": 26
+    },
+    "27": {
+      "gates": [
+        {
+          "arguments": [
+            27
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            27
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            27
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            27
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            27
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            27
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.868,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 27,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.868,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 27,
+          "target": null
+        }
+      ],
+      "id": 27
+    },
+    "3": {
+      "gates": [
+        {
+          "arguments": [
+            3
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            3
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            3
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            3
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            3
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            3
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.977,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 3,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.977,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 3,
+          "target": null
+        }
+      ],
+      "id": 3
+    },
+    "30": {
+      "gates": [
+        {
+          "arguments": [
+            30
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            30
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            30
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            30
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            30
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            30
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.933,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 30,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.933,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 30,
+          "target": null
+        }
+      ],
+      "id": 30
+    },
+    "31": {
+      "dead": true,
+      "gates": [],
+      "id": 31
+    },
+    "32": {
+      "gates": [
+        {
+          "arguments": [
+            32
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            32
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            32
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            32
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            32
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            32
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.957,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 32,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.957,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 32,
+          "target": null
+        }
+      ],
+      "id": 32
+    },
+    "33": {
+      "gates": [
+        {
+          "arguments": [
+            33
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            33
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            33
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            33
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            33
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            33
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.934,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 33,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.934,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 33,
+          "target": null
+        }
+      ],
+      "id": 33
+    },
+    "34": {
+      "gates": [
+        {
+          "arguments": [
+            34
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            34
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            34
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            34
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            34
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            34
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.944,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 34,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.944,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 34,
+          "target": null
+        }
+      ],
+      "id": 34
+    },
+    "35": {
+      "gates": [
+        {
+          "arguments": [
+            35
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            35
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            35
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            35
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            35
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            35
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.951,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 35,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.951,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 35,
+          "target": null
+        }
+      ],
+      "id": 35
+    },
+    "36": {
+      "gates": [
+        {
+          "arguments": [
+            36
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            36
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            36
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            36
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            36
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            36
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.907,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 36,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.907,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 36,
+          "target": null
+        }
+      ],
+      "id": 36
+    },
+    "37": {
+      "gates": [
+        {
+          "arguments": [
+            37
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            37
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            37
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            37
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            37
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            37
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.963,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 37,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.963,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 37,
+          "target": null
+        }
+      ],
+      "id": 37
+    },
+    "4": {
+      "gates": [
+        {
+          "arguments": [
+            4
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            4
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            4
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            4
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            4
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            4
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.973,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 4,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.973,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 4,
+          "target": null
+        }
+      ],
+      "id": 4
+    },
+    "5": {
+      "gates": [
+        {
+          "arguments": [
+            5
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            5
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            5
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            5
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            5
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            5
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.96,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 5,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.96,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 5,
+          "target": null
+        }
+      ],
+      "id": 5
+    },
+    "6": {
+      "gates": [
+        {
+          "arguments": [
+            6
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            6
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            6
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            6
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            6
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            6
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.985,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 6,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.985,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 6,
+          "target": null
+        }
+      ],
+      "id": 6
+    },
+    "7": {
+      "gates": [
+        {
+          "arguments": [
+            7
+          ],
+          "duration": 50.0,
+          "fidelity": 1.0,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            0.0
+          ]
+        },
+        {
+          "arguments": [
+            7
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            7
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -3.141592653589793
+          ]
+        },
+        {
+          "arguments": [
+            7
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            7
+          ],
+          "duration": 50.0,
+          "fidelity": 0.95,
+          "operator": "RX",
+          "operator_type": "gate",
+          "parameters": [
+            -1.5707963267948966
+          ]
+        },
+        {
+          "arguments": [
+            7
+          ],
+          "duration": 0.01,
+          "fidelity": 1.0,
+          "operator": "RZ",
+          "operator_type": "gate",
+          "parameters": [
+            "_"
+          ]
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.973,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 7,
+          "target": "_"
+        },
+        {
+          "duration": 2000.0,
+          "fidelity": 0.973,
+          "operator": "MEASURE",
+          "operator_type": "measure",
+          "qubit": 7,
+          "target": null
+        }
+      ],
+      "id": 7
     }
+  },
+  "2Q": {
+    "0-1": {
+      "dead": true,
+      "gates": [],
+      "ids": [
+        0,
+        1
+      ]
+    },
+    "0-7": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.827373529811633,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        }
+      ],
+      "ids": [
+        0,
+        7
+      ]
+    },
+    "1-16": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.963810998363568,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.969188284497237,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        1,
+        16
+      ]
+    },
+    "1-2": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.827034240060698,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        1,
+        2
+      ]
+    },
+    "10-11": {
+      "dead": true,
+      "gates": [],
+      "ids": [
+        10,
+        11
+      ]
+    },
+    "10-17": {
+      "dead": true,
+      "gates": [],
+      "ids": [
+        10,
+        17
+      ]
+    },
+    "11-12": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.802429544672657,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.971066599707853,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        11,
+        12
+      ]
+    },
+    "11-26": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.910436219297188,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.840193961279927,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        11,
+        26
+      ]
+    },
+    "12-13": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.814134152755118,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.881177283813748,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        12,
+        13
+      ]
+    },
+    "12-25": {
+      "dead": true,
+      "gates": [],
+      "ids": [
+        12,
+        25
+      ]
+    },
+    "13-14": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.884225667854257,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.750306760959217,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        13,
+        14
+      ]
+    },
+    "14-15": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.858347094059726,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.711986884534236,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        14,
+        15
+      ]
+    },
+    "15-16": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.82929882121941,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.96238538049698,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        15,
+        16
+      ]
+    },
+    "16-17": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.956423059904334,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.913342572784603,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        16,
+        17
+      ]
+    },
+    "2-15": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.761104307092066,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.906865591126598,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        2,
+        15
+      ]
+    },
+    "2-3": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.678760499686747,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.750382622112465,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        2,
+        3
+      ]
+    },
+    "20-21": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.976491247349509,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.982300057787109,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        20,
+        21
+      ]
+    },
+    "20-27": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.976044970222359,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.974351481307288,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        20,
+        27
+      ]
+    },
+    "21-22": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.960196083923008,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        21,
+        22
+      ]
+    },
+    "21-36": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.894622255097713,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.9739098152627,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        21,
+        36
+      ]
+    },
+    "22-23": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.800349240495056,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.887800962505768,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        22,
+        23
+      ]
+    },
+    "22-35": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.945399033154115,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.940514040770703,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        22,
+        35
+      ]
+    },
+    "23-24": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.835462460003224,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        }
+      ],
+      "ids": [
+        23,
+        24
+      ]
+    },
+    "24-25": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.958532411524689,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.907485454888485,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        24,
+        25
+      ]
+    },
+    "25-26": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.980953668001148,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.975458993777444,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        25,
+        26
+      ]
+    },
+    "26-27": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.972299346504856,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.970333122588459,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        26,
+        27
+      ]
+    },
+    "3-4": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.844817114645156,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.951494807160403,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        3,
+        4
+      ]
+    },
+    "30-31": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.962505082735891,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        }
+      ],
+      "ids": [
+        30,
+        31
+      ]
+    },
+    "30-37": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.941529902941919,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        }
+      ],
+      "ids": [
+        30,
+        37
+      ]
+    },
+    "31-32": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.984330374008766,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.970416051000658,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        31,
+        32
+      ]
+    },
+    "32-33": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.991077236512742,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.989990859777998,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        32,
+        33
+      ]
+    },
+    "33-34": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.965154410047365,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.979827735266774,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        33,
+        34
+      ]
+    },
+    "34-35": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.976761456156647,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.969357194375034,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        34,
+        35
+      ]
+    },
+    "35-36": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.9701474597447,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.941981091837248,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        35,
+        36
+      ]
+    },
+    "36-37": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.970775336390861,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.958112387890874,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        36,
+        37
+      ]
+    },
+    "4-5": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.902989902621697,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.945615850027519,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        4,
+        5
+      ]
+    },
+    "5-6": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.957500836136268,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.96394809507086,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        5,
+        6
+      ]
+    },
+    "6-7": {
+      "gates": [
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.956503244436433,
+          "operator": "CZ",
+          "operator_type": "gate",
+          "parameters": []
+        },
+        {
+          "arguments": [
+            "_",
+            "_"
+          ],
+          "duration": 200.0,
+          "fidelity": 0.986637648709386,
+          "operator": "XY",
+          "operator_type": "gate",
+          "parameters": [
+            "theta"
+          ]
+        }
+      ],
+      "ids": [
+        6,
+        7
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Description
-----------

When Pyquil passes the compiler edges and qubits without gates, the compiler will treat quil on those gates qubits/ edges as valid physical qubits/ edges, but will throw an error when the quil applies an operator to those qubits/ edges (see [comment](https://github.com/rigetti/pyquil/pull/1317#issuecomment-811245645)). Historically, the standard way to deal with these qubits/ edges has been to characterize them as dead in the ISA passed to quilc.

Detailed examples follow in the comments.

A few questions to consider:

* Should the Python client expose the Qubit/ Edge `dead` attribute as something the user can set, or set it when casting to a dictionary and there are no gates present? My preference is the current implementation (I like giving users more flexibility and the responsibility that comes with it - you break it, you buy it). 
* Should we side-step the issue here and make a change in Quilc, to assume gateless qubits/ edges are dead?


Checklist
---------

- [X] The above description motivates these changes.
- [X] There is a unit test that covers these changes.
- [X] All new and existing tests pass locally and on [Travis CI][travis].
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [X] (New Feature) The [docs][docs] have been updated accordingly.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [X] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
