### PR TITLE
Docs: Fix Python syntax typo in docs/start.rst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changelog
 
 - Allow `np.ndarray` when writing QAM memory. Disallow non-integer and non-float types.
 - Fix typo where `qc.compiler.calibration_program` should be `qc.compiler.get_calibration_program()`.
-- Fix docs typo in `start.rst`, where an extra parentheses was present in a python code block.
+- Fix docs typo in `start.rst`, where an extra parentheses was present in a python code block (@ThomasMerkh).
 
 [v3.0.0](https://github.com/rigetti/pyquil/releases/tag/v3.0.0)
 ------------------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog
 
 - Allow `np.ndarray` when writing QAM memory. Disallow non-integer and non-float types.
 - Fix typo where `qc.compiler.calibration_program` should be `qc.compiler.get_calibration_program()`.
+- Fix docs typo in `start.rst`, where an extra parentheses was present in a python code block.
 
 [v3.0.0](https://github.com/rigetti/pyquil/releases/tag/v3.0.0)
 ------------------------------------------------------------------------------------

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -282,7 +282,7 @@ allows us to declare classical memory regions so that we can receive data from t
     .. code:: python
 
         from pyquil import get_qc, Program
-        from pyquil.gates import CNOT, Z, MEASURE, H
+        from pyquil.gates import CNOT, Z, MEASURE
         from pyquil.api import local_forest_runtime
         from pyquil.quilbase import Declare
 

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -282,7 +282,7 @@ allows us to declare classical memory regions so that we can receive data from t
     .. code:: python
 
         from pyquil import get_qc, Program
-        from pyquil.gates import CNOT, Z, MEASURE
+        from pyquil.gates import CNOT, Z, MEASURE, H
         from pyquil.api import local_forest_runtime
         from pyquil.quilbase import Declare
 
@@ -296,7 +296,7 @@ allows us to declare classical memory regions so that we can receive data from t
 
         with local_forest_runtime():
             qvm = get_qc('9q-square-qvm')
-            bitstrings = qvm.run(qvm.compile(prog))).readout_data.get("ro")
+            bitstrings = qvm.run(qvm.compile(prog)).readout_data.get("ro")
 
 Next, let's construct our Bell State.
 


### PR DESCRIPTION
Description
-----------
This PR removes an extra parentheses which was present in the python code block under Notes in [this section](https://pyquil-docs.rigetti.com/en/stable/start.html#run-your-first-program) of the getting started documentation.

Checklist
---------

- [x] The PR targets the `rc` branch (**not** `master`).
- [x] Commit messages are prefixed with one of the prefixes outlined in the [commit syntax checker][commit-syntax] (see `pattern` field).
- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on the PR's checks.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[commit-syntax]: https://github.com/rigetti/pyquil/blob/master/.github/workflows/commit_syntax.yml
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
