### PR TITLE
Fix: Docker qvm/quilc in `rigetti/forest` image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG python_version=3.7
 # use multi-stage builds to independently pull dependency versions
 FROM rigetti/quilc:$quilc_version as quilc
 FROM rigetti/qvm:$qvm_version as qvm
-FROM python:$python_version
+FROM python:$python_version-buster
 
 ARG pyquil_version
 


### PR DESCRIPTION
Description
-----------

Currently, the latest `rigetti/forest` image fails to start `quilc` or `qvm` with the same error seen on Ubuntu in #1434. The fix is simply specifying the version of Debian that comes with the right shared libraries.

Ultimately we will also want to update the qvm and quilc binaries at some point so they work on up-to-date Debian-like distros.

Checklist
---------

- [x] The PR targets the `rc` branch (**not** `master`).
- [x] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on the PR's checks.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
