### PR TITLE
fix: Remove pyi type annotations causing runtime errors

### DIFF
--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -121,7 +121,7 @@ class QPUCompiler(AbstractCompiler):
         return EncryptedProgram(
             program=translated_program["program"],
             memory_descriptors=_collect_memory_descriptors(nq_program),
-            ro_sources={parse_mref(mref): source for mref, source in translated_program["ro_sources"] or []},
+            ro_sources={parse_mref(mref): source for mref, source in translated_program["ro_sources"].items() or []},
             recalculation_table=rewrite_response["recalculation_table"],
             _memory=nq_program._memory.copy(),
         )

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -107,7 +107,7 @@ class QPUCompiler(AbstractCompiler):
         # the event loop is available. Wrapping it in a Python async function ensures that
         # the event loop is available. This is a limitation of pyo3:
         # https://pyo3.rs/v0.17.1/ecosystem/async-await.html#a-note-about-asynciorun
-        async def _translate(*args) -> qcs_sdk.TranslationResult:  # type: ignore
+        async def _translate(*args):
             return await qcs_sdk.translate(*args)
 
         translated_program = self._event_loop.run_until_complete(

--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -193,7 +193,7 @@ class QPU(QAM[QPUExecuteResponse]):
         Retrieve results from execution on the QPU.
         """
 
-        async def _get_result(*args) -> qcs_sdk.ExecutionResults:  # type: ignore
+        async def _get_result(*args):
             return await qcs_sdk.retrieve_results(*args)
 
         results = self._event_loop.run_until_complete(


### PR DESCRIPTION
## Description

Our use of pyi types in type annotations is preventing execution. Remove them (for now).

Closes #1505.

## Checklist

- [x] The PR targets the `v4` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [ ] All changes to code are covered via unit tests.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
