### PR TITLE
Controlled gates QVM

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -221,6 +221,16 @@ class Gate(AbstractInstruction):
         self.qubits = qubits_list
         self.modifiers: List[str] = []
 
+    @property
+    def modified_name(self):
+        """ If there's a modifier on this gate then the 'official' name
+            of the gate needs to change, otherwise gate lookups for
+            matrices don't work.
+        """
+        if "CONTROLLED" in self.modifiers:
+            return "C" + self.name
+        return self.name
+
     def get_qubits(self, indices: bool = True) -> Set[QubitDesignator]:
         return {_extract_qubit_index(q, indices) for q in self.qubits}
 

--- a/pyquil/simulation/_numpy.py
+++ b/pyquil/simulation/_numpy.py
@@ -150,9 +150,9 @@ def _get_gate_tensor_and_qubits(gate: Gate) -> Tuple[np.ndarray, List[int]]:
     :return: tensor, qubit_inds.
     """
     if len(gate.params) > 0:
-        matrix = QUANTUM_GATES[gate.name](*gate.params)
+        matrix = QUANTUM_GATES[gate.modified_name](*gate.params)
     else:
-        matrix = QUANTUM_GATES[gate.name]
+        matrix = QUANTUM_GATES[gate.modified_name]
 
     qubit_inds = [q.index for q in gate.qubits]
 

--- a/pyquil/simulation/matrices.py
+++ b/pyquil/simulation/matrices.py
@@ -107,6 +107,8 @@ from typing import Tuple
 
 import numpy as np
 
+INV_ROOT2 = 1.0 / np.sqrt(2.0)
+
 I = np.array([[1.0, 0.0], [0.0, 1.0]])
 
 X = np.array([[0.0, 1.0], [1.0, 0.0]])
@@ -115,7 +117,16 @@ Y = np.array([[0.0, 0.0 - 1.0j], [0.0 + 1.0j, 0.0]])
 
 Z = np.array([[1.0, 0.0], [0.0, -1.0]])
 
-H = (1.0 / np.sqrt(2.0)) * np.array([[1.0, 1.0], [1.0, -1.0]])
+H = INV_ROOT2 * np.array([[1.0, 1.0], [1.0, -1.0]])
+
+CH = np.array(
+    [
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0],
+        [0.0, 0.0, INV_ROOT2, INV_ROOT2],
+        [0.0, 0.0, INV_ROOT2, -INV_ROOT2],
+    ]
+)
 
 S = np.array([[1.0, 0.0], [0.0, 1.0j]])
 
@@ -236,9 +247,11 @@ def BARENCO(alpha: float, phi: float, theta: float) -> np.ndarray:
 QUANTUM_GATES = {
     "I": I,
     "X": X,
+    "CX": CNOT,
     "Y": Y,
     "Z": Z,
     "H": H,
+    "CH": CH,
     "S": S,
     "T": T,
     "PHASE": PHASE,

--- a/pyquil/tests/test_pyqvm.py
+++ b/pyquil/tests/test_pyqvm.py
@@ -1,0 +1,30 @@
+import pytest
+
+from pyquil import Program
+from pyquil.gates import H, X, CNOT, Z, SWAP
+from pyquil.pyqvm import PyQVM
+
+
+@pytest.mark.parametrize(
+    "first_gate,second_gate,expected",
+    [
+        (X(0), H(1), "X 0\nH 1\n"),
+        (X(0), H(1).controlled(0), "X 0\nCONTROLLED H 0 1\n"),
+        (H(0), X(1), "H 0\nX 1\n"),
+        (H(0), X(1).controlled(0), "H 0\nCONTROLLED X 0 1\n"),
+        (H(0), Z(1), "H 0\nZ 1\n"),
+        (H(0), Z(1).controlled(0), "H 0\nCONTROLLED Z 0 1\n"),
+        (X(0), X(1), "X 0\nX 1\n"),
+        (X(0), X(1).controlled(0), "X 0\nCONTROLLED X 0 1\n"),
+        (H(0), SWAP(0, 1), "H 0\nSWAP 0 1\n"),
+        (X(0), CNOT(0, 1), "X 0\nCNOT 0 1\n"),
+    ],
+)
+def test_pyqvm_controlled_gates(first_gate, second_gate, expected):
+    """ Unit-test based on the bug report in
+        https://github.com/rigetti/pyquil/issues/1259
+    """
+    p = Program(first_gate, second_gate)
+    qvm = PyQVM(n_qubits=2)
+    result = qvm.execute(p)
+    assert result.program.out() == expected


### PR DESCRIPTION
Description
-----------

Fixes #1259 

Controlled gates weren't getting treated properly in the `QUANTUM_GATES` / matrix globals. The name needs to be modified to pick up the right matrix. As a result I've added a new `modified_name` property which corrects the name for controlled gates, and a unit-test showing the example in 1259 now passes.

Checklist
---------

- [X] The above description motivates these changes.
- [X] There is a unit test that covers these changes.
- [X] All new and existing tests pass locally and on [Travis CI][travis].
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
