### PR TITLE
Handle back-to-back engagements

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -888,6 +888,28 @@ pytest = ">=6.0.0,<7.0.0"
 testing = ["pytest-asyncio (>=0.14.0,<0.15.0)", "pytest-cov (>=2.0.0,<3.0.0)"]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "9.1.1"
+description = "pytest plugin to re-run tests to eliminate flaky failures"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[[package]]
+name = "pytest-timeout"
+version = "1.4.2"
+description = "py.test plugin to abort hanging tests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytest = ">=3.6.0"
+
+[[package]]
 name = "pytest-xdist"
 version = "2.2.1"
 description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
@@ -1008,6 +1030,18 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+
+[[package]]
+name = "retry"
+version = "0.9.2"
+description = "Easy to use retry decorator."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+decorator = ">=3.4.2"
+py = ">=1.4.26,<2.0.0"
 
 [[package]]
 name = "retrying"
@@ -1349,7 +1383,7 @@ docs = ["Sphinx", "sphinx-rtd-theme", "sphinx-autodoc-typehints", "nbsphinx", "r
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "c3eb494ddb6fd8595bcdcbc40ffdcea7ed2314adfca695bb9e3a118f652d1ff4"
+content-hash = "9a124808f89852c8faeb057b4be66878e21ec0085d5cf8338f4d4c9a392ce570"
 
 [metadata.files]
 alabaster = [
@@ -1861,6 +1895,14 @@ pytest-httpx = [
     {file = "pytest_httpx-0.9.0-py3-none-any.whl", hash = "sha256:f337cc19176600ed0615c5ec8390646306857d35ee49e5b662e68dfc0fc17dce"},
     {file = "pytest_httpx-0.9.0.tar.gz", hash = "sha256:7bfcc9344e13f441068181fb909fc86a545f25b4343ad98de55c1327ab336bfd"},
 ]
+pytest-rerunfailures = [
+    {file = "pytest-rerunfailures-9.1.1.tar.gz", hash = "sha256:1cb11a17fc121b3918414eb5eaf314ee325f2e693ac7cb3f6abf7560790827f2"},
+    {file = "pytest_rerunfailures-9.1.1-py3-none-any.whl", hash = "sha256:2eb7d0ad651761fbe80e064b0fd415cf6730cdbc53c16a145fd84b66143e609f"},
+]
+pytest-timeout = [
+    {file = "pytest-timeout-1.4.2.tar.gz", hash = "sha256:20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76"},
+    {file = "pytest_timeout-1.4.2-py2.py3-none-any.whl", hash = "sha256:541d7aa19b9a6b4e475c759fd6073ef43d7cdc9a92d95644c260076eb257a063"},
+]
 pytest-xdist = [
     {file = "pytest-xdist-2.2.1.tar.gz", hash = "sha256:718887296892f92683f6a51f25a3ae584993b06f7076ce1e1fd482e59a8220a2"},
     {file = "pytest_xdist-2.2.1-py3-none-any.whl", hash = "sha256:2447a1592ab41745955fb870ac7023026f20a5f0bfccf1b52a879bd193d46450"},
@@ -2004,6 +2046,10 @@ regex = [
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
+]
+retry = [
+    {file = "retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606"},
+    {file = "retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4"},
 ]
 retrying = [
     {file = "retrying-1.3.3.tar.gz", hash = "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ sphinx-rtd-theme = "^0.5.1"
 sphinx-autodoc-typehints = "^1.11.1"
 nbsphinx = "^0.8.2"
 recommonmark = "^0.7.1"
+retry = "^0.9.2"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"
@@ -31,6 +32,8 @@ pytest-cov = "^2.11.1"
 pytest-httpx = "^0.9"
 mypy = "0.740"
 pytest-xdist = "^2.2.1"
+pytest-rerunfailures = "^9.1.1"
+pytest-timeout = "^1.4.2"
 
 [tool.poetry.extras]
 docs = [

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,5 +1,7 @@
 import json
 import os
+import random
+import socket
 from pathlib import Path
 from typing import Dict, Any
 
@@ -25,7 +27,7 @@ from pyquil.quantum_processor.transformers.graph_to_compiler_isa import (
     _transform_qubit_operation_to_gates,
 )
 from pyquil.quil import Program
-from test.unit.utils import DummyCompiler
+from test.unit.utils import DummyCompiler, CLIENT_PUBLIC_KEY, CLIENT_SECRET_KEY, SERVER_PUBLIC_KEY, SERVER_SECRET_KEY
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
 
@@ -164,14 +166,6 @@ def client_configuration() -> QCSClientConfiguration:
     )
 
 
-# Valid, sample Z85-encoded keys specified by zmq curve for testing:
-#   http://api.zeromq.org/master:zmq-curve#toc4
-CLIENT_PUBLIC_KEY = "Yne@$w-vo<fVvi]a<NY6T1ed:M$fCG*[IaLV{hID"
-CLIENT_SECRET_KEY = "D:)Q[IlAW!ahhC2ac:9*A}h:p?([4%wOTJ%JR%cs"
-SERVER_PUBLIC_KEY = "rq:rM>}U?@Lns47E1%kR.o@n%FcmmsL/@{H8]yf7"
-SERVER_SECRET_KEY = "JTKVSB%%)wK0E.X)V>+}o?pNmC{O&4W4b!Ni{Lh6"
-
-
 @pytest.fixture(scope="session")
 def engagement_credentials() -> EngagementCredentials:
     return EngagementCredentials(
@@ -194,6 +188,17 @@ def rpcq_server_with_auth() -> rpcq.Server:
 @pytest.fixture(scope="function")
 def rpcq_server() -> rpcq.Server:
     return rpcq.Server()
+
+
+@pytest.fixture(scope="function")
+def port() -> int:
+    while True:
+        p = random.randint(10000, 60000)
+        sock = socket.socket()
+        err = sock.connect_ex(("localhost", p))
+        sock.close()
+        if err != 0:  # 0 => port in use
+            return p
 
 
 @pytest.fixture(scope="session")

--- a/test/unit/test_qpu_client.py
+++ b/test/unit/test_qpu_client.py
@@ -13,10 +13,15 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
+import time
+from datetime import datetime, timedelta
 from typing import Any, Dict
+from unittest import mock
 
 import pytest
 import rpcq
+from dateutil.tz import tzutc
+from pytest import raises
 from qcs_api_client.models import EngagementWithCredentials, EngagementCredentials
 
 from pyquil.api._qpu_client import (
@@ -30,15 +35,31 @@ from pyquil.api._qpu_client import (
 from test.unit.utils import run_rpcq_server
 
 
-def test_init__sets_engagement_and_timeout(engagement: EngagementWithCredentials):
-    qpu_client = QPUClient(engagement=engagement, request_timeout=3.14)
+def test_init__sets_processor_and_timeout(mock_engagement_manager: mock.MagicMock):
+    qpu_client = QPUClient(
+        quantum_processor_id="some-processor",
+        engagement_manager=mock_engagement_manager,
+        request_timeout=3.14,
+    )
 
-    assert qpu_client.engagement == engagement
+    assert qpu_client.quantum_processor_id == "some-processor"
     assert qpu_client.timeout == 3.14
 
 
-def test_run_program__returns_job_info(engagement: EngagementWithCredentials, rpcq_server_with_auth: rpcq.Server):
-    qpu_client = QPUClient(engagement=engagement)
+def test_run_program__returns_job_info(
+    mock_engagement_manager: mock.MagicMock,
+    engagement_credentials: EngagementCredentials,
+    rpcq_server_with_auth: rpcq.Server,
+    port: int,
+):
+    qpu_client = QPUClient(quantum_processor_id="some-processor", engagement_manager=mock_engagement_manager)
+
+    mock_engagement_manager.get_engagement.return_value = engagement(
+        quantum_processor_id="some-processor",
+        seconds_left=10,
+        credentials=engagement_credentials,
+        port=port,
+    )
 
     @rpcq_server_with_auth.rpc_handler
     def execute_qpu_request(request: rpcq.messages.QPURequest, user: str, priority: int) -> str:
@@ -53,7 +74,7 @@ def test_run_program__returns_job_info(engagement: EngagementWithCredentials, rp
         assert priority == 1
         return "some-job"
 
-    with run_rpcq_server(rpcq_server_with_auth, 5557):
+    with run_rpcq_server(rpcq_server_with_auth, port):
         request = RunProgramRequest(
             id="some-qpu-request",
             priority=1,
@@ -64,9 +85,19 @@ def test_run_program__returns_job_info(engagement: EngagementWithCredentials, rp
 
 
 def test_get_buffers__returns_buffers_for_job(
-    engagement: EngagementWithCredentials, rpcq_server_with_auth: rpcq.Server
+    mock_engagement_manager: mock.MagicMock,
+    engagement_credentials: EngagementCredentials,
+    rpcq_server_with_auth: rpcq.Server,
+    port: int,
 ):
-    qpu_client = QPUClient(engagement=engagement)
+    qpu_client = QPUClient(quantum_processor_id="some-processor", engagement_manager=mock_engagement_manager)
+
+    mock_engagement_manager.get_engagement.return_value = engagement(
+        quantum_processor_id="some-processor",
+        seconds_left=10,
+        credentials=engagement_credentials,
+        port=port,
+    )
 
     @rpcq_server_with_auth.rpc_handler
     def get_buffers(job_id: str, wait: bool) -> Dict[str, Any]:
@@ -80,7 +111,7 @@ def test_get_buffers__returns_buffers_for_job(
             },
         }
 
-    with run_rpcq_server(rpcq_server_with_auth, 5557):
+    with run_rpcq_server(rpcq_server_with_auth, port):
         request = GetBuffersRequest(
             job_id="some-job",
             wait=True,
@@ -96,13 +127,178 @@ def test_get_buffers__returns_buffers_for_job(
         )
 
 
-@pytest.fixture
-def engagement(engagement_credentials: EngagementCredentials) -> EngagementWithCredentials:
-    return EngagementWithCredentials(
-        address="tcp://localhost:5557",
-        credentials=engagement_credentials,
-        endpoint_id="some-endpoint",
-        expires_at="9999-01-01T00:00:00Z",
+def test_fetches_engagement_for_quantum_processor_on_request(
+    mock_engagement_manager: mock.MagicMock,
+    engagement_credentials: EngagementCredentials,
+    rpcq_server_with_auth: rpcq.Server,
+    port: int,
+):
+    qpu_client = QPUClient(
         quantum_processor_id="some-processor",
+        engagement_manager=mock_engagement_manager,
+        request_timeout=3.14,
+    )
+
+    def mock_get_engagement(quantum_processor_id: str, request_timeout: float) -> EngagementWithCredentials:
+        assert quantum_processor_id == "some-processor"
+        assert request_timeout == qpu_client.timeout
+        return engagement(
+            quantum_processor_id="some-processor",
+            seconds_left=9999,
+            credentials=engagement_credentials,
+            port=port,
+        )
+
+    mock_engagement_manager.get_engagement.side_effect = mock_get_engagement
+
+    @rpcq_server_with_auth.rpc_handler
+    def execute_qpu_request(request: rpcq.messages.QPURequest, user: str, priority: int):
+        return ""
+
+    with run_rpcq_server(rpcq_server_with_auth, port):
+        request = RunProgramRequest(
+            id="",
+            priority=0,
+            program="",
+            patch_values={},
+        )
+        qpu_client.run_program(request)
+
+
+def test_sets_timeout_on_requests__engagement_expires_later(
+    mock_engagement_manager: mock.MagicMock,
+    engagement_credentials: EngagementCredentials,
+    rpcq_server_with_auth: rpcq.Server,
+    port: int,
+):
+    """
+    Tests that the original request timeout is honored when time until engagement expiration is longer than timeout.
+    """
+    qpu_client = QPUClient(
+        quantum_processor_id="some-processor",
+        engagement_manager=mock_engagement_manager,
+        request_timeout=0.1,
+    )
+
+    mock_engagement_manager.get_engagement.return_value = engagement(
+        quantum_processor_id="some-processor",
+        seconds_left=qpu_client.timeout * 10,
+        credentials=engagement_credentials,
+        port=port,
+    )
+
+    @rpcq_server_with_auth.rpc_handler
+    def execute_qpu_request(request: rpcq.messages.QPURequest, user: str, priority: int):
+        time.sleep(qpu_client.timeout * 2)
+
+    with run_rpcq_server(rpcq_server_with_auth, port):
+        with raises(TimeoutError, match=f"Timeout on client tcp://localhost:{port}, method name execute_qpu_request"):
+            request = RunProgramRequest(
+                id="",
+                priority=0,
+                program="",
+                patch_values={},
+            )
+            qpu_client.run_program(request)
+
+
+def test_sets_timeout_on_requests__engagement_expires_sooner(
+    mock_engagement_manager: mock.MagicMock,
+    engagement_credentials: EngagementCredentials,
+    rpcq_server_with_auth: rpcq.Server,
+    port: int,
+):
+    """
+    Tests that the original request timeout is truncated when time until engagement expiration is sooner than timeout.
+    """
+    qpu_client = QPUClient(
+        quantum_processor_id="some-processor",
+        engagement_manager=mock_engagement_manager,
+        request_timeout=1.0,
+    )
+
+    engagement_seconds_left = qpu_client.timeout / 10
+    mock_engagement_manager.get_engagement.return_value = engagement(
+        quantum_processor_id="some-processor",
+        seconds_left=engagement_seconds_left,
+        credentials=engagement_credentials,
+        port=port,
+    )
+
+    @rpcq_server_with_auth.rpc_handler
+    def execute_qpu_request(request: rpcq.messages.QPURequest, user: str, priority: int):
+        time.sleep(engagement_seconds_left * 2)
+
+    with run_rpcq_server(rpcq_server_with_auth, port):
+        with raises(TimeoutError, match=f"Timeout on client tcp://localhost:{port}, method name execute_qpu_request"):
+            request = RunProgramRequest(
+                id="",
+                priority=0,
+                program="",
+                patch_values={},
+            )
+            qpu_client.run_program(request)
+
+
+def test_handles_contiguous_engagements(
+    mock_engagement_manager: mock.MagicMock,
+    engagement_credentials: EngagementCredentials,
+    rpcq_server_with_auth: rpcq.Server,
+    port: int,
+):
+    """Test that a request crossing the boundary between two contiguous engagements can successfully complete."""
+
+    qpu_client = QPUClient(
+        quantum_processor_id="some-processor",
+        engagement_manager=mock_engagement_manager,
+        request_timeout=1.0,
+    )
+
+    first_engagement_seconds_left = qpu_client.timeout / 10
+    mock_engagement_manager.get_engagement.side_effect = [
+        engagement(
+            quantum_processor_id="some-processor",
+            seconds_left=first_engagement_seconds_left,
+            credentials=engagement_credentials,
+            port=port,
+        ),
+        engagement(
+            quantum_processor_id="some-processor",
+            seconds_left=9999,
+            credentials=engagement_credentials,
+            port=port,
+        ),
+    ]
+
+    @rpcq_server_with_auth.rpc_handler
+    def execute_qpu_request(request: rpcq.messages.QPURequest, user: str, priority: int):
+        time.sleep(first_engagement_seconds_left * 2)
+        return "some-job"
+
+    with run_rpcq_server(rpcq_server_with_auth, port):
+        request = RunProgramRequest(
+            id="",
+            priority=0,
+            program="",
+            patch_values={},
+        )
+        assert qpu_client.run_program(request) == RunProgramResponse(job_id="some-job")
+
+
+def engagement(
+    *, quantum_processor_id: str, seconds_left: float, credentials: EngagementCredentials, port: int
+) -> EngagementWithCredentials:
+    return EngagementWithCredentials(
+        address=f"tcp://localhost:{port}",
+        credentials=credentials,
+        endpoint_id="some-endpoint",
+        expires_at=str(datetime.now(tzutc()) + timedelta(seconds=seconds_left)),
+        quantum_processor_id=quantum_processor_id,
         user_id="some-user",
     )
+
+
+@pytest.fixture()
+@mock.patch("pyquil.api.EngagementManager", autospec=True)
+def mock_engagement_manager(mock_engagement_manager_class: mock.MagicMock) -> mock.MagicMock:
+    return mock_engagement_manager_class.return_value


### PR DESCRIPTION
- `QPUClient` now takes an `EngagementManager` rather than an engagement in its constructor
- `QPUClient` can now do two things:
  - On each request, sets the timeout to the lesser of: 1) its originally-configured timeout (from constructor) and 2) the time remaining in the current engagement
  - Upon a timeout (which could be due to running into an engagement boundary), retries the request one extra time with a newly-fetched engagement. This should mitigate situations where a request spanned the wall between two contiguous engagements.