### PR TITLE
Fix: allow np.ndarray in write_memory and disallow non-int and non-fl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-[next](https://github.com/rigetti/pyquil/compare/master..rc) (In development)
+[next](https://github.com/rigetti/pyquil/compare/v3.0.0..master) (In development)
 ------------------------------------------------------------------------------------
 
 ### Announcements
@@ -9,6 +9,8 @@ Changelog
 ### Improvements and Changes
 
 ### Bugfixes
+
+- Allow `np.ndarray` when writing QAM memory. Disallow non-integer and non-float types.
 
 [v3.0.0](https://github.com/rigetti/pyquil/releases/tag/v3.0.0)
 ------------------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-[next](https://github.com/rigetti/pyquil/compare/v3.0.0..master) (In development)
+[next](https://github.com/rigetti/pyquil/compare/master..rc) (In development)
 ------------------------------------------------------------------------------------
 
 ### Announcements

--- a/pyquil/_memory.py
+++ b/pyquil/_memory.py
@@ -46,14 +46,20 @@ class Memory:
         if isinstance(parameter, str):
             parameter = ParameterAref(name=parameter, index=0)
 
+        import numpy as np
+
         if isinstance(value, (int, float)):
             self.values[parameter] = value
-        elif isinstance(value, Sequence):
+        elif isinstance(value, (Sequence, np.ndarray)):
             if parameter.index != 0:
                 raise ValueError("Parameter may not have a non-zero index when its value is a sequence")
 
             for index, v in enumerate(value):
+                if not isinstance(v, (int, float)):
+                    raise TypeError(f"Parameter must be numeric, not {type(value)}")
                 aref = ParameterAref(name=parameter.name, index=index)
                 self.values[aref] = v
+        else:
+            raise TypeError(f"Parameter must be numeric or an iterable of numeric values, not {type(value)}")
 
         return self

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -493,7 +493,7 @@ def test_run_with_bad_parameters(client_configuration: QCSClientConfiguration, p
         MEASURE(0, MemoryReference("ro")),
     ).wrap_in_numshots_loop(1000)
 
-    with pytest.raises(TypeError, match="Parameter must be numeric or an iterable of numeric values"):
+    with pytest.raises(TypeError, match=r"Parameter must be"):
         executable.write_memory(region_name="theta", value=param)
 
 

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -493,7 +493,7 @@ def test_run_with_bad_parameters(client_configuration: QCSClientConfiguration, p
         MEASURE(0, MemoryReference("ro")),
     ).wrap_in_numshots_loop(1000)
 
-    with pytest.raises(TypeError, matches="Parameter must be numeric or an iterable of numeric values"):
+    with pytest.raises(TypeError, match="Parameter must be numeric or an iterable of numeric values"):
         executable.write_memory(region_name="theta", value=param)
 
 

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -456,7 +456,7 @@ def test_qc_error(client_configuration: QCSClientConfiguration):
         get_qc("5q", as_qvm=False, client_configuration=client_configuration)
 
 
-@pytest.mark.parametrize("param", [1, np.pi, [np.pi], np.array([np.pi])])
+@pytest.mark.parametrize("param", [np.pi, [np.pi], np.array([np.pi])])
 def test_run_with_parameters(client_configuration: QCSClientConfiguration, param):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(3))
     qc = QuantumComputer(

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -456,7 +456,8 @@ def test_qc_error(client_configuration: QCSClientConfiguration):
         get_qc("5q", as_qvm=False, client_configuration=client_configuration)
 
 
-def test_run_with_parameters(client_configuration: QCSClientConfiguration):
+@pytest.mark.parametrize("param", [np.pi, [np.pi], np.array([np.pi])])
+def test_run_with_parameters(client_configuration: QCSClientConfiguration, param):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(3))
     qc = QuantumComputer(
         name="testy!",
@@ -470,11 +471,30 @@ def test_run_with_parameters(client_configuration: QCSClientConfiguration):
         MEASURE(0, MemoryReference("ro")),
     ).wrap_in_numshots_loop(1000)
 
-    executable.write_memory(region_name="theta", value=np.pi)
+    executable.write_memory(region_name="theta", value=param)
     bitstrings = qc.run(executable).readout_data.get('ro')
 
     assert bitstrings.shape == (1000, 1)
     assert all([bit == 1 for bit in bitstrings])
+
+
+@pytest.mark.parametrize("param", [1j, "np.pi", ["np.pi"]])
+def test_run_with_bad_parameters(client_configuration: QCSClientConfiguration, param):
+    quantum_processor = NxQuantumProcessor(nx.complete_graph(3))
+    qc = QuantumComputer(
+        name="testy!",
+        qam=QVM(client_configuration=client_configuration),
+        compiler=DummyCompiler(quantum_processor=quantum_processor, client_configuration=client_configuration),
+    )
+    executable = Program(
+        Declare(name="theta", memory_type="REAL"),
+        Declare(name="ro", memory_type="BIT"),
+        RX(MemoryReference("theta"), 0),
+        MEASURE(0, MemoryReference("ro")),
+    ).wrap_in_numshots_loop(1000)
+
+    with pytest.raises(TypeError):
+        executable.write_memory(region_name="theta", value=param)
 
 
 def test_reset(client_configuration: QCSClientConfiguration):

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -456,7 +456,7 @@ def test_qc_error(client_configuration: QCSClientConfiguration):
         get_qc("5q", as_qvm=False, client_configuration=client_configuration)
 
 
-@pytest.mark.parametrize("param", [np.pi, [np.pi], np.array([np.pi])])
+@pytest.mark.parametrize("param", [1, np.pi, [np.pi], np.array([np.pi])])
 def test_run_with_parameters(client_configuration: QCSClientConfiguration, param):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(3))
     qc = QuantumComputer(
@@ -478,7 +478,7 @@ def test_run_with_parameters(client_configuration: QCSClientConfiguration, param
     assert all([bit == 1 for bit in bitstrings])
 
 
-@pytest.mark.parametrize("param", [1j, "np.pi", ["np.pi"]])
+@pytest.mark.parametrize("param", [1j, "not_a_number", ["not_a_number"]])
 def test_run_with_bad_parameters(client_configuration: QCSClientConfiguration, param):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(3))
     qc = QuantumComputer(
@@ -493,7 +493,7 @@ def test_run_with_bad_parameters(client_configuration: QCSClientConfiguration, p
         MEASURE(0, MemoryReference("ro")),
     ).wrap_in_numshots_loop(1000)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, matches="Parameter must be numeric or an iterable of numeric values"):
         executable.write_memory(region_name="theta", value=param)
 
 


### PR DESCRIPTION
…oat types

Description
-----------

Closes #1364 

Checklist
---------

- [x] The PR targets the `rc` branch (**not** `master`).
- [x] Commit messages are prefixed with one of the prefixes outlined in the [commit syntax checker][commit-syntax] (see `pattern` field).
- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on the PR's checks.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[commit-syntax]: https://github.com/rigetti/pyquil/blob/master/.github/workflows/commit_syntax.yml
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
