### PR TITLE
Use quil_rs for Calibrations

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1911,6 +1911,7 @@ url = "https://github.com/rigetti/qcs-sdk-rust"
 reference = "reexport-quil-py"
 resolved_reference = "97692714637d3ae121537a6f10d734a526b3943f"
 subdirectory = "crates/python"
+
 [[package]]
 name = "recommonmark"
 version = "0.7.1"

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -134,7 +134,7 @@ class Program:
     @property
     def measure_calibrations(self) -> List[DefMeasureCalibration]:
         """A list of measure calibrations"""
-        return self._program.measure_calibrations
+        return self._program.calibrations.measure_calibrations
 
     @property
     def waveforms(self) -> Dict[str, DefWaveform]:
@@ -631,6 +631,11 @@ class Program:
                 gate.modifiers, gate.name, gate.parameters, gate.qubits
             )
             return _convert_to_calibration_match(gate, match)
+
+        if instruction.is_measurement():
+            measurement = instruction.to_measurement()
+            match = self._program.calibrations.get_match_for_measurement(measurement)
+            return _convert_to_calibration_match(measurement, match)
 
         return None
 

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -85,6 +85,7 @@ from pyquil.quiltcalibrations import (
     CalibrationMatch,
     expand_calibration,
     match_calibration,
+    _convert_to_calibration_match,
 )
 
 from qcs_sdk.quil.program import Program as RSProgram
@@ -623,9 +624,13 @@ class Program:
         if not isinstance(instr, (Gate, Measurement)):
             return None
 
-        instr = _convert_to_rs_instruction(instr)
-        if isinstance(instr, quil_rs.Gate):
-            self._program.calibrations.get_match_for_gate(instr.modifiers, instr.name, instr.parameters, instr.qubits)
+        instruction = _convert_to_rs_instruction(instr)
+        if instruction.is_gate():
+            gate = instruction.to_gate()
+            match = self._program.calibrations.get_match_for_gate(
+                gate.modifiers, gate.name, gate.parameters, gate.qubits
+            )
+            return _convert_to_calibration_match(gate, match)
 
         return None
 
@@ -643,7 +648,6 @@ class Program:
 
         return None
 
-    # TODO: Port calibrations logic from quil-rs
     def calibrate(
         self,
         instruction: AbstractInstruction,

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -603,7 +603,6 @@ class Program:
         """
         return {q.as_fixed() for q in self._program.get_used_qubits()}
 
-    # TODO: Port calibrations logic from quil-rs
     def match_calibrations(self, instr: AbstractInstruction) -> Optional[CalibrationMatch]:
         """
         Attempt to match a calibration to the provided instruction.
@@ -639,7 +638,6 @@ class Program:
 
         return None
 
-    # TODO: Port calibrations logic from quil-rs
     def get_calibration(self, instr: AbstractInstruction) -> Optional[Union[DefCalibration, DefMeasureCalibration]]:
         """
         Get the calibration corresponding to the provided instruction.

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -186,7 +186,7 @@ def _convert_to_py_qubit(qubit: QubitDesignator) -> QubitDesignator:
             return Qubit(qubit.to_fixed())
         if qubit.is_variable():
             return FormalArgument(qubit.to_variable())
-    if isinstance(qubit, (Qubit, QubitPlaceholder, FormalArgument, int)):
+    if isinstance(qubit, (Qubit, QubitPlaceholder, FormalArgument, Parameter, int)):
         return qubit
     raise ValueError(f"{type(qubit)} is not a valid QubitDesignator")
 
@@ -336,7 +336,7 @@ def _convert_to_py_parameter(parameter: ParameterDesignator) -> ParameterDesigna
         if parameter.is_number():
             return parameter.to_number()
         if parameter.is_pi():
-            return pi
+            return np.pi
         if parameter.is_variable():
             return Parameter(parameter.to_variable())
     elif isinstance(parameter, (Expression, MemoryReference, Number)):
@@ -576,7 +576,6 @@ class BinaryExp(Expression):
     def _from_rs_infix_expression(cls, infix_expression: quil_rs.InfixExpression):
         left = _convert_to_py_parameter(infix_expression.left)
         right = _convert_to_py_parameter(infix_expression.right)
-        print(infix_expression.operator)
         if infix_expression.operator == quil_rs.InfixOperator.Plus:
             return Add(left, right)
         if infix_expression.operator == quil_rs.InfixOperator.Minus:

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -771,6 +771,13 @@ class MemoryReference(QuilAtom, Expression):
     def _from_rs_memory_reference(cls, memory_reference: quil_rs.MemoryReference) -> "MemoryReference":
         return cls(memory_reference.name, memory_reference.index)
 
+    @classmethod
+    def _from_parameter_str(cls, memory_reference_str: str) -> "MemoryReference":
+        expression = quil_rs.Expression.parse_from_str(memory_reference_str)
+        if expression.is_address():
+            return cls._from_rs_memory_reference(expression.to_address())
+        raise ValueError(f"{memory_reference_str} is not a memory reference")
+
     def out(self) -> str:
         if self.declared_size is not None and self.declared_size == 1 and self.offset == 0:
             return "{}".format(self.name)

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -308,7 +308,7 @@ class LabelPlaceholder(QuilAtom):
         return hash(id(self))
 
 
-ParameterDesignator = Union["Expression", "MemoryReference", quil_rs.Expression, Number]
+ParameterDesignator = Union["Expression", "MemoryReference", quil_rs.Expression, quil_rs.MemoryReference, Number]
 
 
 def _convert_to_rs_expression(parameter: ParameterDesignator) -> quil_rs.Expression:
@@ -339,7 +339,7 @@ def _convert_to_py_parameter(parameter: ParameterDesignator) -> ParameterDesigna
             return np.pi
         if parameter.is_variable():
             return Parameter(parameter.to_variable())
-    elif isinstance(parameter, (Expression, MemoryReference, Number)):
+    elif isinstance(parameter, (Expression, MemoryReference, quil_rs.MemoryReference, Number)):
         return parameter
     raise ValueError(f"{type(parameter)} is not a valid ParameterDesignator")
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1440,13 +1440,13 @@ class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstru
     def __new__(
         cls,
         qubit: Union[Qubit, FormalArgument],
-        memory_reference: Optional[MemoryReference],
+        memory_reference: MemoryReference,
         instrs: List[AbstractInstruction],
     ) -> "DefMeasureCalibration":
         return super().__new__(
             cls,
             _convert_to_rs_qubit(qubit),
-            "" if memory_reference is None else str(memory_reference),
+            memory_reference.name,
             _convert_to_rs_instructions(instrs),
         )
 
@@ -1454,7 +1454,7 @@ class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstru
     def _from_rs_measure_calibration_definition(
         cls, calibration: quil_rs.MeasureCalibrationDefinition
     ) -> "DefMeasureCalibration":
-        return cls(calibration.qubit, calibration.parameter, calibration.instructions)
+        return super().__new__(cls, calibration.qubit, calibration.parameter, calibration.instructions)
 
     @property
     def qubit(self) -> QubitDesignator:
@@ -1466,14 +1466,11 @@ class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstru
 
     @property
     def memory_reference(self) -> Optional[MemoryReference]:
-        if super().parameter == "":
-            return None
         return MemoryReference._from_parameter_str(super().parameter)
 
     @memory_reference.setter
-    def memory_reference(self, memory_reference: Optional[MemoryReference]):
-        parameter = "" if memory_reference is None else str(memory_reference)
-        quil_rs.MeasureCalibrationDefinition.parameter.__set__(self, parameter)
+    def memory_reference(self, memory_reference: MemoryReference):
+        quil_rs.MeasureCalibrationDefinition.parameter.__set__(self, memory_reference.name)
 
     @property
     def instrs(self):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -127,6 +127,12 @@ def _convert_to_rs_instruction(instr: AbstractInstruction) -> quil_rs.Instructio
         return quil_rs.Instruction(instr)
     if isinstance(instr, quil_rs.Calibration):
         return quil_rs.Instruction.from_calibration_definition(instr)
+    if isinstance(instr, quil_rs.Gate):
+        return quil_rs.Instruction.from_gate(instr)
+    if isinstance(instr, quil_rs.MeasureCalibrationDefinition):
+        return quil_rs.Instruction.from_measure_calibration_definition(instr)
+    if isinstance(instr, quil_rs.Measurement):
+        return quil_rs.Instruction.from_measurement(instr)
     else:
         raise ValueError(f"{type(instr)} is not an Instruction")
 
@@ -136,14 +142,18 @@ def _convert_to_rs_instructions(instrs: Iterable[AbstractInstruction]) -> List[q
 
 
 def _convert_to_py_instruction(instr: quil_rs.Instruction) -> AbstractInstruction:
-    if instr.is_gate():
-        return Gate._from_rs_gate(instr.to_gate())
+    if not isinstance(instr, quil_rs.Insrtuction):
+        raise ValueError(f"{type(instr)} is not a valid Instruction type")
     if instr.is_calibration_definition():
         return DefCalibration._from_rs_calibration(instr.to_calibration_definition())
+    if instr.is_gate():
+        return Gate._from_rs_gate(instr.to_gate())
+    if instr.is_measure_calibration_definition():
+        return DefMeasureCalibration._from_rs_measure_calibration_definition(instr)
+    if instr.is_measurement():
+        return Measurement._from_rs_measurement(instr)
     if isinstance(instr, quil_rs.Instruction):
         raise NotImplementedError("This Instruction hasn't been mapped to an AbstractInstruction yet.")
-    else:
-        raise ValueError(f"{type(instr)} is not a valid Instruction type")
 
 
 def _convert_to_py_instructions(instrs: Iterable[quil_rs.Instruction]) -> List[AbstractInstruction]:

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -125,8 +125,10 @@ def _convert_to_rs_instruction(instr: AbstractInstruction) -> quil_rs.Instructio
         return instr
     if isinstance(instr, AbstractInstruction):
         return quil_rs.Instruction(instr)
+    if isinstance(instr, quil_rs.Calibration):
+        return quil_rs.Instruction.from_calibration_definition(instr)
     else:
-        raise ValueError(f"{type(instr)}")
+        raise ValueError(f"{type(instr)} is not an Instruction")
 
 
 def _convert_to_rs_instructions(instrs: Iterable[AbstractInstruction]) -> List[quil_rs.Instruction]:
@@ -134,7 +136,6 @@ def _convert_to_rs_instructions(instrs: Iterable[AbstractInstruction]) -> List[q
 
 
 def _convert_to_py_instruction(instr: quil_rs.Instruction) -> AbstractInstruction:
-    print(type(instr), str(instr))
     if instr.is_gate():
         return Gate._from_rs_gate(instr.to_gate())
     if instr.is_calibration_definition():
@@ -1417,7 +1418,6 @@ class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstru
 
     @property
     def memory_reference(self) -> Optional[MemoryReference]:
-        print("parameter", super().parameter, super().parameter == "")
         if super().parameter == "":
             return None
         return MemoryReference._from_parameter_str(super().parameter)

--- a/pyquil/quiltcalibrations.py
+++ b/pyquil/quiltcalibrations.py
@@ -136,9 +136,6 @@ def _convert_to_calibration_match(
     instruction: Union[quil_rs.Gate, quil_rs.Measurement],
     calibration: Union[quil_rs.Calibration, quil_rs.MeasureCalibrationDefinition],
 ) -> Optional[CalibrationMatch]:
-    if calibration is None:
-        return None
-
     if isinstance(instruction, quil_rs.Gate) and isinstance(calibration, quil_rs.Calibration):
         target_qubits = instruction.qubits
         target_values = instruction.parameters

--- a/pyquil/quiltcalibrations.py
+++ b/pyquil/quiltcalibrations.py
@@ -183,23 +183,20 @@ def match_calibration(
     On a failure, return None.
     """
     calibration = _convert_to_rs_instruction(cal)
-    if calibration.is_calibration_definition():
+    instruction = _convert_to_rs_instruction(instr)
+    if calibration.is_calibration_definition() and instruction.is_gate():
         instruction = _convert_to_rs_instruction(instr)
-        if not instruction.is_gate():
-            return None
-        calibration_set = CalibrationSet([calibration.to_calibration_definition()], [])
         gate = instruction.to_gate()
+        calibration_set = CalibrationSet([calibration.to_calibration_definition()], [])
         matched_calibration = calibration_set.get_match_for_gate(
             gate.modifiers, gate.name, gate.parameters, gate.qubits
         )
         return _convert_to_calibration_match(gate, matched_calibration)
 
-    if calibration.is_measure_calibration_definition():
+    if calibration.is_measure_calibration_definition() and instruction.is_measurement():
         instruction = _convert_to_rs_instruction(instr)
-        if not instruction.is_measurement():
-            return None
-        calibration_set = CalibrationSet([], [calibration.to_measure_calibration_definition()])
         measurement = instruction.to_measurement()
+        calibration_set = CalibrationSet([], [calibration.to_measure_calibration_definition()])
         matched_calibration = calibration_set.get_match_for_measurement(measurement)
         return _convert_to_calibration_match(measurement, matched_calibration)
 

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -22,6 +22,20 @@
   	X 0
   '''
 # ---
+# name: TestDefMeasureCalibration.test_out[MemoryReference]
+  '''
+  DEFCAL MEASURE 1 [<MRef theta[0]>]:
+      X 0
+  
+  '''
+# ---
+# name: TestDefMeasureCalibration.test_out[No-MemoryReference]
+  '''
+  DEFCAL MEASURE 0:
+      X 0
+  
+  '''
+# ---
 # name: TestGate.test_controlled_modifier[CPHASE-Expression]
   'CONTROLLED CPHASE(1.5707963267948966) 5 0 1'
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -24,15 +24,15 @@
 # ---
 # name: TestDefMeasureCalibration.test_out[MemoryReference]
   '''
-  DEFCAL MEASURE 1 [<MRef theta[0]>]:
-      X 0
+  DEFCAL MEASURE 1 theta:
+  	X 0
   
   '''
 # ---
 # name: TestDefMeasureCalibration.test_out[No-MemoryReference]
   '''
-  DEFCAL MEASURE 0:
-      X 0
+  DEFCAL MEASURE 0 :
+  	X 0
   
   '''
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -1,15 +1,25 @@
 # name: TestDefCalibration.test_out[No-Params]
   '''
   DEFCAL Calibrate 0:
-      X 0
-  
+  	X 0
   '''
 # ---
 # name: TestDefCalibration.test_out[Params]
   '''
   DEFCAL Calibrate(%X) 0:
-      X 0
-  
+  	X 0
+  '''
+# ---
+# name: TestDefCalibration.test_str[No-Params]
+  '''
+  DEFCAL Calibrate 0:
+  	X 0
+  '''
+# ---
+# name: TestDefCalibration.test_str[Params]
+  '''
+  DEFCAL Calibrate(%X) 0:
+  	X 0
   '''
 # ---
 # name: TestGate.test_controlled_modifier[CPHASE-Expression]

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -100,7 +100,7 @@
   'MEASURE q theta'
 # ---
 # name: TestMeasurement.test_out[MemoryReference]
-  'MEASURE 1 theta'
+  'MEASURE 1 theta[0]'
 # ---
 # name: TestMeasurement.test_out[No-MemoryReference]
   'MEASURE 0'
@@ -109,7 +109,7 @@
   'MEASURE q theta'
 # ---
 # name: TestMeasurement.test_str[MemoryReference]
-  'MEASURE 1 theta'
+  'MEASURE 1 theta[0]'
 # ---
 # name: TestMeasurement.test_str[No-MemoryReference]
   'MEASURE 0'

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -1,3 +1,17 @@
+# name: TestDefCalibration.test_out[No-Params]
+  '''
+  DEFCAL Calibrate 0:
+      X 0
+  
+  '''
+# ---
+# name: TestDefCalibration.test_out[Params]
+  '''
+  DEFCAL Calibrate(%X) 0:
+      X 0
+  
+  '''
+# ---
 # name: TestGate.test_controlled_modifier[CPHASE-Expression]
   'CONTROLLED CPHASE(1.5707963267948966) 5 0 1'
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -96,3 +96,21 @@
 # name: TestGate.test_str[X-Gate]
   'X 0'
 # ---
+# name: TestMeasurement.test_out[FormalArgument]
+  'MEASURE q theta'
+# ---
+# name: TestMeasurement.test_out[MemoryReference]
+  'MEASURE 1 theta'
+# ---
+# name: TestMeasurement.test_out[No-MemoryReference]
+  'MEASURE 0'
+# ---
+# name: TestMeasurement.test_str[FormalArgument]
+  'MEASURE q theta'
+# ---
+# name: TestMeasurement.test_str[MemoryReference]
+  'MEASURE 1 theta'
+# ---
+# name: TestMeasurement.test_str[No-MemoryReference]
+  'MEASURE 0'
+# ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -36,6 +36,13 @@
   
   '''
 # ---
+# name: TestDefMeasureCalibration.test_out[qubit0-memory_reference0-instrs0]
+  '''
+  DEFCAL MEASURE 0 theta:
+  	X 0
+  
+  '''
+# ---
 # name: TestGate.test_controlled_modifier[CPHASE-Expression]
   'CONTROLLED CPHASE(1.5707963267948966) 5 0 1'
 # ---

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -91,8 +91,8 @@ class TestDefCalibration:
     def calibration(self, name, parameters, qubits, instrs):
         return DefCalibration(name, parameters, qubits, instrs)
 
-    # def test_str(self, calibration, snapshot):
-    #     assert str(calibration) == snapshot
+    def test_str(self, calibration, snapshot):
+        assert str(calibration) == snapshot
 
     def test_out(self, calibration, snapshot):
         assert calibration.out() == snapshot
@@ -104,8 +104,8 @@ class TestDefCalibration:
 
     def test_parameters(self, calibration, parameters):
         assert calibration.parameters == parameters
-        calibration.parameters = [5]
-        assert calibration.parameters == [5]
+        calibration.parameters = [pi / 2]
+        assert calibration.parameters == [pi / 2]
 
     def test_qubits(self, calibration, qubits):
         assert calibration.qubits == qubits

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -164,9 +164,9 @@ class TestDefMeasureCalibration:
     [
         (Qubit(0), None),
         (Qubit(1), MemoryReference("theta", 0, 1)),
-        (FormalArgument("q"), MemoryReference("theta", 0, 1)),
+        # (FormalArgument("q"), MemoryReference("theta", 0, 1)),
     ],
-    ids=("No-MemoryReference", "MemoryReference", "FormalArgument"),
+    ids=("No-MemoryReference", "MemoryReference"),
 )
 class TestMeasurement:
     @pytest.fixture

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -1,11 +1,15 @@
 from math import pi
-from typing import List
+from typing import List, Optional
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
 from pyquil.gates import X
 from pyquil.quil import Program
 from pyquil.quilbase import (
+    AbstractInstruction,
     DefCalibration,
     DefMeasureCalibration,
-    FormalArgument,
     Gate,
     Measurement,
     MemoryReference,
@@ -14,7 +18,6 @@ from pyquil.quilbase import (
 )
 from pyquil.quilatom import BinaryExp, Qubit
 from pyquil.api._compiler import QPUCompiler
-import pytest
 
 
 @pytest.mark.parametrize(
@@ -29,11 +32,11 @@ import pytest
 )
 class TestGate:
     @pytest.fixture
-    def gate(self, name, params, qubits) -> Gate:
+    def gate(self, name: str, params: List[ParameterDesignator], qubits: List[Qubit]) -> Gate:
         return Gate(name, params, qubits)
 
     @pytest.fixture
-    def program(self, params, gate) -> Program:
+    def program(self, params: List[ParameterDesignator], gate: Gate) -> Program:
         """Creates a valid quil program using the gate and declaring memory regions for any of it's parameters"""
         program = Program(gate)
         for param in params:
@@ -47,40 +50,40 @@ class TestGate:
 
         return program
 
-    def test_str(self, gate, snapshot):
+    def test_str(self, gate: Gate, snapshot: SnapshotAssertion):
         assert str(gate) == snapshot
 
-    def test_name(self, gate, name):
+    def test_name(self, gate: Gate, name: str):
         assert gate.name == name
 
-    def test_params(self, gate, params):
+    def test_params(self, gate: Gate, params: List[ParameterDesignator]):
         assert gate.params == params
         gate.params = [pi / 2]
         assert gate.params == [pi / 2]
 
-    def test_qubits(self, gate, qubits):
+    def test_qubits(self, gate: Gate, qubits: List[Qubit]):
         assert gate.qubits == qubits
         gate.qubits = [Qubit(123)]
         assert gate.qubits == [Qubit(123)]
 
-    def test_get_qubits(self, gate, qubits):
+    def test_get_qubits(self, gate: Gate, qubits: List[Qubit]):
         assert gate.get_qubit_indices() == {q.index for q in qubits}
         assert gate.get_qubits(indices=False) == set(qubits)
 
-    def test_controlled_modifier(self, gate, snapshot):
+    def test_controlled_modifier(self, gate: Gate, snapshot: SnapshotAssertion):
         assert str(gate.controlled([Qubit(5)])) == snapshot
 
-    def test_dagger_modifier(self, gate, snapshot):
+    def test_dagger_modifier(self, gate: Gate, snapshot: SnapshotAssertion):
         assert str(gate.dagger()) == snapshot
 
-    def test_forked_modifier(self, gate, params, snapshot):
+    def test_forked_modifier(self, gate: Gate, params: List[ParameterDesignator], snapshot: SnapshotAssertion):
         alt_params: List[ParameterDesignator] = [n for n in range(len(params))]
         assert str(gate.forked(Qubit(5), alt_params)) == snapshot
 
-    def test_repr(self, gate, snapshot):
+    def test_repr(self, gate: Gate, snapshot: SnapshotAssertion):
         assert repr(gate) == snapshot
 
-    def test_compile(self, program, compiler: QPUCompiler):
+    def test_compile(self, program: Program, compiler: QPUCompiler):
         try:
             compiler.quil_to_native_quil(program)
         except Exception as e:
@@ -97,31 +100,33 @@ class TestGate:
 )
 class TestDefCalibration:
     @pytest.fixture
-    def calibration(self, name, parameters, qubits, instrs) -> DefCalibration:
+    def calibration(
+        self, name: str, parameters: List[ParameterDesignator], qubits: List[Qubit], instrs: List[AbstractInstruction]
+    ) -> DefCalibration:
         return DefCalibration(name, parameters, qubits, instrs)
 
-    def test_str(self, calibration, snapshot):
+    def test_str(self, calibration: DefCalibration, snapshot: SnapshotAssertion):
         assert str(calibration) == snapshot
 
-    def test_out(self, calibration, snapshot):
+    def test_out(self, calibration: DefCalibration, snapshot: SnapshotAssertion):
         assert calibration.out() == snapshot
 
-    def test_name(self, calibration, name):
+    def test_name(self, calibration: DefCalibration, name: str):
         assert calibration.name == name
         calibration.name = "new_name"
         assert calibration.name == "new_name"
 
-    def test_parameters(self, calibration, parameters):
+    def test_parameters(self, calibration: DefCalibration, parameters: List[ParameterDesignator]):
         assert calibration.parameters == parameters
         calibration.parameters = [pi / 2]
         assert calibration.parameters == [pi / 2]
 
-    def test_qubits(self, calibration, qubits):
+    def test_qubits(self, calibration: DefCalibration, qubits: List[Qubit]):
         assert calibration.qubits == qubits
         calibration.qubits = [Qubit(123)]
         assert calibration.qubits == [Qubit(123)]
 
-    def test_instrs(self, calibration, instrs):
+    def test_instrs(self, calibration: DefCalibration, instrs: List[AbstractInstruction]):
         assert calibration.instrs == instrs
         calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], [])]
         assert calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], [])]
@@ -129,31 +134,29 @@ class TestDefCalibration:
 
 @pytest.mark.parametrize(
     ("qubit", "memory_reference", "instrs"),
-    [
-        (Qubit(0), None, [X(0)]),
-        (Qubit(1), MemoryReference("theta", 0, 1), [X(0)]),
-    ],
-    ids=("No-MemoryReference", "MemoryReference"),
+    [(Qubit(0), MemoryReference("theta", 0, 1), [X(0)])],
 )
 class TestDefMeasureCalibration:
     @pytest.fixture
-    def measure_calibration(self, qubit, memory_reference, instrs) -> DefMeasureCalibration:
+    def measure_calibration(
+        self, qubit: Qubit, memory_reference: MemoryReference, instrs: List[AbstractInstruction]
+    ) -> DefMeasureCalibration:
         return DefMeasureCalibration(qubit, memory_reference, instrs)
 
-    def test_out(self, measure_calibration, snapshot):
+    def test_out(self, measure_calibration: DefMeasureCalibration, snapshot: SnapshotAssertion):
         assert measure_calibration.out() == snapshot
 
-    def test_qubit(self, measure_calibration, qubit):
+    def test_qubit(self, measure_calibration: DefMeasureCalibration, qubit: Qubit):
         assert measure_calibration.qubit == qubit
         measure_calibration.qubit = Qubit(123)
         assert measure_calibration.qubit == Qubit(123)
 
-    def test_memory_reference(self, measure_calibration, memory_reference):
+    def test_memory_reference(self, measure_calibration: DefMeasureCalibration, memory_reference: MemoryReference):
         assert measure_calibration.memory_reference == memory_reference
         measure_calibration.memory_reference = MemoryReference("new_mem_ref")
         assert measure_calibration.memory_reference == MemoryReference("new_mem_ref")
 
-    def test_instrs(self, measure_calibration, instrs):
+    def test_instrs(self, measure_calibration: DefMeasureCalibration, instrs: List[AbstractInstruction]):
         assert measure_calibration.instrs == instrs
         measure_calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], [])]
         assert measure_calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], [])]
@@ -164,32 +167,31 @@ class TestDefMeasureCalibration:
     [
         (Qubit(0), None),
         (Qubit(1), MemoryReference("theta", 0, 1)),
-        # (FormalArgument("q"), MemoryReference("theta", 0, 1)),
     ],
     ids=("No-MemoryReference", "MemoryReference"),
 )
 class TestMeasurement:
     @pytest.fixture
-    def measurement(self, qubit, classical_reg):
+    def measurement(self, qubit: Qubit, classical_reg: Optional[MemoryReference]):
         return Measurement(qubit, classical_reg)
 
-    def test_out(self, measurement, snapshot):
+    def test_out(self, measurement: Measurement, snapshot: SnapshotAssertion):
         assert measurement.out() == snapshot
 
-    def test_str(self, measurement, snapshot):
+    def test_str(self, measurement: Measurement, snapshot: SnapshotAssertion):
         assert str(measurement) == snapshot
 
-    def test_qubit(self, measurement, qubit):
+    def test_qubit(self, measurement: Measurement, qubit: Qubit):
         assert measurement.qubit == qubit
         measurement.qubit = Qubit(123)
         assert measurement.qubit == Qubit(123)
 
-    def test_get_qubits(self, measurement, qubit):
+    def test_get_qubits(self, measurement: Measurement, qubit: Qubit):
         assert measurement.get_qubits(False) == set([qubit])
         if isinstance(qubit, Qubit):
             assert measurement.get_qubits(True) == set([qubit.index])
 
-    def test_classical_reg(self, measurement, classical_reg):
+    def test_classical_reg(self, measurement: Measurement, classical_reg: MemoryReference):
         assert measurement.classical_reg == classical_reg
         measurement.classical_reg = MemoryReference("new_mem_ref")
         assert measurement.classical_reg == MemoryReference("new_mem_ref")

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -122,7 +122,7 @@ class TestDefCalibration:
     ("qubit", "memory_reference", "instrs"),
     [
         (Qubit(0), None, [X(0)]),
-        (Qubit(1), [MemoryReference("theta", 0, 1)], [X(0)]),
+        (Qubit(1), MemoryReference("theta", 0, 1), [X(0)]),
     ],
     ids=("No-MemoryReference", "MemoryReference"),
 )

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -1,7 +1,8 @@
 from math import pi
 from typing import List
+from pyquil.gates import X
 from pyquil.quil import Program
-from pyquil.quilbase import Gate, MemoryReference, ParameterDesignator
+from pyquil.quilbase import DefCalibration, Gate, MemoryReference, ParameterDesignator, Parameter
 from pyquil.quilatom import BinaryExp, Qubit
 from pyquil.api._compiler import QPUCompiler
 import pytest
@@ -71,3 +72,43 @@ class TestGate:
             compiler.quil_to_native_quil(program)
         except Exception as e:
             assert False, f"Failed to compile the program: {e}\n{program}"
+
+
+@pytest.mark.parametrize(
+    ("name", "parameters", "qubits", "instrs"),
+    [
+        ("Calibrate", [], [Qubit(0)], [X(0)]),
+        ("Calibrate", [Parameter("X")], [Qubit(0)], [X(0)]),
+    ],
+    ids=("No-Params", "Params"),
+)
+class TestDefCalibration:
+    @pytest.fixture
+    def calibration(self, name, parameters, qubits, instrs):
+        return DefCalibration(name, parameters, qubits, instrs)
+
+    # def test_str(self, calibration, snapshot):
+    #     assert str(calibration) == snapshot
+
+    def test_out(self, calibration, snapshot):
+        assert calibration.out() == snapshot
+
+    def test_name(self, calibration, name):
+        assert calibration.name == name
+        calibration.name = "new_name"
+        assert calibration.name == "new_name"
+
+    def test_parameters(self, calibration, parameters):
+        assert calibration.parameters == parameters
+        calibration.parameters = [5]
+        assert calibration.parameters == [5]
+
+    def test_qubits(self, calibration, qubits):
+        assert calibration.qubits == qubits
+        calibration.qubits = [Qubit(123)]
+        assert calibration.qubits == [Qubit(123)]
+
+    def test_instrs(self, calibration, instrs):
+        assert calibration.instrs == instrs
+        calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], [])]
+        assert calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], [])]

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -2,7 +2,7 @@ from math import pi
 from typing import List
 from pyquil.gates import X
 from pyquil.quil import Program
-from pyquil.quilbase import DefCalibration, Gate, MemoryReference, ParameterDesignator, Parameter
+from pyquil.quilbase import DefCalibration, DefMeasureCalibration, Gate, MemoryReference, ParameterDesignator, Parameter
 from pyquil.quilatom import BinaryExp, Qubit
 from pyquil.api._compiler import QPUCompiler
 import pytest
@@ -88,7 +88,7 @@ class TestGate:
 )
 class TestDefCalibration:
     @pytest.fixture
-    def calibration(self, name, parameters, qubits, instrs):
+    def calibration(self, name, parameters, qubits, instrs) -> DefCalibration:
         return DefCalibration(name, parameters, qubits, instrs)
 
     def test_str(self, calibration, snapshot):
@@ -116,3 +116,35 @@ class TestDefCalibration:
         assert calibration.instrs == instrs
         calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], [])]
         assert calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], [])]
+
+
+@pytest.mark.parametrize(
+    ("qubit", "memory_reference", "instrs"),
+    [
+        (Qubit(0), None, [X(0)]),
+        (Qubit(1), [MemoryReference("theta", 0, 1)], [X(0)]),
+    ],
+    ids=("No-MemoryReference", "MemoryReference"),
+)
+class TestDefMeasureCalibration:
+    @pytest.fixture
+    def measure_calibration(self, qubit, memory_reference, instrs) -> DefMeasureCalibration:
+        return DefMeasureCalibration(qubit, memory_reference, instrs)
+
+    def test_out(self, measure_calibration, snapshot):
+        assert measure_calibration.out() == snapshot
+
+    def test_qubit(self, measure_calibration, qubit):
+        assert measure_calibration.qubit == qubit
+        measure_calibration.qubit = Qubit(123)
+        assert measure_calibration.qubit == Qubit(123)
+
+    def test_memory_reference(self, measure_calibration, memory_reference):
+        assert measure_calibration.memory_reference == memory_reference
+        measure_calibration.memory_reference = MemoryReference("new_mem_ref")
+        assert measure_calibration.memory_reference == MemoryReference("new_mem_ref")
+
+    def test_instrs(self, measure_calibration, instrs):
+        assert measure_calibration.instrs == instrs
+        measure_calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], [])]
+        assert measure_calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], [])]

--- a/test/unit/test_quilt.py
+++ b/test/unit/test_quilt.py
@@ -148,8 +148,8 @@ def test_memory_reference_parameter():
 
 def test_measure_calibration_match():
     matches = [
-        ("DEFCAL MEASURE 0 dest", "MEASURE 0"),
-        ("DEFCAL MEASURE q dest", "MEASURE 0"),
+        ("DEFCAL MEASURE 0 dest", "MEASURE 0 ro[0]"),
+        ("DEFCAL MEASURE q dest", "MEASURE 0 ro[1]"),
         ("DEFCAL MEASURE 0 b", "DECLARE ro BIT\nMEASURE 0 ro[0]"),
         ("DEFCAL MEASURE q b", "DECLARE ro BIT\nMEASURE 1 ro[0]"),
     ]
@@ -163,8 +163,7 @@ def test_measure_calibration_match():
 
     mismatches = [
         ("DEFCAL MEASURE 1 dest", "MEASURE 0"),
-        # ("DEFCAL MEASURE 0 b", "MEASURE 0"),
-        # ("DEFCAL MEASURE q dest", "DECLARE ro BIT\nMEASURE 0 ro[0]"),
+        ("DEFCAL MEASURE 0 b", "MEASURE 0"),
     ]
 
     for cal, instr in mismatches:

--- a/test/unit/test_quilt.py
+++ b/test/unit/test_quilt.py
@@ -80,7 +80,6 @@ def _match(cal, instr):
     return match_calibration(instr, cal)
 
 
-# TODO: Calibration API: match calibration
 def test_simple_gate_calibration_match():
     matches = [
         ("DEFCAL X 0", "X 0"),

--- a/test/unit/test_quilt.py
+++ b/test/unit/test_quilt.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 
 import numpy as np
@@ -24,8 +26,10 @@ from pyquil.quiltcalibrations import (
     match_calibration,
 )
 from pyquil.quilbase import (
+    AbstractInstruction,
     Gate,
     DefCalibration,
+    DefMeasureCalibration,
     ShiftPhase,
     DelayQubits,
     Qubit,
@@ -68,7 +72,7 @@ def test_waveform_samples_optional_args():
     assert np.array_equal(np.exp(1j) * flat(), flat(phase=1.0))
 
 
-def _match(cal, instr):
+def _match(cal: DefCalibration, instr: AbstractInstruction) -> Optional[CalibrationMatch]:
     # get the first line, remove trailing colon if present
     cal_header = cal.splitlines()[0].strip().replace(":", "")
     # convert to quil ast
@@ -80,7 +84,7 @@ def _match(cal, instr):
     return match_calibration(instr, cal)
 
 
-def _match_measure(cal, instr):
+def _match_measure(cal: DefMeasureCalibration, instr: AbstractInstruction) -> Optional[CalibrationMatch]:
     # get the first line, remove trailing colon if present
     cal_header = cal.splitlines()[0].strip().replace(":", "")
     # convert to quil ast


### PR DESCRIPTION
This PR updates `DefCalibration`, `DefMeasureCalibration`, and `Measurement` such that they are backed by their quil_rs counterparts and uses the `CalibrationSet` API from quil_rs to handle calibrations.