### PR TITLE
Fix: Correctly apply the phase in quilwaveforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog
 
 - Allow `np.ndarray` when writing QAM memory. Disallow non-integer and non-float types.
 - Fix typo where `qc.compiler.calibration_program` should be `qc.compiler.get_calibration_program()`.
+- Fixed typo where `scale` was being used as the `phase` in generation of several waveforms.
 
 [v3.0.0](https://github.com/rigetti/pyquil/releases/tag/v3.0.0)
 ------------------------------------------------------------------------------------

--- a/pyquil/quiltwaveforms.py
+++ b/pyquil/quiltwaveforms.py
@@ -141,7 +141,7 @@ class GaussianWaveform(TemplateWaveform):
         ts = np.arange(self.num_samples(rate), dtype=np.complex128) / rate
         sigma = 0.5 * self.fwhm / np.sqrt(2.0 * np.log(2.0))
         iqs = np.exp(-0.5 * (ts - self.t0) ** 2 / sigma ** 2)
-        return _update_envelope(iqs, rate, scale=self.scale, phase=self.scale, detuning=self.detuning)
+        return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
 @waveform("drag_gaussian")
@@ -193,7 +193,7 @@ class DragGaussianWaveform(TemplateWaveform):
         env = np.exp(-0.5 * (ts - self.t0) ** 2 / sigma ** 2)
         env_der = (self.alpha * (1.0 / (2 * np.pi * self.anh * sigma ** 2))) * (ts - self.t0) * env
         iqs = env + 1.0j * env_der
-        return _update_envelope(iqs, rate, scale=self.scale, phase=self.scale, detuning=self.detuning)
+        return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
 @waveform("hrm_gaussian")
@@ -263,7 +263,7 @@ class HrmGaussianWaveform(TemplateWaveform):
             * (self.second_order_hrm_coeff * (exponent_of_t - 1) - 1)
         )
         iqs = env + 1.0j * env_der
-        return _update_envelope(iqs, rate, scale=self.scale, phase=self.scale, detuning=self.detuning)
+        return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
 @waveform("erf_square")
@@ -313,7 +313,7 @@ class ErfSquareWaveform(TemplateWaveform):
         zeros_left = np.zeros(int(np.ceil(self.pad_left * rate)), dtype=np.complex128)
         zeros_right = np.zeros(int(np.ceil(self.pad_left * rate)), dtype=np.complex128)
         iqs = np.concatenate((zeros_left, vals, zeros_right))
-        return _update_envelope(iqs, rate, scale=self.scale, phase=self.scale, detuning=self.detuning)
+        return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
 @waveform("boxcar_kernel")
@@ -340,4 +340,4 @@ class BoxcarAveragerKernel(TemplateWaveform):
     def samples(self, rate: float) -> np.ndarray:
         n = self.num_samples(rate)
         iqs = np.full(n, 1.0 / n, dtype=np.complex128)
-        return _update_envelope(iqs, rate, scale=self.scale, phase=self.scale, detuning=self.detuning)
+        return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)


### PR DESCRIPTION
See issue #1407: https://github.com/rigetti/pyquil/issues/1407

Description
-----------

Insert your PR description here. Thanks for [contributing][contributing] to pyQuil! 🙂

Checklist
---------

- [x] The PR targets the `rc` branch (**not** `master`).
- [ ] Commit messages are prefixed with one of the prefixes outlined in the [commit syntax checker][commit-syntax] (see `pattern` field).
- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on the PR's checks.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[commit-syntax]: https://github.com/rigetti/pyquil/blob/master/.github/workflows/commit_syntax.yml
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
