### PR TITLE
Fix: Remove test RPCQ server to improve CI consistency.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -240,6 +240,17 @@ pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
+name = "freezegun"
+version = "1.1.0"
+description = "Let your Python tests travel through time"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "h11"
 version = "0.9.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -874,6 +885,18 @@ py = "*"
 pytest = ">=3.10"
 
 [[package]]
+name = "pytest-freezegun"
+version = "0.4.2"
+description = "Wrap tests with fixtures in freeze_time"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+freezegun = ">0.3"
+pytest = ">=3.0.0"
+
+[[package]]
 name = "pytest-httpx"
 version = "0.9.0"
 description = "Send responses to httpx."
@@ -887,6 +910,20 @@ pytest = ">=6.0.0,<7.0.0"
 
 [package.extras]
 testing = ["pytest-asyncio (>=0.14.0,<0.15.0)", "pytest-cov (>=2.0.0,<3.0.0)"]
+
+[[package]]
+name = "pytest-mock"
+version = "3.6.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
 name = "pytest-rerunfailures"
@@ -1065,7 +1102,7 @@ python-versions = "*"
 
 [[package]]
 name = "rfc3986"
-version = "1.4.0"
+version = "1.5.0"
 description = "Validating URI References per RFC 3986"
 category = "main"
 optional = false
@@ -1385,7 +1422,7 @@ docs = ["Sphinx", "sphinx-rtd-theme", "sphinx-autodoc-typehints", "nbsphinx", "r
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "9a124808f89852c8faeb057b4be66878e21ec0085d5cf8338f4d4c9a392ce570"
+content-hash = "78af3333765543c15a0309f22db0dd133c8a8903a41630a13c7439812d981ace"
 
 [metadata.files]
 alabaster = [
@@ -1452,24 +1489,36 @@ cffi = [
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5"},
     {file = "cffi-1.14.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55"},
     {file = "cffi-1.14.5-cp36-cp36m-win32.whl", hash = "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53"},
     {file = "cffi-1.14.5-cp36-cp36m-win_amd64.whl", hash = "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813"},
     {file = "cffi-1.14.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1"},
     {file = "cffi-1.14.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc"},
     {file = "cffi-1.14.5-cp37-cp37m-win32.whl", hash = "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62"},
     {file = "cffi-1.14.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4"},
     {file = "cffi-1.14.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e"},
     {file = "cffi-1.14.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76"},
     {file = "cffi-1.14.5-cp38-cp38-win32.whl", hash = "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e"},
     {file = "cffi-1.14.5-cp38-cp38-win_amd64.whl", hash = "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396"},
     {file = "cffi-1.14.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c"},
     {file = "cffi-1.14.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7"},
     {file = "cffi-1.14.5-cp39-cp39-win32.whl", hash = "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396"},
     {file = "cffi-1.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d"},
     {file = "cffi-1.14.5.tar.gz", hash = "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"},
@@ -1567,6 +1616,10 @@ execnet = [
 flake8 = [
     {file = "flake8-3.9.0-py2.py3-none-any.whl", hash = "sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff"},
     {file = "flake8-3.9.0.tar.gz", hash = "sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0"},
+]
+freezegun = [
+    {file = "freezegun-1.1.0-py2.py3-none-any.whl", hash = "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"},
+    {file = "freezegun-1.1.0.tar.gz", hash = "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3"},
 ]
 h11 = [
     {file = "h11-0.9.0-py2.py3-none-any.whl", hash = "sha256:4bc6d6a1238b7615b266ada57e0618568066f57dd6fa967d1290ec9309b2f2f1"},
@@ -1893,9 +1946,17 @@ pytest-forked = [
     {file = "pytest-forked-1.3.0.tar.gz", hash = "sha256:6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca"},
     {file = "pytest_forked-1.3.0-py2.py3-none-any.whl", hash = "sha256:dc4147784048e70ef5d437951728825a131b81714b398d5d52f17c7c144d8815"},
 ]
+pytest-freezegun = [
+    {file = "pytest-freezegun-0.4.2.zip", hash = "sha256:19c82d5633751bf3ec92caa481fb5cffaac1787bd485f0df6436fd6242176949"},
+    {file = "pytest_freezegun-0.4.2-py2.py3-none-any.whl", hash = "sha256:5318a6bfb8ba4b709c8471c94d0033113877b3ee02da5bfcd917c1889cde99a7"},
+]
 pytest-httpx = [
     {file = "pytest_httpx-0.9.0-py3-none-any.whl", hash = "sha256:f337cc19176600ed0615c5ec8390646306857d35ee49e5b662e68dfc0fc17dce"},
     {file = "pytest_httpx-0.9.0.tar.gz", hash = "sha256:7bfcc9344e13f441068181fb909fc86a545f25b4343ad98de55c1327ab336bfd"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.6.1.tar.gz", hash = "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"},
+    {file = "pytest_mock-3.6.1-py3-none-any.whl", hash = "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3"},
 ]
 pytest-rerunfailures = [
     {file = "pytest-rerunfailures-9.1.1.tar.gz", hash = "sha256:1cb11a17fc121b3918414eb5eaf314ee325f2e693ac7cb3f6abf7560790827f2"},
@@ -2061,8 +2122,8 @@ rfc3339 = [
     {file = "rfc3339-6.2.tar.gz", hash = "sha256:d53c3b5eefaef892b7240ba2a91fef012e86faa4d0a0ca782359c490e00ad4d0"},
 ]
 rfc3986 = [
-    {file = "rfc3986-1.4.0-py2.py3-none-any.whl", hash = "sha256:af9147e9aceda37c91a05f4deb128d4b4b49d6b199775fd2d2927768abdc8f50"},
-    {file = "rfc3986-1.4.0.tar.gz", hash = "sha256:112398da31a3344dc25dbf477d8df6cb34f9278a94fee2625d89e4514be8bb9d"},
+    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
+    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
 ]
 rpcq = [
     {file = "rpcq-3.9.1.tar.gz", hash = "sha256:bd5b9aa8fd14ce68d63306836f02053b674d2fadba05924133e30d12d7b8f651"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ mypy = "0.740"
 pytest-xdist = "^2.2.1"
 pytest-rerunfailures = "^9.1.1"
 pytest-timeout = "^1.4.2"
+pytest-mock = "^3.6.1"
+pytest-freezegun = "^0.4.2"
 
 [tool.poetry.extras]
 docs = [

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,14 +1,10 @@
 import json
 import os
-import random
-import socket
 from pathlib import Path
 from typing import Dict, Any
-from threading import Lock
 
 import numpy as np
 import pytest
-import rpcq
 from qcs_api_client.client._configuration import QCSClientConfiguration
 from qcs_api_client.models import InstructionSetArchitecture, EngagementCredentials
 
@@ -27,7 +23,7 @@ from pyquil.quantum_processor.transformers.graph_to_compiler_isa import (
     _transform_qubit_operation_to_gates,
 )
 from pyquil.quil import Program
-from test.unit.utils import DummyCompiler, CLIENT_PUBLIC_KEY, CLIENT_SECRET_KEY, SERVER_PUBLIC_KEY, SERVER_SECRET_KEY
+from test.unit.utils import DummyCompiler, CLIENT_PUBLIC_KEY, CLIENT_SECRET_KEY, SERVER_PUBLIC_KEY
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
 
@@ -165,36 +161,6 @@ def engagement_credentials() -> EngagementCredentials:
         client_secret=CLIENT_SECRET_KEY,
         server_public=SERVER_PUBLIC_KEY,
     )
-
-
-@pytest.fixture(scope="function")
-def rpcq_server_with_auth() -> rpcq.Server:
-    auth_config = rpcq.ServerAuthConfig(
-        server_secret_key=SERVER_SECRET_KEY.encode(),
-        server_public_key=SERVER_PUBLIC_KEY.encode(),
-        client_keys_directory=os.path.join(TEST_DATA_DIR, "rpcq_client_key"),
-    )
-    return rpcq.Server(auth_config=auth_config)
-
-
-@pytest.fixture(scope="function")
-def rpcq_server() -> rpcq.Server:
-    return rpcq.Server()
-
-
-port_lock = Lock()
-
-
-@pytest.fixture(scope="function")
-def port() -> int:
-    with port_lock:
-        while True:
-            p = random.randint(10000, 60000)
-            sock = socket.socket()
-            err = sock.connect_ex(("localhost", p))
-            sock.close()
-            if err != 0:  # 0 => port in use
-                return p
 
 
 @pytest.fixture(scope="session")

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -15,22 +15,11 @@
 #    limitations under the License.
 ##############################################################################
 from math import pi
-from unittest import mock
 
 import numpy as np
-import pytest
-from qcs_api_client.client import QCSClientConfiguration
 
-from pyquil.api._qvm_client import (
-    MeasureExpectationResponse,
-    MeasureExpectationRequest,
-    RunAndMeasureProgramResponse,
-    RunAndMeasureProgramRequest,
-    RunProgramRequest,
-    RunProgramResponse,
-)
 from pyquil.external.rpcq import _compiler_isa_from_dict
-from pyquil.gates import CNOT, H, MEASURE, PHASE, Z, RZ, RX, CZ
+from pyquil.gates import CNOT, H, MEASURE, PHASE, RZ, RX, CZ
 from pyquil.paulis import PauliTerm
 from pyquil.quil import Program
 from pyquil.quilatom import MemoryReference

--- a/test/unit/test_compiler_client.py
+++ b/test/unit/test_compiler_client.py
@@ -31,7 +31,7 @@ from pyquil.api._compiler_client import (
     CompileToNativeQuilRequest,
 )
 from pyquil.external.rpcq import CompilerISA, compiler_isa_to_target_quantum_processor
-from test.unit.utils import patch_rpc_client
+from test.unit.utils import patch_rpcq_client
 
 
 def test_init__sets_base_url_and_timeout(monkeypatch: MonkeyPatch):
@@ -60,7 +60,7 @@ def test_sets_timeout_on_requests(mocker: MockerFixture):
     client_configuration = QCSClientConfiguration.load()
     compiler_client = CompilerClient(client_configuration=client_configuration, request_timeout=0.1)
 
-    patch_rpc_client(mocker=mocker, return_value={})
+    patch_rpcq_client(mocker=mocker, return_value={})
 
     with compiler_client._rpcq_client() as client:
         assert client.timeout == compiler_client.timeout
@@ -70,10 +70,10 @@ def test_get_version__returns_version(mocker: MockerFixture):
     client_configuration = QCSClientConfiguration.load()
     compiler_client = CompilerClient(client_configuration=client_configuration)
 
-    client = patch_rpc_client(mocker=mocker, return_value={"quilc": "1.2.3"})
+    rpcq_client = patch_rpcq_client(mocker=mocker, return_value={"quilc": "1.2.3"})
 
     assert compiler_client.get_version() == "1.2.3"
-    client.call.assert_called_once_with(
+    rpcq_client.call.assert_called_once_with(
         "get_version_info"
     )
 
@@ -85,7 +85,7 @@ def test_compile_to_native_quil__returns_native_quil(
     client_configuration = QCSClientConfiguration.load()
     compiler_client = CompilerClient(client_configuration=client_configuration)
 
-    client = patch_rpc_client(
+    rpcq_client = patch_rpcq_client(
         mocker=mocker,
         return_value=rpcq.messages.NativeQuilResponse(
             quil="native-program",
@@ -120,12 +120,12 @@ def test_compile_to_native_quil__returns_native_quil(
             qpu_runtime_estimation=0.1618,
         ),
     )
-    client.call.assert_called_once_with(
+    rpcq_client.call.assert_called_once_with(
         "quil_to_native_quil",
-    rpcq.messages.NativeQuilRequest(
-        quil="some-program",
-        target_device=compiler_isa_to_target_quantum_processor(aspen8_compiler_isa),
-    ),
+        rpcq.messages.NativeQuilRequest(
+            quil="some-program",
+            target_device=compiler_isa_to_target_quantum_processor(aspen8_compiler_isa),
+        ),
         protoquil=True,
     )
 
@@ -135,7 +135,7 @@ def test_conjugate_pauli_by_clifford__returns_conjugation_result(
 ):
     client_configuration = QCSClientConfiguration.load()
     compiler_client = CompilerClient(client_configuration=client_configuration)
-    client = patch_rpc_client(mocker=mocker, return_value=rpcq.messages.ConjugateByCliffordResponse(phase=42, pauli="pauli"))
+    rpcq_client = patch_rpcq_client(mocker=mocker, return_value=rpcq.messages.ConjugateByCliffordResponse(phase=42, pauli="pauli"))
 
     request = ConjugatePauliByCliffordRequest(
         pauli_indices=[0, 1, 2],
@@ -146,7 +146,7 @@ def test_conjugate_pauli_by_clifford__returns_conjugation_result(
         phase_factor=42,
         pauli="pauli",
     )
-    client.call.assert_called_once_with(
+    rpcq_client.call.assert_called_once_with(
         "conjugate_pauli_by_clifford",
         rpcq.messages.ConjugateByCliffordRequest(
             pauli=rpcq.messages.PauliTerm(indices=[0, 1, 2], symbols=["x", "y", "z"]),
@@ -161,7 +161,7 @@ def test_generate_randomized_benchmarking_sequence__returns_benchmarking_sequenc
     client_configuration = QCSClientConfiguration.load()
     compiler_client = CompilerClient(client_configuration=client_configuration)
 
-    client = patch_rpc_client(mocker=mocker, return_value=rpcq.messages.RandomizedBenchmarkingResponse(sequence=[[3, 1, 4], [1, 6, 1]]))
+    rpcq_client = patch_rpcq_client(mocker=mocker, return_value=rpcq.messages.RandomizedBenchmarkingResponse(sequence=[[3, 1, 4], [1, 6, 1]]))
 
     request = GenerateRandomizedBenchmarkingSequenceRequest(
         depth=42,
@@ -173,7 +173,7 @@ def test_generate_randomized_benchmarking_sequence__returns_benchmarking_sequenc
     assert compiler_client.generate_randomized_benchmarking_sequence(
         request
     ) == GenerateRandomizedBenchmarkingSequenceResponse(sequence=[[3, 1, 4], [1, 6, 1]])
-    client.call.assert_called_once_with(
+    rpcq_client.call.assert_called_once_with(
         "generate_rb_sequence",
         rpcq.messages.RandomizedBenchmarkingRequest(
             depth=42,

--- a/test/unit/test_compiler_client.py
+++ b/test/unit/test_compiler_client.py
@@ -13,12 +13,11 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-import time
-from typing import Dict
 
 import rpcq
 from _pytest.monkeypatch import MonkeyPatch
 from pytest import raises
+from pytest_mock import MockerFixture
 from qcs_api_client.client import QCSClientConfiguration
 
 from pyquil.api._compiler_client import (
@@ -32,20 +31,21 @@ from pyquil.api._compiler_client import (
     CompileToNativeQuilRequest,
 )
 from pyquil.external.rpcq import CompilerISA, compiler_isa_to_target_quantum_processor
-from test.unit.utils import run_rpcq_server
+from test.unit.utils import patch_rpc_client
 
 
-def test_init__sets_base_url_and_timeout(monkeypatch: MonkeyPatch, port: int):
-    monkeypatch.setenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QUILC_URL", f"tcp://localhost:{port}")
+def test_init__sets_base_url_and_timeout(monkeypatch: MonkeyPatch):
+    host = "tcp://localhost:1234"
+    monkeypatch.setenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QUILC_URL", host)
     client_configuration = QCSClientConfiguration.load()
 
     compiler_client = CompilerClient(client_configuration=client_configuration, request_timeout=3.14)
 
-    assert compiler_client.base_url == f"tcp://localhost:{port}"
+    assert compiler_client.base_url == host
     assert compiler_client.timeout == 3.14
 
 
-def test_init__validates_compiler_url(monkeypatch: MonkeyPatch, port: int):
+def test_init__validates_compiler_url(monkeypatch: MonkeyPatch):
     monkeypatch.setenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QUILC_URL", "not-http-or-tcp://example.com")
     client_configuration = QCSClientConfiguration.load()
 
@@ -56,53 +56,38 @@ def test_init__validates_compiler_url(monkeypatch: MonkeyPatch, port: int):
         CompilerClient(client_configuration=client_configuration)
 
 
-def test_sets_timeout_on_requests(rpcq_server: rpcq.Server, monkeypatch: MonkeyPatch, port: int):
-    monkeypatch.setenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QUILC_URL", f"tcp://localhost:{port}")
+def test_sets_timeout_on_requests(mocker: MockerFixture):
     client_configuration = QCSClientConfiguration.load()
     compiler_client = CompilerClient(client_configuration=client_configuration, request_timeout=0.1)
 
-    @rpcq_server.rpc_handler
-    def get_version_info():
-        time.sleep(compiler_client.timeout * 2)
+    patch_rpc_client(mocker=mocker, return_value={})
 
-    with run_rpcq_server(rpcq_server, port):
-        with raises(TimeoutError, match=f"Timeout on client tcp://localhost:{port}, method name get_version_info"):
-            compiler_client.get_version()
+    with compiler_client._rpcq_client() as client:
+        assert client.timeout == compiler_client.timeout
 
 
-def test_get_version__returns_version(rpcq_server: rpcq.Server, monkeypatch: MonkeyPatch, port: int):
-    monkeypatch.setenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QUILC_URL", f"tcp://localhost:{port}")
+def test_get_version__returns_version(mocker: MockerFixture):
     client_configuration = QCSClientConfiguration.load()
     compiler_client = CompilerClient(client_configuration=client_configuration)
 
-    @rpcq_server.rpc_handler
-    def get_version_info() -> Dict[str, str]:
-        return {"quilc": "1.2.3"}
+    client = patch_rpc_client(mocker=mocker, return_value={"quilc": "1.2.3"})
 
-    with run_rpcq_server(rpcq_server, port):
-        assert compiler_client.get_version() == "1.2.3"
+    assert compiler_client.get_version() == "1.2.3"
+    client.call.assert_called_once_with(
+        "get_version_info"
+    )
 
 
 def test_compile_to_native_quil__returns_native_quil(
-    rpcq_server: rpcq.Server,
     aspen8_compiler_isa: CompilerISA,
-    monkeypatch: MonkeyPatch,
-    port: int,
+    mocker: MockerFixture,
 ):
-    monkeypatch.setenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QUILC_URL", f"tcp://localhost:{port}")
     client_configuration = QCSClientConfiguration.load()
     compiler_client = CompilerClient(client_configuration=client_configuration)
 
-    @rpcq_server.rpc_handler
-    def quil_to_native_quil(
-        request: rpcq.messages.NativeQuilRequest, protoquil: bool
-    ) -> rpcq.messages.NativeQuilResponse:
-        assert request == rpcq.messages.NativeQuilRequest(
-            quil="some-program",
-            target_device=compiler_isa_to_target_quantum_processor(aspen8_compiler_isa),
-        )
-        assert protoquil is True
-        return rpcq.messages.NativeQuilResponse(
+    client = patch_rpc_client(
+        mocker=mocker,
+        return_value=rpcq.messages.NativeQuilResponse(
             quil="native-program",
             metadata=rpcq.messages.NativeQuilMetadata(
                 final_rewiring=[0, 1, 2],
@@ -115,87 +100,86 @@ def test_compile_to_native_quil__returns_native_quil(
                 qpu_runtime_estimation=0.1618,
             ),
         )
+    )
+    request = CompileToNativeQuilRequest(
+        program="some-program",
+        target_quantum_processor=compiler_isa_to_target_quantum_processor(aspen8_compiler_isa),
+        protoquil=True,
+    )
 
-    with run_rpcq_server(rpcq_server, port):
-        request = CompileToNativeQuilRequest(
-            program="some-program",
-            target_quantum_processor=compiler_isa_to_target_quantum_processor(aspen8_compiler_isa),
-            protoquil=True,
-        )
-        assert compiler_client.compile_to_native_quil(request) == CompileToNativeQuilResponse(
-            native_program="native-program",
-            metadata=NativeQuilMetadataResponse(
-                final_rewiring=[0, 1, 2],
-                gate_depth=10,
-                gate_volume=42,
-                multiqubit_gate_depth=5,
-                program_duration=3.14,
-                program_fidelity=0.99,
-                topological_swaps=3,
-                qpu_runtime_estimation=0.1618,
-            ),
-        )
+    assert compiler_client.compile_to_native_quil(request) == CompileToNativeQuilResponse(
+        native_program="native-program",
+        metadata=NativeQuilMetadataResponse(
+            final_rewiring=[0, 1, 2],
+            gate_depth=10,
+            gate_volume=42,
+            multiqubit_gate_depth=5,
+            program_duration=3.14,
+            program_fidelity=0.99,
+            topological_swaps=3,
+            qpu_runtime_estimation=0.1618,
+        ),
+    )
+    client.call.assert_called_once_with(
+        "quil_to_native_quil",
+    rpcq.messages.NativeQuilRequest(
+        quil="some-program",
+        target_device=compiler_isa_to_target_quantum_processor(aspen8_compiler_isa),
+    ),
+        protoquil=True,
+    )
 
 
 def test_conjugate_pauli_by_clifford__returns_conjugation_result(
-    rpcq_server: rpcq.Server, monkeypatch: MonkeyPatch, port: int
+    mocker: MockerFixture
 ):
-    monkeypatch.setenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QUILC_URL", f"tcp://localhost:{port}")
     client_configuration = QCSClientConfiguration.load()
     compiler_client = CompilerClient(client_configuration=client_configuration)
+    client = patch_rpc_client(mocker=mocker, return_value=rpcq.messages.ConjugateByCliffordResponse(phase=42, pauli="pauli"))
 
-    @rpcq_server.rpc_handler
-    def conjugate_pauli_by_clifford(
-        request: rpcq.messages.ConjugateByCliffordRequest,
-    ) -> rpcq.messages.ConjugateByCliffordResponse:
-        assert request == rpcq.messages.ConjugateByCliffordRequest(
+    request = ConjugatePauliByCliffordRequest(
+        pauli_indices=[0, 1, 2],
+        pauli_symbols=["x", "y", "z"],
+        clifford="cliff",
+    )
+    assert compiler_client.conjugate_pauli_by_clifford(request) == ConjugatePauliByCliffordResponse(
+        phase_factor=42,
+        pauli="pauli",
+    )
+    client.call.assert_called_once_with(
+        "conjugate_pauli_by_clifford",
+        rpcq.messages.ConjugateByCliffordRequest(
             pauli=rpcq.messages.PauliTerm(indices=[0, 1, 2], symbols=["x", "y", "z"]),
             clifford="cliff",
         )
-        return rpcq.messages.ConjugateByCliffordResponse(phase=42, pauli="pauli")
-
-    with run_rpcq_server(rpcq_server, port):
-        request = ConjugatePauliByCliffordRequest(
-            pauli_indices=[0, 1, 2],
-            pauli_symbols=["x", "y", "z"],
-            clifford="cliff",
-        )
-        assert compiler_client.conjugate_pauli_by_clifford(request) == ConjugatePauliByCliffordResponse(
-            phase_factor=42,
-            pauli="pauli",
-        )
+    )
 
 
 def test_generate_randomized_benchmarking_sequence__returns_benchmarking_sequence(
-    rpcq_server: rpcq.Server,
-    monkeypatch: MonkeyPatch,
-    port: int,
+    mocker: MockerFixture,
 ):
-    monkeypatch.setenv("QCS_SETTINGS_APPLICATIONS_PYQUIL_QUILC_URL", f"tcp://localhost:{port}")
     client_configuration = QCSClientConfiguration.load()
     compiler_client = CompilerClient(client_configuration=client_configuration)
 
-    @rpcq_server.rpc_handler
-    def generate_rb_sequence(
-        request: rpcq.messages.RandomizedBenchmarkingRequest,
-    ) -> rpcq.messages.RandomizedBenchmarkingResponse:
-        assert request == rpcq.messages.RandomizedBenchmarkingRequest(
+    client = patch_rpc_client(mocker=mocker, return_value=rpcq.messages.RandomizedBenchmarkingResponse(sequence=[[3, 1, 4], [1, 6, 1]]))
+
+    request = GenerateRandomizedBenchmarkingSequenceRequest(
+        depth=42,
+        num_qubits=3,
+        gateset=["some", "gate", "set"],
+        seed=314,
+        interleaver="some-interleaver",
+    )
+    assert compiler_client.generate_randomized_benchmarking_sequence(
+        request
+    ) == GenerateRandomizedBenchmarkingSequenceResponse(sequence=[[3, 1, 4], [1, 6, 1]])
+    client.call.assert_called_once_with(
+        "generate_rb_sequence",
+        rpcq.messages.RandomizedBenchmarkingRequest(
             depth=42,
             qubits=3,
             gateset=["some", "gate", "set"],
             seed=314,
             interleaver="some-interleaver",
         )
-        return rpcq.messages.RandomizedBenchmarkingResponse(sequence=[[3, 1, 4], [1, 6, 1]])
-
-    with run_rpcq_server(rpcq_server, port):
-        request = GenerateRandomizedBenchmarkingSequenceRequest(
-            depth=42,
-            num_qubits=3,
-            gateset=["some", "gate", "set"],
-            seed=314,
-            interleaver="some-interleaver",
-        )
-        assert compiler_client.generate_randomized_benchmarking_sequence(
-            request
-        ) == GenerateRandomizedBenchmarkingSequenceResponse(sequence=[[3, 1, 4], [1, 6, 1]])
+    )

--- a/test/unit/test_noise.py
+++ b/test/unit/test_noise.py
@@ -1,8 +1,8 @@
 from collections import OrderedDict
-from unittest import mock
 
 import numpy as np
 import pytest
+from pytest_mock import MockerFixture
 
 from pyquil.api._qam import QAMExecutionResult
 from pyquil.gates import RZ, RX, I, CZ
@@ -279,11 +279,9 @@ def test_readout_compensation():
     assert np.isclose(zm[1, 1, 1], 1.0)
 
 
-@mock.patch("pyquil.api._abstract_compiler.AbstractCompiler")
-@mock.patch("pyquil.api.QuantumComputer")
-def test_estimate_assignment_probs(mock_qc_class: mock.MagicMock, mock_compiler_class: mock.MagicMock):
-    mock_qc = mock_qc_class.return_value
-    mock_compiler = mock_compiler_class.return_value
+def test_estimate_assignment_probs(mocker: MockerFixture):
+    mock_qc = mocker.patch("pyquil.api.QuantumComputer").return_value
+    mock_compiler = mocker.patch("pyquil.api._abstract_compiler.AbstractCompiler").return_value
 
     trials = 100
     p00 = 0.8

--- a/test/unit/test_qpu_client.py
+++ b/test/unit/test_qpu_client.py
@@ -13,16 +13,15 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-import time
 from datetime import datetime, timedelta
-from typing import Any, Dict
 from unittest import mock
 
 import pytest
 import rpcq
 from dateutil.tz import tzutc
-from pytest import raises
+from pytest_mock import MockerFixture
 from qcs_api_client.models import EngagementWithCredentials, EngagementCredentials
+from rpcq.messages import QPURequest
 
 from pyquil.api._qpu_client import (
     QPUClient,
@@ -32,7 +31,7 @@ from pyquil.api._qpu_client import (
     RunProgramRequest,
     RunProgramResponse,
 )
-from test.unit.utils import run_rpcq_server
+from test.unit.utils import patch_rpc_client
 
 
 def test_init__sets_processor_and_timeout(mock_engagement_manager: mock.MagicMock):
@@ -49,8 +48,7 @@ def test_init__sets_processor_and_timeout(mock_engagement_manager: mock.MagicMoc
 def test_run_program__returns_job_info(
     mock_engagement_manager: mock.MagicMock,
     engagement_credentials: EngagementCredentials,
-    rpcq_server_with_auth: rpcq.Server,
-    port: int,
+    mocker: MockerFixture,
 ):
     qpu_client = QPUClient(quantum_processor_id="some-processor", engagement_manager=mock_engagement_manager)
 
@@ -58,231 +56,205 @@ def test_run_program__returns_job_info(
         quantum_processor_id="some-processor",
         seconds_left=10,
         credentials=engagement_credentials,
-        port=port,
+        port=1234,
     )
 
-    @rpcq_server_with_auth.rpc_handler
-    def execute_qpu_request(request: rpcq.messages.QPURequest, user: str, priority: int) -> str:
-        assert request == rpcq.messages.QPURequest(
+    client = patch_rpc_client(mocker=mocker, return_value="some-job")
+    request = RunProgramRequest(
+        id="some-qpu-request",
+        priority=1,
+        program="encrypted-program",
+        patch_values={"foo": [42]},
+    )
+    assert qpu_client.run_program(request) == RunProgramResponse(job_id="some-job")
+    client.call.assert_called_once_with(
+        "execute_qpu_request",
+        request=rpcq.messages.QPURequest(
             id="some-qpu-request",
             program="encrypted-program",
             patch_values={"foo": [42]},
-        )
-        # NOTE: user no longer needs to be passed to server by client-under-test, but we still need to ensure the mock
-        # handler signature matches that of the server
-        assert user is None
-        assert priority == 1
-        return "some-job"
-
-    with run_rpcq_server(rpcq_server_with_auth, port):
-        request = RunProgramRequest(
-            id="some-qpu-request",
-            priority=1,
-            program="encrypted-program",
-            patch_values={"foo": [42]},
-        )
-        assert qpu_client.run_program(request) == RunProgramResponse(job_id="some-job")
+        ),
+        priority=request.priority,
+        user=None,
+    )
 
 
 def test_get_buffers__returns_buffers_for_job(
     mock_engagement_manager: mock.MagicMock,
     engagement_credentials: EngagementCredentials,
-    rpcq_server_with_auth: rpcq.Server,
-    port: int,
+    mocker: MockerFixture,
 ):
     qpu_client = QPUClient(quantum_processor_id="some-processor", engagement_manager=mock_engagement_manager)
-
     mock_engagement_manager.get_engagement.return_value = engagement(
         quantum_processor_id="some-processor",
         seconds_left=10,
         credentials=engagement_credentials,
-        port=port,
+        port=1234,
+    )
+    client = patch_rpc_client(mocker=mocker, return_value={
+        "ro": {
+            "shape": (1000, 2),
+            "dtype": "float64",
+            "data": b"buffer-data",
+        },
+    })
+    job_id = "some-job"
+    wait = True
+    request = GetBuffersRequest(
+        job_id=job_id,
+        wait=wait,
     )
 
-    @rpcq_server_with_auth.rpc_handler
-    def get_buffers(job_id: str, wait: bool) -> Dict[str, Any]:
-        assert job_id == "some-job"
-        assert wait is True
-        return {
-            "ro": {
-                "shape": (1000, 2),
-                "dtype": "float64",
-                "data": b"buffer-data",
-            },
+    assert qpu_client.get_buffers(request) == GetBuffersResponse(
+        buffers={
+            "ro": BufferResponse(
+                shape=(1000, 2),
+                dtype="float64",
+                data=b"buffer-data",
+            )
         }
-
-    with run_rpcq_server(rpcq_server_with_auth, port):
-        request = GetBuffersRequest(
-            job_id="some-job",
-            wait=True,
-        )
-        assert qpu_client.get_buffers(request) == GetBuffersResponse(
-            buffers={
-                "ro": BufferResponse(
-                    shape=(1000, 2),
-                    dtype="float64",
-                    data=b"buffer-data",
-                )
-            }
-        )
+    )
+    client.call.assert_called_once_with(
+        "get_buffers",
+        job_id=job_id,
+        wait=wait,
+    )
 
 
 def test_fetches_engagement_for_quantum_processor_on_request(
     mock_engagement_manager: mock.MagicMock,
     engagement_credentials: EngagementCredentials,
-    rpcq_server_with_auth: rpcq.Server,
-    port: int,
+    mocker: MockerFixture,
 ):
+    processor_id = "some-processor"
     qpu_client = QPUClient(
-        quantum_processor_id="some-processor",
+        quantum_processor_id=processor_id,
         engagement_manager=mock_engagement_manager,
         request_timeout=3.14,
     )
-
-    def mock_get_engagement(quantum_processor_id: str, request_timeout: float) -> EngagementWithCredentials:
-        assert quantum_processor_id == "some-processor"
-        assert request_timeout == qpu_client.timeout
-        return engagement(
-            quantum_processor_id="some-processor",
+    mock_engagement_manager.get_engagement.return_value = engagement(
+            quantum_processor_id=processor_id,
             seconds_left=9999,
             credentials=engagement_credentials,
-            port=port,
+            port=1234,
         )
 
-    mock_engagement_manager.get_engagement.side_effect = mock_get_engagement
+    patch_rpc_client(mocker=mocker, return_value="")
 
-    @rpcq_server_with_auth.rpc_handler
-    def execute_qpu_request(request: rpcq.messages.QPURequest, user: str, priority: int):
-        return ""
+    request = RunProgramRequest(
+        id="",
+        priority=0,
+        program="",
+        patch_values={},
+    )
+    qpu_client.run_program(request)
+    mock_engagement_manager.get_engagement.assert_called_once_with(
+        quantum_processor_id=processor_id,
+        request_timeout=qpu_client.timeout,
+    )
 
-    with run_rpcq_server(rpcq_server_with_auth, port):
-        request = RunProgramRequest(
-            id="",
-            priority=0,
-            program="",
-            patch_values={},
-        )
-        qpu_client.run_program(request)
 
-
-def test_sets_timeout_on_requests__engagement_expires_later(
+def test__calculate_timeout_engagement_is_longer_than_timeout(
     mock_engagement_manager: mock.MagicMock,
     engagement_credentials: EngagementCredentials,
-    rpcq_server_with_auth: rpcq.Server,
-    port: int,
 ):
     """
     Tests that the original request timeout is honored when time until engagement expiration is longer than timeout.
     """
+    client_timeout = 0.1
     qpu_client = QPUClient(
         quantum_processor_id="some-processor",
         engagement_manager=mock_engagement_manager,
-        request_timeout=0.1,
+        request_timeout=client_timeout,
     )
-
-    mock_engagement_manager.get_engagement.return_value = engagement(
+    _engagement = engagement(
         quantum_processor_id="some-processor",
         seconds_left=qpu_client.timeout * 10,
         credentials=engagement_credentials,
-        port=port,
+        port=1234,
     )
+    mock_engagement_manager.get_engagement.return_value = _engagement
 
-    @rpcq_server_with_auth.rpc_handler
-    def execute_qpu_request(request: rpcq.messages.QPURequest, user: str, priority: int):
-        time.sleep(qpu_client.timeout * 2)
-
-    with run_rpcq_server(rpcq_server_with_auth, port):
-        with raises(TimeoutError, match=f"Timeout on client tcp://localhost:{port}, method name execute_qpu_request"):
-            request = RunProgramRequest(
-                id="",
-                priority=0,
-                program="",
-                patch_values={},
-            )
-            qpu_client.run_program(request)
+    assert qpu_client._calculate_timeout(engagement=_engagement) == client_timeout
 
 
-def test_sets_timeout_on_requests__engagement_expires_sooner(
+def test__calculate_timeout_engagement_is_shorter_than_timeout(
+    freezer,  # This freezes time so that timeout can be compared with ==
     mock_engagement_manager: mock.MagicMock,
     engagement_credentials: EngagementCredentials,
-    rpcq_server_with_auth: rpcq.Server,
-    port: int,
 ):
     """
     Tests that the original request timeout is truncated when time until engagement expiration is sooner than timeout.
     """
+    mock_engagement_manager.get_engagement.return_value = {}
+    client_timeout = 1.0
+    seconds_left = 0.5
     qpu_client = QPUClient(
         quantum_processor_id="some-processor",
         engagement_manager=mock_engagement_manager,
-        request_timeout=1.0,
+        request_timeout=client_timeout,
     )
-
-    engagement_seconds_left = qpu_client.timeout / 10
-    mock_engagement_manager.get_engagement.return_value = engagement(
+    _engagement = engagement(
         quantum_processor_id="some-processor",
-        seconds_left=engagement_seconds_left,
+        seconds_left=seconds_left,
         credentials=engagement_credentials,
-        port=port,
+        port=1234,
     )
+    mock_engagement_manager.get_engagement.return_value = _engagement
 
-    @rpcq_server_with_auth.rpc_handler
-    def execute_qpu_request(request: rpcq.messages.QPURequest, user: str, priority: int):
-        time.sleep(engagement_seconds_left * 2)
-
-    with run_rpcq_server(rpcq_server_with_auth, port):
-        with raises(TimeoutError, match=f"Timeout on client tcp://localhost:{port}, method name execute_qpu_request"):
-            request = RunProgramRequest(
-                id="",
-                priority=0,
-                program="",
-                patch_values={},
-            )
-            qpu_client.run_program(request)
+    assert qpu_client._calculate_timeout(engagement=_engagement) == seconds_left
 
 
-def test_handles_contiguous_engagements(
+def test_run_program__retries_on_timeout(
     mock_engagement_manager: mock.MagicMock,
     engagement_credentials: EngagementCredentials,
-    rpcq_server_with_auth: rpcq.Server,
-    port: int,
+    mocker: MockerFixture,
 ):
-    """Test that a request crossing the boundary between two contiguous engagements can successfully complete."""
+    """Test that if a program times out, it will be retried.
 
+    A real-world example is a request crossing the boundary between two contiguous engagements.
+    """
+
+    # SETUP
+    processor_id = "some-processor"
+    job_id = "some-job"
     qpu_client = QPUClient(
-        quantum_processor_id="some-processor",
+        quantum_processor_id=processor_id,
         engagement_manager=mock_engagement_manager,
         request_timeout=1.0,
     )
-
-    first_engagement_seconds_left = qpu_client.timeout / 10
-    mock_engagement_manager.get_engagement.side_effect = [
-        engagement(
-            quantum_processor_id="some-processor",
-            seconds_left=first_engagement_seconds_left,
+    mock_engagement_manager.get_engagement.return_value = engagement(
+            quantum_processor_id=processor_id,
+            seconds_left=0,
             credentials=engagement_credentials,
-            port=port,
-        ),
-        engagement(
-            quantum_processor_id="some-processor",
-            seconds_left=9999,
-            credentials=engagement_credentials,
-            port=port,
-        ),
-    ]
-
-    @rpcq_server_with_auth.rpc_handler
-    def execute_qpu_request(request: rpcq.messages.QPURequest, user: str, priority: int):
-        time.sleep(first_engagement_seconds_left * 2)
-        return "some-job"
-
-    with run_rpcq_server(rpcq_server_with_auth, port):
-        request = RunProgramRequest(
-            id="",
-            priority=0,
-            program="",
-            patch_values={},
+            port=1234,
         )
-        assert qpu_client.run_program(request) == RunProgramResponse(job_id="some-job")
+    client = patch_rpc_client(mocker=mocker, return_value=None)
+    client.call.side_effect = [
+        TimeoutError,  # First request must look like it timed out so we can verify retry
+        job_id,
+    ]
+    request_kwargs = {"id": "TestingContiguous", "patch_values": {}, "program": ""}
+    request = RunProgramRequest(  # Thing we give to QPUClient
+        priority=0,
+        **request_kwargs,
+    )
+    qpu_request = QPURequest(**request_kwargs)  # Thing QPUClient gives to rpcq.Client
+
+    # ACT
+    assert qpu_client.run_program(request) == RunProgramResponse(job_id=job_id)
+
+    # ASSERT
+    # Engagement should be fetched twice, once per RPC call
+    mock_engagement_manager.get_engagement.assert_has_calls([
+        mocker.call(quantum_processor_id='some-processor', request_timeout=1.0),
+        mocker.call(quantum_processor_id='some-processor', request_timeout=1.0),
+    ])
+    # RPC call should happen twice since the first one times out
+    client.call.assert_has_calls([
+        mocker.call("execute_qpu_request", request=qpu_request, priority=0, user=None),
+        mocker.call("execute_qpu_request", request=qpu_request, priority=0, user=None),
+    ])
 
 
 def engagement(
@@ -299,6 +271,6 @@ def engagement(
 
 
 @pytest.fixture()
-@mock.patch("pyquil.api.EngagementManager", autospec=True)
-def mock_engagement_manager(mock_engagement_manager_class: mock.MagicMock) -> mock.MagicMock:
+def mock_engagement_manager(mocker: MockerFixture) -> mock.MagicMock:
+    mock_engagement_manager_class = mocker.patch("pyquil.api.EngagementManager", autospec=True)
     return mock_engagement_manager_class.return_value

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -17,8 +17,8 @@ SERVER_PUBLIC_KEY = "rq:rM>}U?@Lns47E1%kR.o@n%FcmmsL/@{H8]yf7"
 SERVER_SECRET_KEY = "JTKVSB%%)wK0E.X)V>+}o?pNmC{O&4W4b!Ni{Lh6"
 
 
-def patch_rpc_client(*, mocker: MockerFixture, return_value: Any) -> MagicMock:
-    """Patch rpc.Client and return the MagicMock object it's patched with.
+def patch_rpcq_client(*, mocker: MockerFixture, return_value: Any) -> MagicMock:
+    """Patch rpcq.Client and return the MagicMock object it's patched with.
 
     :param return_value: The response that should come back from calling client.call()
     :return the instance of MagicMock standing in for rpc.Client that other functions will use.


### PR DESCRIPTION
Description
-----------

Occasionally an issue will come up in CI where tests will fail trying to bind to ports for running a local RPCQ server. This server was effectively mocking the responses of anyway, so this PR changes techniques to instead patch the RPC client to mock the response earlier.

I know that both @ameyer-rigetti and @kalzoo have suffered from this in, CI, and @ameyer-rigetti is already aware of these changes, so I'm adding you both as reviewers.

One change I'm not totally convinced of is the test to `_calculate_timeout`. Generally I don't like testing internal methods, but checking the timeouts via only public methods requires a lot of setup and introspection which isn't much better. I'd love to get some opinions on the con of testing an internal method vs a much longer and harder to read test.

If this one is merged then they'll be no need for #1348 anymore.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on [Travis CI][travis].
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- []x (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, gh-xxx).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
[travis]: https://travis-ci.org/rigetti/pyquil
