### PR TITLE
Add ENABLE-RAW-CAPTURE attribute to DefFrame

### DIFF
--- a/pyquil/_parser/grammar.lark
+++ b/pyquil/_parser/grammar.lark
@@ -66,6 +66,7 @@ frame_spec : _NEWLINE_TAB frame_attr ":" ( expression | string )
             | "DIRECTION"
             | "HARDWARE-OBJECT"
             | "CENTER-FREQUENCY"
+            | "ENABLE-RAW-CAPTURE"
 
 def_waveform : "DEFWAVEFORM" waveform_name params ":" matrix
 

--- a/pyquil/_parser/parser.py
+++ b/pyquil/_parser/parser.py
@@ -137,6 +137,7 @@ class QuilTransformer(Transformer):  # type: ignore
             "INITIAL-FREQUENCY": "initial_frequency",
             "SAMPLE-RATE": "sample_rate",
             "CENTER-FREQUENCY": "center_frequency",
+            "ENABLE-RAW-CAPTURE": "enable_raw_capture",
         }
         options = {}
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1363,6 +1363,9 @@ class DefFrame(AbstractInstruction):
     center_frequency: Optional[float] = None
     """ The 'center' frequency of the frame, used for detuning arithmetic. """
 
+    enable_raw_capture: Optional[str] = None
+    """ A flag signalling that raw capture is enabled for this frame. """
+
     def out(self) -> str:
         r = f"DEFFRAME {self.frame.out()}"
         options = [
@@ -1371,6 +1374,7 @@ class DefFrame(AbstractInstruction):
             (self.center_frequency, "CENTER-FREQUENCY"),
             (self.hardware_object, "HARDWARE-OBJECT"),
             (self.sample_rate, "SAMPLE-RATE"),
+            (self.enable_raw_capture, "ENABLE-RAW-CAPTURE"),
         ]
         if any(value for (value, name) in options):
             r += ":"

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -598,6 +598,22 @@ def test_parsing_defframe():
         "    INITIAL-FREQUENCY: 10\n",  # TODO: should this parse as a float?
         DefFrame(Frame([Qubit(0)], "rf"), sample_rate=2.0, initial_frequency=10),
     )
+    parse_equals(
+        'DEFFRAME 0 "rf":\n'
+        '    SAMPLE-RATE: 2.0\n'
+        '    INITIAL-FREQUENCY: 10\n'
+        '    ENABLE-RAW-CAPTURE: "true"',
+        DefFrame(
+            Frame([Qubit(0)], "rf"),
+            sample_rate=2.0,
+            initial_frequency=10,
+            enable_raw_capture="true",
+        ),
+    )
+    assert DefFrame(
+        Frame([Qubit(0)], "rf"), enable_raw_capture="true"
+    ).out() == 'DEFFRAME 0 "rf":\n    ENABLE-RAW-CAPTURE: "true"\n'
+
     with pytest.raises(UnexpectedToken) as excp:
         parse('DEFFRAME 0 "rf":\n' "    UNSUPPORTED: 2.0\n")
 


### PR DESCRIPTION
## Description

Add `ENABLE-RAW-CAPTURE` to DefFrame objects.

Closes #1537 

## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
