### PR TITLE
Fix calibration program typo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,6 +163,7 @@ Coverage:
 #  - TEST_PYPI_PASSWORD
 PyPI Publish Branch (TestPyPI):
   stage: deploy
+  allow_failure: true
   script:
     - . scripts/ci_install_deps
     - *install-dephell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog
 
 ### Bugfixes
 
+- Allow `np.ndarray` when writing QAM memory. Disallow non-integer and non-float types.
+
 [v3.0.0](https://github.com/rigetti/pyquil/releases/tag/v3.0.0)
 ------------------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 
 ### Improvements and Changes
 
+- Both `get_qc` and `QPU` now accept an `endpoint_id` argument which is used to engage
+  against a specific QCS [quantum processor endpoint](https://docs.api.qcs.rigetti.com/#tag/endpoints).
+
 ### Bugfixes
 
 - Allow `np.ndarray` when writing QAM memory. Disallow non-integer and non-float types.

--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -82,6 +82,30 @@ Below is an example that demonstrates how to use pyQuil in a multithreading scen
         print(f"Results for program {i}:\n{result}\n")
 
 
+Alternative QPU Endpoints
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Rigetti QCS supports alternative endpoints for access to a QPU architecture, useful for very particular cases.
+Generally, this is useful to call "mock" or test endpoints, which simulate the results of execution for the
+purposes of integration testing without the need for an active reservation or contention with other users.
+See the `QCS API Docs <https://docs.api.qcs.rigetti.com/#tag/endpoints>`_ for more information on QPU Endpoints.
+
+To be able to call these endpoints using pyQuil, enter the ``endpoint_id`` of your desired endpoint in one
+of the sites where ``quantum_processor_id`` is used:
+
+.. code:: python
+
+    # Option 1
+    qc = get_qc("Aspen-9", endpoint_id="my_endpoint")
+
+    # Option 2
+    qam = QPU("Aspen-9", endpoint_id="my_endpoint")
+
+After doing so, for all intents and purposes - compilation, optimization, etc - your program will behave the same
+as when using "default" endpoint for a given quantum processor, except that it will be executed by an
+alternate QCS service, and the results of execution should not be treated as correct or meaningful.
+
+
 Using Qubit Placeholders
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/quilt_getting_started.ipynb
+++ b/docs/source/quilt_getting_started.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cals = qc.compiler.calibration_program"
+    "cals = qc.compiler.get_calibration_program()"
    ]
   },
   {

--- a/docs/source/quilt_parametric.ipynb
+++ b/docs/source/quilt_parametric.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cals = qc.compiler.calibration_program"
+    "cals = qc.compiler.get_calibration_program()"
    ]
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4452,9 +4452,9 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
     },
     "trim-off-newlines": {
       "version": "1.0.1",

--- a/poetry.lock
+++ b/poetry.lock
@@ -904,21 +904,6 @@ freezegun = ">0.3"
 pytest = ">=3.0.0"
 
 [[package]]
-name = "pytest-httpx"
-version = "0.9.0"
-description = "Send responses to httpx."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-httpx = ">=0.15.0,<0.16.0"
-pytest = ">=6.0.0,<7.0.0"
-
-[package.extras]
-testing = ["pytest-asyncio (>=0.14.0,<0.15.0)", "pytest-cov (>=2.0.0,<3.0.0)"]
-
-[[package]]
 name = "pytest-mock"
 version = "3.6.1"
 description = "Thin-wrapper around the mock package for easier use with pytest"
@@ -1075,6 +1060,17 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+
+[[package]]
+name = "respx"
+version = "0.15.1"
+description = "A utility for mocking out the Python HTTPX and HTTP Core libraries."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+httpx = ">=0.15"
 
 [[package]]
 name = "retry"
@@ -1415,7 +1411,7 @@ latex = ["ipython"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "c059d449facf631a118d653669a4f0891da7d2a38e5402232bd5310045997975"
+content-hash = "050a9333fe1cc8e432323d9a4ca369d5b984da16a5b286a63d5ae10445cff067"
 
 [metadata.files]
 alabaster = [
@@ -1912,10 +1908,6 @@ pytest-freezegun = [
     {file = "pytest-freezegun-0.4.2.zip", hash = "sha256:19c82d5633751bf3ec92caa481fb5cffaac1787bd485f0df6436fd6242176949"},
     {file = "pytest_freezegun-0.4.2-py2.py3-none-any.whl", hash = "sha256:5318a6bfb8ba4b709c8471c94d0033113877b3ee02da5bfcd917c1889cde99a7"},
 ]
-pytest-httpx = [
-    {file = "pytest_httpx-0.9.0-py3-none-any.whl", hash = "sha256:f337cc19176600ed0615c5ec8390646306857d35ee49e5b662e68dfc0fc17dce"},
-    {file = "pytest_httpx-0.9.0.tar.gz", hash = "sha256:7bfcc9344e13f441068181fb909fc86a545f25b4343ad98de55c1327ab336bfd"},
-]
 pytest-mock = [
     {file = "pytest-mock-3.6.1.tar.gz", hash = "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"},
     {file = "pytest_mock-3.6.1-py3-none-any.whl", hash = "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3"},
@@ -2071,6 +2063,10 @@ regex = [
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
+]
+respx = [
+    {file = "respx-0.15.1-py2.py3-none-any.whl", hash = "sha256:07b69af4f127e6651ab0fd104a484bcb9d98b901b25234d4158851ff5a37e34a"},
+    {file = "respx-0.15.1.tar.gz", hash = "sha256:d3438b7ec2edb5a4f575c0ca5a51c37b9a55c42c6693d178a1917aeca290de7f"},
 ]
 retry = [
     {file = "retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyquil"
-version = "3.0.0"
+version = "3.0.1-rc.1"
 description = "A Python library for creating Quantum Instruction Language (Quil) programs."
 authors = ["Rigetti Computing <softapps@rigetti.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyquil"
-version = "3.0.1-rc.1"
+version = "3.0.1-rc.2"
 description = "A Python library for creating Quantum Instruction Language (Quil) programs."
 authors = ["Rigetti Computing <softapps@rigetti.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,13 +45,13 @@ black = "^20.8b1"
 flake8 = "^3.8.1"
 pytest = "^6.2.2"
 pytest-cov = "^2.11.1"
-pytest-httpx = "^0.9"
 mypy = "0.740"
 pytest-xdist = "^2.2.1"
 pytest-rerunfailures = "^9.1.1"
 pytest-timeout = "^1.4.2"
 pytest-mock = "^3.6.1"
 pytest-freezegun = "^0.4.2"
+respx = "^0.15"
 
 [tool.poetry.extras]
 latex = ["ipython"]

--- a/pyquil/_memory.py
+++ b/pyquil/_memory.py
@@ -46,14 +46,20 @@ class Memory:
         if isinstance(parameter, str):
             parameter = ParameterAref(name=parameter, index=0)
 
+        import numpy as np
+
         if isinstance(value, (int, float)):
             self.values[parameter] = value
-        elif isinstance(value, Sequence):
+        elif isinstance(value, (Sequence, np.ndarray)):
             if parameter.index != 0:
                 raise ValueError("Parameter may not have a non-zero index when its value is a sequence")
 
             for index, v in enumerate(value):
+                if not isinstance(v, (int, float)):
+                    raise TypeError(f"Parameter must be numeric, not {type(value)}")
                 aref = ParameterAref(name=parameter.name, index=index)
                 self.values[aref] = v
+        else:
+            raise TypeError(f"Parameter must be numeric or an iterable of numeric values, not {type(value)}")
 
         return self

--- a/pyquil/api/_engagement_manager.py
+++ b/pyquil/api/_engagement_manager.py
@@ -15,18 +15,24 @@
 ##############################################################################
 import threading
 from datetime import datetime
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import Dict, NamedTuple, Optional, TYPE_CHECKING
 
 from dateutil.parser import parse as parsedate
 from dateutil.tz import tzutc
 from qcs_api_client.client import QCSClientConfiguration
 from qcs_api_client.models import EngagementWithCredentials, CreateEngagementRequest
 from qcs_api_client.operations.sync import create_engagement
+from qcs_api_client.types import UNSET
 
 from pyquil.api._qcs_client import qcs_client
 
 if TYPE_CHECKING:
     import httpx
+
+
+class EngagementCacheKey(NamedTuple):
+    quantum_processor_id: str
+    endpoint_id: Optional[str]
 
 
 class EngagementManager:
@@ -44,28 +50,36 @@ class EngagementManager:
         :param client_configuration: Client configuration, used for refreshing engagements.
         """
         self._client_configuration = client_configuration
-        self._cached_engagements: Dict[str, EngagementWithCredentials] = {}
+        self._cached_engagements: Dict[EngagementCacheKey, EngagementWithCredentials] = {}
         self._lock = threading.Lock()
 
-    def get_engagement(self, *, quantum_processor_id: str, request_timeout: float = 10.0) -> EngagementWithCredentials:
+    def get_engagement(
+        self, *, quantum_processor_id: str, request_timeout: float = 10.0, endpoint_id: Optional[str] = None
+    ) -> EngagementWithCredentials:
         """
-        Gets an engagement for the given quantum processor. If an engagement was already fetched previously and
-        remains valid, it will be returned instead of creating a new engagement.
+        Gets an engagement for the given quantum processor endpoint.
+
+        If an engagement was already fetched previously and remains valid, it will be returned instead
+        of creating a new engagement.
 
         :param quantum_processor_id: Quantum processor being engaged.
         :param request_timeout: Timeout for request, in seconds.
+        :param endpoint_id: Optional ID of the endpoint to use for engagement. If provided, it must
+            correspond to an endpoint serving the provided Quantum Processor.
         :return: Fetched or cached engagement.
         """
+        key = EngagementCacheKey(quantum_processor_id, endpoint_id)
+
         with self._lock:
-            if not self._engagement_valid(self._cached_engagements.get(quantum_processor_id)):
+            if not self._engagement_valid(self._cached_engagements.get(key)):
                 with qcs_client(
                     client_configuration=self._client_configuration, request_timeout=request_timeout
                 ) as client:  # type: httpx.Client
-                    request = CreateEngagementRequest(quantum_processor_id=quantum_processor_id)
-                    self._cached_engagements[quantum_processor_id] = create_engagement(
-                        client=client, json_body=request
-                    ).parsed
-            return self._cached_engagements[quantum_processor_id]
+                    request = CreateEngagementRequest(
+                        quantum_processor_id=quantum_processor_id, endpoint_id=endpoint_id or UNSET
+                    )
+                    self._cached_engagements[key] = create_engagement(client=client, json_body=request).parsed
+            return self._cached_engagements[key]
 
     @staticmethod
     def _engagement_valid(engagement: Optional[EngagementWithCredentials]) -> bool:

--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -115,6 +115,7 @@ class QPU(QAM[QPUExecuteResponse]):
         timeout: float = 10.0,
         client_configuration: Optional[QCSClientConfiguration] = None,
         engagement_manager: Optional[EngagementManager] = None,
+        endpoint_id: Optional[str] = None,
     ) -> None:
         """
         A connection to the QPU.
@@ -123,10 +124,9 @@ class QPU(QAM[QPUExecuteResponse]):
         :param priority: The priority with which to insert jobs into the QPU queue. Lower integers
             correspond to higher priority.
         :param timeout: Time limit for requests, in seconds.
-        :param client_configuration: Optional client configuration. If none is provided, a default
-            one will be loaded.
-        :param engagement_manager: Optional engagement manager. If none is provided, a default one
-            will be created.
+        :param client_configuration: Optional client configuration. If none is provided, a default one will be loaded.
+        :param endpoint_id: Optional endpoint ID to be used for engagement.
+        :param engagement_manager: Optional engagement manager. If none is provided, a default one will be created.
         """
         super().__init__()
 
@@ -136,6 +136,7 @@ class QPU(QAM[QPUExecuteResponse]):
         engagement_manager = engagement_manager or EngagementManager(client_configuration=client_configuration)
         self._qpu_client = QPUClient(
             quantum_processor_id=quantum_processor_id,
+            endpoint_id=endpoint_id,
             engagement_manager=engagement_manager,
             request_timeout=timeout,
         )

--- a/pyquil/api/_qpu_client.py
+++ b/pyquil/api/_qpu_client.py
@@ -15,7 +15,7 @@
 ##############################################################################
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, cast, Tuple, Union, List, Any
+from typing import Dict, Optional, cast, Tuple, Union, List, Any
 
 import rpcq
 from dateutil.parser import parse as parsedate
@@ -104,6 +104,7 @@ class QPUClient:
         *,
         quantum_processor_id: str,
         engagement_manager: EngagementManager,
+        endpoint_id: Optional[str] = None,
         request_timeout: float = 10.0,
     ) -> None:
         """
@@ -114,6 +115,7 @@ class QPUClient:
         :param request_timeout: Timeout for requests, in seconds.
         """
         self.quantum_processor_id = quantum_processor_id
+        self._endpoint_id = endpoint_id
         self._engagement_manager = engagement_manager
         self.timeout = request_timeout
 
@@ -157,6 +159,7 @@ class QPUClient:
     @retry(exceptions=TimeoutError, tries=2)  # type: ignore
     def _rpcq_request(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
         engagement = self._engagement_manager.get_engagement(
+            endpoint_id=self._endpoint_id,
             quantum_processor_id=self.quantum_processor_id,
             request_timeout=self.timeout,
         )

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -725,6 +725,7 @@ def get_qc(
     compiler_timeout: float = 10.0,
     execution_timeout: float = 10.0,
     client_configuration: Optional[QCSClientConfiguration] = None,
+    endpoint_id: Optional[str] = None,
     engagement_manager: Optional[EngagementManager] = None,
 ) -> QuantumComputer:
     """
@@ -794,9 +795,12 @@ def get_qc(
     :param compiler_timeout: Time limit for compilation requests, in seconds.
     :param execution_timeout: Time limit for execution requests, in seconds.
     :param client_configuration: Optional client configuration. If none is provided, a default one will be loaded.
+    :param endpoint_id: Optional quantum processor endpoint ID, as used in the `QCS API Docs`_.
     :param engagement_manager: Optional engagement manager. If none is provided, a default one will be created.
 
     :return: A pre-configured QuantumComputer
+
+    .. _QCS API Docs: https://docs.api.qcs.rigetti.com/#tag/endpoints
     """
 
     client_configuration = client_configuration or QCSClientConfiguration.load()
@@ -862,6 +866,7 @@ def get_qc(
             quantum_processor_id=quantum_processor.quantum_processor_id,
             timeout=execution_timeout,
             client_configuration=client_configuration,
+            endpoint_id=endpoint_id,
             engagement_manager=engagement_manager,
         )
         compiler = QPUCompiler(

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -787,10 +787,10 @@ def get_qc(
         of the name's suffix
     :param noisy: An optional flag to force inclusion of a noise model. If
         specified and set to ``True``, a quantum computer with a noise model will be returned
-        regardless of the name's suffix. The noise model for QVMs based on a real QPU
-        is an empirically parameterized model based on real quantum_processor noise characteristics.
-        The generic QVM noise model is simple T1 and T2 noise plus readout error. See
-        :py:func:`~pyquil.noise.decoherence_noise_with_asymmetric_ro`.
+        regardless of the name's suffix. The generic QVM noise model is simple T1 and T2 noise
+        plus readout error. See :py:func:`~pyquil.noise.decoherence_noise_with_asymmetric_ro`.
+        Note, we currently do not support noise models based on QCS hardware; a value of
+        `True`` will result in an error if the requested QPU is a QCS hardware QPU.
     :param compiler_timeout: Time limit for compilation requests, in seconds.
     :param execution_timeout: Time limit for execution requests, in seconds.
     :param client_configuration: Optional client configuration. If none is provided, a default one will be loaded.

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name="pyquil",
-    version="3.0.0",
+    version="3.0.1-rc.1",
     description="A Python library for creating Quantum Instruction Language (Quil) programs.",
     python_requires="==3.*,>=3.7.0",
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name="pyquil",
-    version="3.0.1-rc.1",
+    version="3.0.1-rc.2",
     description="A Python library for creating Quantum Instruction Language (Quil) programs.",
     python_requires="==3.*,>=3.7.0",
     project_urls={
@@ -74,11 +74,11 @@ setup(
             "pytest==6.*,>=6.2.2",
             "pytest-cov==2.*,>=2.11.1",
             "pytest-freezegun==0.*,>=0.4.2",
-            "pytest-httpx==0.*,>=0.9.0",
             "pytest-mock==3.*,>=3.6.1",
             "pytest-rerunfailures==9.*,>=9.1.1",
             "pytest-timeout==1.*,>=1.4.2",
             "pytest-xdist==2.*,>=2.2.1",
+            "respx==0.*,>=0.15.0",
         ],
         "docs": [
             "nbsphinx==0.*,>=0.8.6",

--- a/test/unit/test_engagement_manager.py
+++ b/test/unit/test_engagement_manager.py
@@ -14,47 +14,93 @@
 #    limitations under the License.
 ##############################################################################
 import json
+from typing import List, Optional
 
-from pytest_httpx import HTTPXMock
-from qcs_api_client.models import EngagementWithCredentials, EngagementCredentials
-
-from pyquil.api._engagement_manager import EngagementManager
+import httpx
+import respx
 from pyquil.api import QCSClientConfiguration
+from pyquil.api._engagement_manager import EngagementManager
+from qcs_api_client.models import EngagementCredentials, EngagementWithCredentials
 
+DEFAULT_ENDPOINT_ID = "some-endpoint"
 
+@respx.mock
 def test_get_engagement__refreshes_engagement_when_cached_engagement_expired(
-    client_configuration: QCSClientConfiguration, httpx_mock: HTTPXMock
+    client_configuration: QCSClientConfiguration,
 ):
     engagement_manager = EngagementManager(client_configuration=client_configuration)
     cache_engagement(
-        engagement_manager, expired_engagement(quantum_processor_id="some-processor"), client_configuration, httpx_mock
+        engagement_manager, expired_engagement(quantum_processor_id="some-processor"), client_configuration,
     )
-    httpx_mock.add_response(
-        method="POST",
+    respx.post(
         url=f"{client_configuration.profile.api_url}/v1/engagements",
-        match_content=json.dumps({"quantumProcessorId": "some-processor"}).encode(),
-        json=unexpired_engagement(quantum_processor_id="some-processor").to_dict(),
-    )
+        json={"quantumProcessorId": "some-processor"},
+    ).respond(json=unexpired_engagement(quantum_processor_id="some-processor").to_dict())
 
     engagement = engagement_manager.get_engagement(quantum_processor_id="some-processor")
 
     assert engagement == unexpired_engagement(quantum_processor_id="some-processor")
 
 
+@respx.mock
+def test_get_engagement__refreshes_engagement_when_cached_engagement_expired__using_endpoint_id(
+    client_configuration: QCSClientConfiguration,
+):
+    """
+    Assert that endpoint ID is correctly used to engage against an endpoint when the cached engagement has expired.
+    """
+    engagement_manager = EngagementManager(client_configuration=client_configuration)
+    cache_engagement(
+        engagement_manager,
+        expired_engagement(quantum_processor_id="some-processor", endpoint_id="custom-endpoint"),
+        client_configuration,
+    )
+    respx.post(
+        url=f"{client_configuration.profile.api_url}/v1/engagements",
+        json={"quantumProcessorId": "some-processor", "endpointId": "custom-endpoint"},
+    ).respond(json=unexpired_engagement(quantum_processor_id="some-processor").to_dict())
+
+    engagement = engagement_manager.get_engagement(quantum_processor_id="some-processor")
+
+    assert engagement == unexpired_engagement(quantum_processor_id="some-processor")
+
+
+@respx.mock
 def test_get_engagement__reuses_engagement_when_cached_engagement_unexpired(
-    client_configuration: QCSClientConfiguration, httpx_mock: HTTPXMock
+    client_configuration: QCSClientConfiguration,
 ):
     engagement_manager = EngagementManager(client_configuration=client_configuration)
     cached_engagement = cache_engagement(
         engagement_manager,
         unexpired_engagement(quantum_processor_id="some-processor"),
         client_configuration,
-        httpx_mock,
     )
-    network_calls_before = len(httpx_mock.get_requests())
+    network_calls_before = respx.calls.call_count
 
     engagement = engagement_manager.get_engagement(quantum_processor_id="some-processor")
-    network_calls_after = len(httpx_mock.get_requests())
+    network_calls_after = respx.calls.call_count
+
+    assert network_calls_before == network_calls_after
+    assert engagement is cached_engagement
+
+
+@respx.mock
+def test_get_engagement__reuses_engagement_when_cached_engagement_unexpired__using_endpoint_id(
+    client_configuration: QCSClientConfiguration,
+):
+    """
+    Assert that endpoint ID is correctly used to engage against an endpoint.
+    """
+    engagement_manager = EngagementManager(client_configuration=client_configuration)
+    cached_engagement = cache_engagement(
+        engagement_manager,
+        unexpired_engagement(quantum_processor_id="some-processor", endpoint_id="custom-endpoint"),
+        client_configuration,
+    )
+    network_calls_before = respx.calls.call_count
+
+    engagement = engagement_manager.get_engagement(quantum_processor_id="some-processor", endpoint_id="custom-endpoint")
+    network_calls_after = respx.calls.call_count
 
     assert network_calls_before == network_calls_after
     assert engagement is cached_engagement
@@ -64,22 +110,42 @@ def cache_engagement(
     engagement_manager: EngagementManager,
     engagement: EngagementWithCredentials,
     client_configuration: QCSClientConfiguration,
-    httpx_mock: HTTPXMock,
 ) -> EngagementWithCredentials:
-    httpx_mock.add_response(
-        method="POST",
-        url=f"{client_configuration.profile.api_url}/v1/engagements",
-        match_content=json.dumps({"quantumProcessorId": engagement.quantum_processor_id}).encode(),
-        json=engagement.to_dict(),
-    )
+    mock_engagement(client_configuration=client_configuration, engagement=engagement)
 
-    cached_engagement = engagement_manager.get_engagement(quantum_processor_id=engagement.quantum_processor_id)
+    if engagement.endpoint_id == DEFAULT_ENDPOINT_ID:
+        endpoint_id = None
+    else:
+        endpoint_id = engagement.endpoint_id
+
+    cached_engagement = engagement_manager.get_engagement(
+        quantum_processor_id=engagement.quantum_processor_id, endpoint_id=endpoint_id
+    )
 
     assert cached_engagement == engagement
     return cached_engagement
 
 
-def make_engagement(*, quantum_processor_id: str, expires_at: str) -> EngagementWithCredentials:
+def mock_engagement(engagement: EngagementWithCredentials, *, client_configuration: QCSClientConfiguration):
+    """
+    Apply and respond with an engagement when it matches.
+    """
+
+    if engagement.endpoint_id == DEFAULT_ENDPOINT_ID:
+        respx.post(
+            url=f"{client_configuration.profile.api_url}/v1/engagements",
+            json={"quantumProcessorId": engagement.quantum_processor_id}
+        ).respond(json=engagement.to_dict())
+
+    respx.post(
+        url=f"{client_configuration.profile.api_url}/v1/engagements",
+        json={"endpointId": engagement.endpoint_id}
+    ).respond(json=engagement.to_dict())
+
+
+def make_engagement(
+    *, quantum_processor_id: str, endpoint_id: Optional[str] = None, expires_at: str
+) -> EngagementWithCredentials:
     return EngagementWithCredentials(
         address="tcp://example.com/qpu",
         credentials=EngagementCredentials(
@@ -87,7 +153,7 @@ def make_engagement(*, quantum_processor_id: str, expires_at: str) -> Engagement
             client_secret="client-secret-123",
             server_public="server-public-123",
         ),
-        endpoint_id="some-endpoint",
+        endpoint_id=endpoint_id or DEFAULT_ENDPOINT_ID,
         expires_at=expires_at,
         quantum_processor_id=quantum_processor_id,
         user_id="some-user",
@@ -95,9 +161,13 @@ def make_engagement(*, quantum_processor_id: str, expires_at: str) -> Engagement
     )
 
 
-def unexpired_engagement(*, quantum_processor_id: str) -> EngagementWithCredentials:
-    return make_engagement(quantum_processor_id=quantum_processor_id, expires_at="9999-01-01T00:00:00Z")
+def unexpired_engagement(*, quantum_processor_id: str, endpoint_id: Optional[str] = None) -> EngagementWithCredentials:
+    return make_engagement(
+        quantum_processor_id=quantum_processor_id, endpoint_id=endpoint_id, expires_at="9999-01-01T00:00:00Z"
+    )
 
 
-def expired_engagement(*, quantum_processor_id: str) -> EngagementWithCredentials:
-    return make_engagement(quantum_processor_id=quantum_processor_id, expires_at="1970-01-01T00:00:00Z")
+def expired_engagement(*, quantum_processor_id: str, endpoint_id: Optional[str] = None) -> EngagementWithCredentials:
+    return make_engagement(
+        quantum_processor_id=quantum_processor_id, endpoint_id=endpoint_id, expires_at="1970-01-01T00:00:00Z"
+    )


### PR DESCRIPTION
Description
-----------

Fix references to `qc.compiler.calibration_program` -> `qc.compiler.get_calibration_program()`

Checklist
---------

- [ ] The PR targets the `rc` branch (**not** `master`).
- [ ] Commit messages are prefixed with one of the prefixes outlined in the [commit syntax checker][commit-syntax] (see `pattern` field).
- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on the PR's checks.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[commit-syntax]: https://github.com/rigetti/pyquil/blob/master/.github/workflows/commit_syntax.yml
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
