### PR TITLE
Provide default conf on get qcs qpu

### DIFF
--- a/pyquil/quantum_processor/qcs.py
+++ b/pyquil/quantum_processor/qcs.py
@@ -60,9 +60,21 @@ class QCSQuantumProcessor(AbstractQuantumProcessor):
 
 def get_qcs_quantum_processor(
     quantum_processor_id: str,
-    client_configuration: QCSClientConfiguration,
+    client_configuration: Optional[QCSClientConfiguration] = None,
     timeout: float = 10.0,
 ) -> QCSQuantumProcessor:
+    """
+    Retrieve an instruction set architecture for the specified ``quantum_processor_id`` and initialize a
+    ``QCSQuantumProcessor`` with it.
+
+    :param quantum_processor_id: QCS ID for the quantum processor.
+    :param timeout: Time limit for request, in seconds.
+    :param client_configuration: Optional client configuration. If none is provided, a default one will
+    be loaded.
+
+    :return: A ``QCSQuantumProcessor`` with the requested ISA.
+    """
+    client_configuration = client_configuration or QCSClientConfiguration.load()
     with qcs_client(client_configuration=client_configuration, request_timeout=timeout) as client:  # type: httpx.Client
         isa = get_instruction_set_architecture(client=client, quantum_processor_id=quantum_processor_id).parsed
 


### PR DESCRIPTION
Description
-----------

Let's not force users to initialize their own configuration when calling `get_qcs_quantum_processor`. 

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
