### PR TITLE
Upgrade: Expand qcs-api-client range to include 0.20.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog
 
 - Function `pyquil.quilatom.substitute()` now supports substitution of classical `MemoryReference`
   objects such as `theta[4]` with their parameter values, enabling user-side parameter substitution.
+- Versions of `qcs-api-client` up to 0.20.x are now supported.
 
 ### Bugfixes
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1005,7 +1005,7 @@ py = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qcs-api-client"
-version = "0.12.1"
+version = "0.20.10"
 description = "A client library for accessing the Rigetti QCS API"
 category = "main"
 optional = false
@@ -1411,7 +1411,7 @@ latex = ["ipython"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "1683a9b95fd848a2b2e40f1a6d47cd3b8eff4364d749c4f1dd8fdd958ed1c04d"
+content-hash = "5d98557a55fd54e7578339ad507f20c6d6782f72edf4f466defff4bed516a2f6"
 
 [metadata.files]
 alabaster = [
@@ -2022,8 +2022,8 @@ pyzmq = [
     {file = "pyzmq-22.1.0.tar.gz", hash = "sha256:7040d6dd85ea65703904d023d7f57fab793d7ffee9ba9e14f3b897f34ff2415d"},
 ]
 qcs-api-client = [
-    {file = "qcs-api-client-0.12.1.tar.gz", hash = "sha256:8767026c8e1e0ebedf55f93ef105758c04e19ee766f1b81e89a2c4442a6920b3"},
-    {file = "qcs_api_client-0.12.1-py3-none-any.whl", hash = "sha256:293c1c67eab21c59a2d16901760c454142afd2617381415c66d771aebc5727ec"},
+    {file = "qcs-api-client-0.20.10.tar.gz", hash = "sha256:4859884f43a3a29a90171c0470fb8a8e3524a50d6986ff5e12c4b877594ee837"},
+    {file = "qcs_api_client-0.20.10-py3-none-any.whl", hash = "sha256:8ba34444f623cb684b9ee6717c95490fbf20e2209856964c02c3e5578a4dc16c"},
 ]
 recommonmark = [
     {file = "recommonmark-0.7.1-py2.py3-none-any.whl", hash = "sha256:1b1db69af0231efce3fa21b94ff627ea33dee7079a01dd0a7f8482c3da148b3f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ lark = "^0.11.1"
 rpcq = "^3.6.0"
 networkx = "^2.5"
 importlib-metadata = { version = "^3.7.3", python = "<3.8" }
-qcs-api-client = ">=0.8.1,<0.13.0"
+qcs-api-client = ">=0.8.1,<0.21.0"
 retry = "^0.9.2"
 
 # latex extra


### PR DESCRIPTION
Description
-----------

Update the `qcs-api-client` requirements for #1421.

Checklist
---------

- [x] The PR targets the `rc` branch (**not** `master`).
- [x] Commit messages are prefixed with one of the prefixes outlined in the [commit syntax checker][commit-syntax] (see `pattern` field).
- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] All new and existing tests pass locally and on the PR's checks.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[commit-syntax]: https://github.com/rigetti/pyquil/blob/master/.github/workflows/commit_syntax.yml
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
