### PR TITLE
Update: support qcs account headers on engagement creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog
 
 - `QAMExecutionResult` now includes `execution_duration_microseconds`, providing the amount of time
   a job held exclusive hardware access. (@randall-fulton, #1436)
+  
+- `get_qc` accepts `account_id` and `account_type` keyword arguments, which `EngagementManager` can use to specify `X-QCS-ACCOUNT-{ID/TYPE}` headers on engagement requests. (@erichulburd, #1438)
 
 ### Bugfixes
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1005,7 +1005,7 @@ py = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qcs-api-client"
-version = "0.20.10"
+version = "0.20.12"
 description = "A client library for accessing the Rigetti QCS API"
 category = "main"
 optional = false
@@ -1411,7 +1411,7 @@ latex = ["ipython"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a2b41292a997e87f5cc8c599e8a824feb1d7f75c98cec276e04903282007a89e"
+content-hash = "d2af98c6620da01edbf16ab8815b833152357794f62122671ca937e3a5ecede3"
 
 [metadata.files]
 alabaster = [
@@ -2057,8 +2057,8 @@ pyzmq = [
     {file = "pyzmq-22.1.0.tar.gz", hash = "sha256:7040d6dd85ea65703904d023d7f57fab793d7ffee9ba9e14f3b897f34ff2415d"},
 ]
 qcs-api-client = [
-    {file = "qcs-api-client-0.20.10.tar.gz", hash = "sha256:4859884f43a3a29a90171c0470fb8a8e3524a50d6986ff5e12c4b877594ee837"},
-    {file = "qcs_api_client-0.20.10-py3-none-any.whl", hash = "sha256:8ba34444f623cb684b9ee6717c95490fbf20e2209856964c02c3e5578a4dc16c"},
+    {file = "qcs-api-client-0.20.12.tar.gz", hash = "sha256:e7815d0d3e819c95aac741716f664172e0e8d84caad8e29c1f6c2bf02cf497b4"},
+    {file = "qcs_api_client-0.20.12-py3-none-any.whl", hash = "sha256:075b13bd97ed624d7f702c2f6a43dd7f1caf947bf73db5031e947377a63eb39c"},
 ]
 recommonmark = [
     {file = "recommonmark-0.7.1-py2.py3-none-any.whl", hash = "sha256:1b1db69af0231efce3fa21b94ff627ea33dee7079a01dd0a7f8482c3da148b3f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ lark = "^0.11.1"
 rpcq = "^3.10.0"
 networkx = "^2.5"
 importlib-metadata = { version = "^3.7.3", python = "<3.8" }
-qcs-api-client = ">=0.8.1,<0.21.0"
+qcs-api-client = ">=0.20.12,<0.21.0"
 retry = "^0.9.2"
 
 # latex extra

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -36,7 +36,7 @@ from typing import (
 import httpx
 import networkx as nx
 import numpy as np
-from qcs_api_client.client import QCSClientConfiguration
+from qcs_api_client.client import QCSClientConfiguration, QCSAccountType
 from qcs_api_client.models import ListQuantumProcessorsResponse
 from qcs_api_client.operations.sync import list_quantum_processors
 from rpcq.messages import ParameterAref
@@ -727,6 +727,8 @@ def get_qc(
     client_configuration: Optional[QCSClientConfiguration] = None,
     endpoint_id: Optional[str] = None,
     engagement_manager: Optional[EngagementManager] = None,
+    account_id: Optional[str] = None,
+    account_type: Optional[QCSAccountType] = None,
 ) -> QuantumComputer:
     """
     Get a quantum computer.
@@ -797,6 +799,14 @@ def get_qc(
     :param client_configuration: Optional client configuration. If none is provided, a default one will be loaded.
     :param endpoint_id: Optional quantum processor endpoint ID, as used in the `QCS API Docs`_.
     :param engagement_manager: Optional engagement manager. If none is provided, a default one will be created.
+    :param account_id: Optional account id. If engagement manager is not set, ``EngagementManager`` will be
+        initialized with this ``account_id``. In practice, this should be left blank unless specifying a QCS
+        group account name, which will be used for the purposes of billing and metrics. This will
+        override the QCS account id set on your QCS profile.
+    :param account_type: Optional account type. If engagement manager is not set, ``EngagementManager`` will be
+        initialized with this ``account_type``. In practice, this should be left blank unless specifying a QCS
+        group account type, which will be used for the purposes of billing and metrics. This will
+        override the QCS account type set on your QCS profile.
 
     :return: A pre-configured QuantumComputer
 
@@ -804,7 +814,11 @@ def get_qc(
     """
 
     client_configuration = client_configuration or QCSClientConfiguration.load()
-    engagement_manager = engagement_manager or EngagementManager(client_configuration=client_configuration)
+    engagement_manager = engagement_manager or EngagementManager(
+        client_configuration=client_configuration,
+        account_id=account_id,
+        account_type=account_type,
+    )
 
     # 1. Parse name, check for redundant options, canonicalize names.
     prefix, qvm_type, noisy = _parse_name(name, as_qvm, noisy)


### PR DESCRIPTION
Description
-----------

We want to support the client's ability to explicitly set QCS account on the quantum computer they will execute against. To this end, we allow clients to explicitly pass `account_id` and `account_type` on `get_qc`. This will initialize an `EngagementManager` with account id/type, which, in turn, will set the `X-QCS-ACCOUNT-{ID/TYPE}` headers on the engagement request. This enables users to identify their QPU job as belonging to a group account.

TODO:

- [X] Run poetry update qcs-api-client and commit poetry.lock

Checklist
---------

- [X] The PR targets the `rc` branch (**not** `master`).
- [X] The above description motivates these changes.
- [X] There is a unit test that covers these changes.
- [X] All new and existing tests pass locally and on the PR's checks.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [X] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [x] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
