### PR TITLE
Fix typo in docs for QVM env var

### DIFF
--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -109,7 +109,7 @@ These are all the configuration options available to you, and where they can be 
    * - QVM URL
 
        Simulator
-     - ``QCS_URL``
+     - ``QVM_URL``
      - ``.forest_config``
 
        Key: ``qvm_address``


### PR DESCRIPTION
Description
-----------

Fixes #1336 

There's a minor typo/copy-paste error in the docs, and the wrong variable was documented for QVM_URL.

Checklist
---------

- [X] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on [Travis CI][travis].
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
