### PR TITLE
2q-qvm --> 4q-pyqvm

### DIFF
--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -289,7 +289,7 @@ Getting Started
 
     # We could ask for "2q-noisy-qvm" but we will be specifying
     # our noise model as PRAGMAs on the Program itself.
-    qc = get_qc('2q-qvm')
+    qc = get_qc('4q-pyqvm')
 
 
 Example 1: Amplitude Damping


### PR DESCRIPTION
ConnectError: [WinError 10061] No connection could be made because the target machine actively refused it
qc = get_qc('2q-qvm') --> qc = get_qc('4q-pyqvm')

Description
-----------

Insert your PR description here. Thanks for [contributing][contributing] to pyQuil! 🙂

Checklist
---------

- [ ] The PR targets the `rc` branch (**not** `master`).
- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on the PR's checks.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
