### PR TITLE
chore: use new poetry installer

### DIFF
--- a/scripts/ci_install_deps
+++ b/scripts/ci_install_deps
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+curl -sSL https://install.python-poetry.org | python3 -
 . $HOME/.poetry/env
 poetry --version
 poetry config virtualenvs.in-project true

--- a/scripts/ci_install_deps
+++ b/scripts/ci_install_deps
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 curl -sSL https://install.python-poetry.org | python3 -
-. $HOME/.poetry/env
+which poetry > /dev/null || export PATH=$PATH:$HOME/.local/bin
 poetry --version
 poetry config virtualenvs.in-project true
 poetry run python -m ensurepip --upgrade


### PR DESCRIPTION
## Description

This modifies the `scripts/ci_install_deps` script to use the new Poetry installer. This should fix the issues with brownouts in CI:

> This installer is deprecated, and cannot install Poetry 1.2.0a1 or newer.
Additionally, Poetry installations created by this installer cannot `self update` to 1.2.0a1 or later.
You should migrate to https://install.python-poetry.org/ instead. Instructions are available at https://python-poetry.org/docs/#installation.

> A CI environment has been detected! Due to the above deprecation, this installer is subject to an escalating brownout percentage (currently 5%)!

Resolves #1470.

## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
