### PR TITLE
ci: update knope to 0.7.0 with version detection fixes

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install Knope
       uses: knope-dev/action@v1
       with:
-        version: 0.6.3 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
+        version: 0.7.0 # Test before updating, breaking changes likely: https://github.com/knope-dev/action#install-latest-version
     - name: Configure Git
       run: |
         git config --global user.name "${{ github.triggering_actor }}"


### PR DESCRIPTION
## Description

Resolves #1525. Knope 0.7.0 contains important fixes to how versions are calculated, which should prevent issues we saw in `quil-rs`.

## Checklist

- [x] The PR targets the ~~`master`~~ `v4` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [ ] (N/A) All changes to code are covered via unit tests.
- [ ] (N/A) Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] (N/A) Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (N/A) (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
