### PR TITLE
pyproject: allow qcs-api-client >= 0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ lark = "^0.11.1"
 rpcq = "^3.6.0"
 networkx = "^2.5"
 importlib-metadata = { version = "^3.7.3", python = "<3.8" }
-qcs-api-client = "^0.8.0"
+qcs-api-client = ">=0.8.0, 0.*"
 retry = "^0.9.2"
 
 # latex extra


### PR DESCRIPTION
The pyproject version for qcs-api-client was malformatted, only allowed
qcs-api-client<0.9.0,>=0.8.0.
This will allow up to the latest version of qcs-api-client.
