### PR TITLE
No code: fix typo in documentation which used the old `.program` property

### DIFF
--- a/docs/source/compiler.rst
+++ b/docs/source/compiler.rst
@@ -57,7 +57,7 @@ as in the following:
 
     ep = qc.compile(Program(H(0), CNOT(0,1), CNOT(1,2)))
 
-    print(ep.program)
+    print(ep)
 
 with output
 
@@ -111,7 +111,7 @@ the previous example snippet is identical to the following:
     print(np.metadata)
 
     ep = qc.compiler.native_quil_to_executable(np)
-    print(ep.program)
+    print(ep)
 
 Timeouts
 --------
@@ -346,7 +346,7 @@ For example, consider running a ``CZ`` on non-neighboring qubits on a linear dev
    qc = _get_qvm_with_topology(name="line", topology=graph)
 
    p = Program(CZ(0, 2))
-   print(qc.compile(p).program)
+   print(qc.compile(p))
 
    CZ 2 1
 
@@ -368,7 +368,7 @@ inserting swaps. For example, the following program requires a ``SWAP`` that inc
    qc = _get_qvm_with_topology(name="line", topology=graph)
 
    p = Program(CZ(0, 1), H(0), CZ(1, 2), CZ(0, 2))
-   print(qc.compile(p).program)
+   print(qc.compile(p))
 
    CZ 2 1
    RX(-pi/2) 2
@@ -433,7 +433,7 @@ For example, if your program consists of two-qubit instructions where the qubits
    qc = get_qc("Aspen-X", as_qvm=True)
    p = Program(CZ(3, 4))
 
-   print(qc.compile(p).program)
+   print(qc.compile(p))
 
    CZ 3 4
 
@@ -452,7 +452,7 @@ partial strategy:
    qc = get_qc("Aspen-X", as_qvm=True)
    p = Program(CZ(3, 4))
 
-   print(qc.compile(p).program)
+   print(qc.compile(p))
 
    RZ(-pi/2) 0
    RX(pi/2) 0
@@ -485,7 +485,7 @@ compiling this program with naive rewiring will **not** move the ``CZ`` to a bet
    qc = get_qc("Aspen-X", as_qvm=True)
    p = Program('PRAGMA INITIAL_REWIRING "NAIVE"', CZ(0, 1))
 
-   print(qc.compile(p).program)
+   print(qc.compile(p))
 
    PRAGMA INITIAL_REWIRING "NAIVE"
    CZ 0 1
@@ -502,7 +502,7 @@ logical-physical qubit mapping. For example,
    qc = get_qc("Aspen-X", as_qvm=True)
    p = Program('PRAGMA INITIAL_REWIRING "NAIVE"', CZ(0, 2))
 
-   print(qc.compile(p).program)
+   print(qc.compile(p))
 
    PRAGMA INITIAL_REWIRING "NAIVE"
    CZ 6 5
@@ -534,7 +534,7 @@ the compiler can find an alternative that improves the program fidelity:
    qc = get_qc("Aspen-X", as_qvm=True)
    p = Program('PRAGMA INITIAL_REWIRING "PARTIAL"', CZ(0, 1))
 
-   print(qc.compile(p).program)
+   print(qc.compile(p))
 
    PRAGMA INITIAL_REWIRING "PARTIAL"
    CZ 20 27


### PR DESCRIPTION
Description
-----------

Closes #1394 

Checklist
---------

- [x] The PR targets the `rc` branch (**not** `master`).
- [x] Commit messages are prefixed with one of the prefixes outlined in the [commit syntax checker][commit-syntax] (see `pattern` field).
- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on the PR's checks.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[commit-syntax]: https://github.com/rigetti/pyquil/blob/master/.github/workflows/commit_syntax.yml
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
