### PR TITLE
V4 Setters for the Gate class

### DIFF
--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -576,15 +576,16 @@ class BinaryExp(Expression):
     def _from_rs_infix_expression(cls, infix_expression: quil_rs.InfixExpression):
         left = _convert_to_py_parameter(infix_expression.left)
         right = _convert_to_py_parameter(infix_expression.right)
-        if infix_expression.operator.is_plus():
+        print(infix_expression.operator)
+        if infix_expression.operator == quil_rs.InfixOperator.Plus:
             return Add(left, right)
-        if infix_expression.operator.is_minus():
+        if infix_expression.operator == quil_rs.InfixOperator.Minus:
             return Sub(left, right)
-        if infix_expression.operator.is_slash():
+        if infix_expression.operator == quil_rs.InfixOperator.Slash:
             return Div(left, right)
-        if infix_expression.operator.is_star():
+        if infix_expression.operator == quil_rs.InfixOperator.Star:
             return Mul(left, right)
-        if infix_expression.operator.is_caret():
+        if infix_expression.operator == quil_rs.InfixOperator.Caret:
             return Pow(left, right)
         raise ValueError(f"{type(infix_expression)} is not a valid InfixExpression")
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -236,9 +236,17 @@ class Gate(quil_rs.Gate, AbstractInstruction):
     def qubits(self):
         return list(self.get_qubits(indices=False))
 
+    @qubits.setter
+    def qubits(self, qubits: Iterable[Union[Qubit, QubitPlaceholder, FormalArgument]]):
+        quil_rs.Gate.qubits.__set__(self, _convert_to_rs_qubits(qubits))
+
     @property
     def params(self):
         return _convert_to_py_parameters(super().parameters)
+
+    @params.setter
+    def params(self, params: Iterable[ParameterDesignator]):
+        quil_rs.Gate.parameters.__set__(self, _convert_to_rs_expressions(params))
 
     def get_qubit_indices(self) -> Set[int]:
         return {qubit.as_fixed() for qubit in super().qubits}

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -45,9 +45,13 @@ class TestGate:
 
     def test_params(self, gate, params):
         assert gate.params == params
+        gate.params = [pi / 2]
+        assert gate.params == [pi / 2]
 
     def test_qubits(self, gate, qubits):
         assert gate.qubits == qubits
+        gate.qubits = [Qubit(123)]
+        assert gate.qubits == [Qubit(123)]
 
     def test_get_qubits(self, gate, qubits):
         assert gate.get_qubit_indices() == {q.index for q in qubits}


### PR DESCRIPTION
## Description

After recent discussions about the importance of setters for the instruction classes, it dawned on me that the re-written `Gate` class didn't have a compatibility layer over its setters. This fixes that.