### PR TITLE
Throw error on qc with isa and noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Changelog
 - Dropped `api._quantum_processors`. Moved `get_device` to `pyquil.quantum_processor.qcs.get_qcs_quantum_processor`.
 
 - Dropped `gates_in_isa` and refactored as an internal function for preparing a list of `pyquil.Gate`'s that the user may use to initialize a `NoiseModel` based on the underlying `CompilerISA`.
+
+- `get_qc` raises `ValueError` when the user passes a QCS quantum processor name and `noisy=True`.
   
 ### Bugfixes
 

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -930,6 +930,12 @@ def get_qc(
             execution_timeout=execution_timeout,
         )
 
+    if noisy:
+        raise ValueError(
+            "pyQuil currently does not support initializing a noisy QuantumComputer "
+            "based on a QCSQuantumProcessor. Change noisy to False or specify the name of a QVM."
+        )
+
     # 4. Not a special case, query the web for information about this quantum_processor.
     quantum_processor = get_qcs_quantum_processor(
         quantum_processor_id=prefix, client_configuration=client_configuration
@@ -940,19 +946,12 @@ def get_qc(
             client_configuration=client_configuration,
             name=name,
             quantum_processor=quantum_processor,
-            noisy=noisy,
+            noisy=False,
             qvm_type=qvm_type,
             compiler_timeout=compiler_timeout,
             execution_timeout=execution_timeout,
         )
     else:
-        # 4.2 A real quantum processor
-        if noisy is not None and noisy:
-            warnings.warn(
-                "You have specified `noisy=True`, but you're getting a QPU. This flag "
-                "is meant for controlling noise models on QVMs."
-            )
-
         qpu = QPU(
             quantum_processor_id=quantum_processor.quantum_processor_id,
             timeout=execution_timeout,

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -757,6 +757,13 @@ def test_qc_joint_expectation(client_configuration: QCSClientConfiguration, dumm
     assert results[0].additional_results[1].total_counts == 40
 
 
+def test_get_qc_noisy_qpu_error(client_configuration: QCSClientConfiguration, dummy_compiler: DummyCompiler):
+    expected_message = "pyQuil currently does not support initializing a noisy QuantumComputer " \
+        "based on a QCSQuantumProcessor. Change noisy to False or specify the name of a QVM."
+    with pytest.raises(ValueError, match=expected_message):
+        get_qc("Aspen-8", noisy=True)
+
+
 def test_qc_joint_calibration(client_configuration: QCSClientConfiguration):
     # noise model with 95% symmetrized readout fidelity per qubit
     noise_model = asymmetric_ro_model([0, 1], 0.945, 0.955)


### PR DESCRIPTION
Description
-----------

`get_qcs_quantum_processor` initializes QCSQuantumProcessor without a noise model by default, so we throw an error if a user calls `get_qc` with a QPU name and `noisy=True`. 

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
