### PR TITLE
docs: fix the definition of the ccnot_matrix

### DIFF
--- a/docs/source/basics.rst
+++ b/docs/source/basics.rst
@@ -517,7 +517,7 @@ Some gates can be compactly represented as a permutation. For example, ``CCNOT``
        [0, 0, 0, 0, 1, 0, 0, 0],
        [0, 0, 0, 0, 0, 1, 0, 0],
        [0, 0, 0, 0, 0, 0, 0, 1],
-       [1, 0, 0, 0, 0, 0, 1, 0]
+       [0, 0, 0, 0, 0, 0, 1, 0]
    ])
 
    ccnot_gate = DefGate("CCNOT", ccnot_matrix)


### PR DESCRIPTION
## Description

The example `ccnot_matrix` in the documentation isn't correct; the last row starts with a one when it should be zero.

Closes #1463

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
~- [ ] All changes to code are covered via unit tests.~
~- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].~
~- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.~
- [X] (New Feature) The [docs][docs] have been updated accordingly.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
