### PR TITLE
Add support for memory references in substitute() method

### DIFF
--- a/test/unit/test_memory.py
+++ b/test/unit/test_memory.py
@@ -47,39 +47,37 @@ def test_pauli_term_to_measurement_memory_map():
 
 
 def test_substitute_memory_reference():
-    x = MemoryReference("x", 0, declared_size=2)
     x_0 = MemoryReference("x", 0, declared_size=2)
     x_1 = MemoryReference("x", 1, declared_size=2)
 
     # complete substitutions
 
-    assert substitute(x_0, {x: [+5, -5]}) == +5
-    assert substitute(x_1, {x: [+5, -5]}) == -5
+    assert substitute(x_0, {x_0: 5}) == 5
 
-    assert substitute(x_0 + x_1, {x: [+5, -5]}) == 0
-    assert substitute(x_0 - x_1, {x: [+5, -5]}) == 10
-    assert substitute(x_0 * x_1, {x: [+5, -5]}) == -25
-    assert substitute(x_0 / x_1, {x: [+5, -5]}) == -1
+    assert substitute(x_0 + x_1, {x_0: +5, x_1: -5}) == 0
+    assert substitute(x_0 - x_1, {x_0: +5, x_1: -5}) == 10
+    assert substitute(x_0 * x_1, {x_0: +5, x_1: -5}) == -25
+    assert substitute(x_0 / x_1, {x_0: +5, x_1: -5}) == -1
 
-    assert substitute(x_0 * x_0 ** 2 / x_1, {x: [5, 10]}) == 12.5
+    assert substitute(x_0 * x_0 ** 2 / x_1, {x_0: 5, x_1: 10}) == 12.5
 
-    assert np.isclose(substitute(quil_exp(x_0), {x: [5, 10]}), np.exp(5))
-    assert np.isclose(substitute(quil_sin(x_0), {x: [5, 10]}), np.sin(5))
-    assert np.isclose(substitute(quil_cos(x_0), {x: [5, 10]}), np.cos(5))
-    assert np.isclose(substitute(quil_sqrt(x), {x: [5, 10]}), np.sqrt(5))
-    assert np.isclose(substitute(quil_cis(x), {x: [5, 10]}), np.exp(1j * 5.0))
+    assert np.isclose(substitute(quil_exp(x_0), {x_0: 5, x_1: 10}), np.exp(5))
+    assert np.isclose(substitute(quil_sin(x_0), {x_0: 5, x_1: 10}), np.sin(5))
+    assert np.isclose(substitute(quil_cos(x_0), {x_0: 5, x_1: 10}), np.cos(5))
+    assert np.isclose(substitute(quil_sqrt(x_0), {x_0: 5, x_1: 10}), np.sqrt(5))
+    assert np.isclose(substitute(quil_cis(x_0), {x_0: 5, x_1: 10}), np.exp(1j * 5.0))
 
     # incomplete substitutions
 
     y = MemoryReference("y", 0, declared_size=1)
     z = MemoryReference("z", 0, declared_size=1)
 
-    assert substitute(y + z, {y: [5]}) == 5 + z
+    assert substitute(y + z, {y: 5}) == 5 + z
 
-    assert substitute(quil_cis(z), {y: [5]}) == quil_cis(z)
+    assert substitute(quil_cis(z), {y: 5}) == quil_cis(z)
 
     # array substitution pass-through
 
     a = MemoryReference("a", 0, declared_size=1)
 
-    assert np.allclose(substitute_array([quil_sin(a), quil_cos(a)], {a: [5]}), [np.sin(5), np.cos(5)])
+    assert np.allclose(substitute_array([quil_sin(a), quil_cos(a)], {a: 5}), [np.sin(5), np.cos(5)])

--- a/test/unit/test_memory.py
+++ b/test/unit/test_memory.py
@@ -6,6 +6,16 @@ from pyquil.experiment._memory import (
     pauli_term_to_measurement_memory_map,
 )
 from pyquil.paulis import sX, sY
+from pyquil.quilatom import (
+    MemoryReference,
+    quil_cis,
+    quil_cos,
+    quil_exp,
+    quil_sin,
+    quil_sqrt,
+    substitute,
+    substitute_array,
+)
 
 
 def test_merge_memory_map_lists():
@@ -34,3 +44,42 @@ def test_pauli_term_to_measurement_memory_map():
         "measurement_beta": [0.0, np.pi / 2],
         "measurement_gamma": [0.0, -np.pi / 2],
     }
+
+
+def test_substitute_memory_reference():
+    x = MemoryReference("x", 0, declared_size=2)
+    x_0 = MemoryReference("x", 0, declared_size=2)
+    x_1 = MemoryReference("x", 1, declared_size=2)
+
+    # complete substitutions
+
+    assert substitute(x_0, {x: [+5, -5]}) == +5
+    assert substitute(x_1, {x: [+5, -5]}) == -5
+
+    assert substitute(x_0 + x_1, {x: [+5, -5]}) == 0
+    assert substitute(x_0 - x_1, {x: [+5, -5]}) == 10
+    assert substitute(x_0 * x_1, {x: [+5, -5]}) == -25
+    assert substitute(x_0 / x_1, {x: [+5, -5]}) == -1
+
+    assert substitute(x_0 * x_0 ** 2 / x_1, {x: [5, 10]}) == 12.5
+
+    assert np.isclose(substitute(quil_exp(x_0), {x: [5, 10]}), np.exp(5))
+    assert np.isclose(substitute(quil_sin(x_0), {x: [5, 10]}), np.sin(5))
+    assert np.isclose(substitute(quil_cos(x_0), {x: [5, 10]}), np.cos(5))
+    assert np.isclose(substitute(quil_sqrt(x), {x: [5, 10]}), np.sqrt(5))
+    assert np.isclose(substitute(quil_cis(x), {x: [5, 10]}), np.exp(1j * 5.0))
+
+    # incomplete substitutions
+
+    y = MemoryReference("y", 0, declared_size=1)
+    z = MemoryReference("z", 0, declared_size=1)
+
+    assert substitute(y + z, {y: [5]}) == 5 + z
+
+    assert substitute(quil_cis(z), {y: [5]}) == quil_cis(z)
+
+    # array substitution pass-through
+
+    a = MemoryReference("a", 0, declared_size=1)
+
+    assert np.allclose(substitute_array([quil_sin(a), quil_cos(a)], {a: [5]}), [np.sin(5), np.cos(5)])


### PR DESCRIPTION
Description
-----------

Addresses #1383 generally as suggested. However, because the identity of a memory reference (as a key- ie. its hash) includes the offset, and substitution is via a map using this key, it was easier to ask the user to address each offset to be substituted individually. Thus, conceptually, the substitution map is `{ x[0]: <number>, x[1]: <number>, x[2]: <number> }` for some array `x` of length 3.

I'm assuming there are no large-scale performance expectations on this new ability where the array access would make a difference. There is no impact on previous code paths. The alternative would be to use the names (strings) only as the key, but that would technically be a breaking change, where as this PR is not (the key is covariant to the previous `Parameter` class, and now also `MemoryReference`).

Checklist
---------

- [x] The PR targets the `rc` branch (**not** `master`).
- [ ] Commit messages are prefixed with one of the prefixes outlined in the [commit syntax checker][commit-syntax] (see `pattern` field).
- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on the PR's checks.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[commit-syntax]: https://github.com/rigetti/pyquil/blob/master/.github/workflows/commit_syntax.yml
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
