### PR TITLE
Fix parse strings with spaces

### DIFF
--- a/pyquil/_parser/grammar.lark
+++ b/pyquil/_parser/grammar.lark
@@ -60,7 +60,7 @@ def_circuit : "DEFCIRCUIT" name [ variables ] [ qubit_designators ] ":" indented
 //             | "DEFCIRCUIT" name [ variables ] qubit_designators ":" indented_instrs -> def_circuit_qubits
 
 def_frame : "DEFFRAME" frame ( ":" frame_spec+ )?
-frame_spec : _NEWLINE_TAB frame_attr ":" (expression | "\"" name "\"" )
+frame_spec : _NEWLINE_TAB frame_attr ":" (expression | string )
 !frame_attr : "SAMPLE-RATE"
             | "INITIAL-FREQUENCY"
             | "DIRECTION"

--- a/pyquil/_parser/parser.py
+++ b/pyquil/_parser/parser.py
@@ -142,6 +142,9 @@ class QuilTransformer(Transformer):  # type: ignore
         for (spec_name, spec_value) in specs:
             name = names.get(spec_name, None)
             if name:
+                if isinstance(spec_value, str) and spec_value[0] == '"' and spec_value[-1] == '"':
+                    # Strip quotes if necessary
+                    spec_value = spec_value[1:-1]
                 options[name] = spec_value
             else:
                 raise ValueError(

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -684,3 +684,14 @@ H 0 # mid-line comment on second line
 )
 def test_parse_comments(program):
     Program(program)
+
+
+def test_parse_strings_with_spaces():
+    Program(str(Program("""
+DEFFRAME 0 "readout_tx":
+    DIRECTION: "tx"
+    INITIAL-FREQUENCY: 7220000000.0
+    CENTER-FREQUENCY: 7125000000
+    HARDWARE-OBJECT: "A_string_with_one space"
+    SAMPLE-RATE: 1000000000.0
+""")))


### PR DESCRIPTION
Description
-----------

Insert your PR description here. Thanks for [contributing][contributing] to pyQuil! 🙂

Checklist
---------

- [ ] The PR targets the `rc` branch (**not** `master`).
- [ ] Commit messages are prefixed with one of the prefixes outlined in the [commit syntax checker][commit-syntax] (see `pattern` field).
- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on the PR's checks.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[commit-syntax]: https://github.com/rigetti/pyquil/blob/master/.github/workflows/commit_syntax.yml
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
