### PR TITLE
Fix/parametric compilation

### DIFF
--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -153,6 +153,8 @@ class QPU(QAM[QPUExecuteResponse]):
         job descriptor which should be passed directly to ``QPU.get_result`` to retrieve
         results.
         """
+        executable = executable.copy()
+
         assert isinstance(
             executable, EncryptedProgram
         ), "QPU#execute requires an rpcq.EncryptedProgram. Create one with QuantumComputer#compile"

--- a/pyquil/api/_qvm.py
+++ b/pyquil/api/_qvm.py
@@ -21,7 +21,6 @@ from qcs_api_client.client import QCSClientConfiguration
 
 from pyquil._version import pyquil_version
 from pyquil.api import QuantumExecutable
-
 from pyquil.api._qam import QAM, QAMExecutionResult
 from pyquil.api._qvm_client import (
     QVMClient,
@@ -127,6 +126,7 @@ http://pyquil.readthedocs.io/en/latest/noise_models.html#support-for-noisy-gates
         """
         Synchronously execute the input program to completion.
         """
+        executable = executable.copy()
 
         if not isinstance(executable, Program):
             raise TypeError(f"`QVM#executable` argument must be a `Program`; got {type(executable)}")

--- a/pyquil/compatibility/v2/api/_qam.py
+++ b/pyquil/compatibility/v2/api/_qam.py
@@ -23,7 +23,7 @@ class StatefulQAM(QAM[T]):
             qam.reset()
 
     def load(self, executable: QuantumExecutable) -> "StatefulQAM[T]":
-        self._loaded_executable = executable.copy()
+        self._loaded_executable = executable.copy()  # copy here because calls to self.write_memory() will mutate it
         return self
 
     def read_memory(self, region_name: str) -> Optional[np.ndarray]:


### PR DESCRIPTION
Fix execution of parametric programs.

Programs were aggregating all parameter settings, instead of just one. Starting execution with a fresh copy of the program fixes this.