### PR TITLE
Re-write `get_classical_addresses_from_quil_program` to use `quil-rs`

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -155,7 +155,7 @@ def _convert_to_py_instruction(instr: quil_rs.Instruction) -> AbstractInstructio
     if instr.is_measurement():
         return Measurement._from_rs_measurement(instr.to_measurement())
     if isinstance(instr, quil_rs.Instruction):
-        raise NotImplementedError(f"The {instr} Instruction hasn't been mapped to an AbstractInstruction yet.")
+        raise NotImplementedError(f"The {type(instr)} Instruction hasn't been mapped to an AbstractInstruction yet.")
 
 
 def _convert_to_py_instructions(instrs: Iterable[quil_rs.Instruction]) -> List[AbstractInstruction]:

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -110,7 +110,7 @@ class AbstractInstruction(metaclass=_InstructionMeta):
     """
 
     def __str__(self) -> str:
-        return self.__str__()
+        return self.__repr__()
 
     def __eq__(self, other: object) -> bool:
         return isinstance(other, self.__class__) and str(self) == str(other)
@@ -155,7 +155,7 @@ def _convert_to_py_instruction(instr: quil_rs.Instruction) -> AbstractInstructio
     if instr.is_measurement():
         return Measurement._from_rs_measurement(instr.to_measurement())
     if isinstance(instr, quil_rs.Instruction):
-        raise NotImplementedError("This Instruction hasn't been mapped to an AbstractInstruction yet.")
+        raise NotImplementedError(f"The {instr} Instruction hasn't been mapped to an AbstractInstruction yet.")
 
 
 def _convert_to_py_instructions(instrs: Iterable[quil_rs.Instruction]) -> List[AbstractInstruction]:
@@ -394,7 +394,6 @@ class Measurement(quil_rs.Measurement, AbstractInstruction):
 
         if classical_reg is not None:
             try:
-                print(type(classical_reg))
                 classical_reg = _convert_to_rs_expression(classical_reg).to_address()
             except ValueError:
                 raise TypeError(f"classical_reg should be None or a MemoryReference instance")
@@ -709,6 +708,9 @@ class SimpleInstruction(AbstractInstruction):
 
     def out(self) -> str:
         return self.op
+
+    def __str__(self) -> str:
+        return self.out()
 
 
 class Halt(SimpleInstruction):
@@ -1151,6 +1153,9 @@ class Declare(AbstractInstruction):
                 ret += " OFFSET {} {}".format(offset[0], offset[1])
 
         return ret
+
+    def __str__(self) -> str:
+        return self.out()
 
     def __repr__(self) -> str:
         return "<DECLARE {}>".format(self.name)

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -99,7 +99,7 @@ DEFGATE XGATE:
 """
 
 
-# TODO: isinstance compatibility
+# TODO: Instruction API - DefGate
 def test_remove_reset_from_program(snapshot):
     p = Program(DEFGATE_X)
     p += RESET()
@@ -108,7 +108,7 @@ def test_remove_reset_from_program(snapshot):
     assert new_p.out() == snapshot
 
 
-# TODO: isinstance compatibility
+# TODO: Instruction API - RESET
 def test_generate_experiment_program():
     # simplest example
     p = Program()

--- a/test/unit/test_noise.py
+++ b/test/unit/test_noise.py
@@ -103,7 +103,6 @@ def test_damping_after_dephasing():
     np.testing.assert_allclose(noisy_rho, target_rho)
 
 
-# TODO isinstance compatibility
 def test_noise_helpers():
     gates = RX(np.pi / 2, 0), RX(-np.pi / 2, 1), I(1), CZ(0, 1)
     prog = Program(*gates)
@@ -111,7 +110,7 @@ def test_noise_helpers():
     assert set(inferred_gates) == set(gates)
 
 
-# TODO isinstance compatibility
+# TODO: Instruction API - DefGate
 def test_decoherence_noise():
     prog = Program(RX(np.pi / 2, 0), CZ(0, 1), RZ(np.pi, 0))
     gates = _get_program_gates(prog)

--- a/test/unit/test_numpy.py
+++ b/test/unit/test_numpy.py
@@ -56,7 +56,6 @@ def test_wfn_ordering_tensordot():
     np.testing.assert_allclose(two_q_wfn[:, 0], 1 / np.sqrt(2) * np.ones(2))
 
 
-# TODO isinstance compatibility
 def test_einsum_simulator_H():
     prog = Program(H(0))
     qam = PyQVM(n_qubits=1, quantum_simulator_type=NumpyWavefunctionSimulator)
@@ -65,7 +64,6 @@ def test_einsum_simulator_H():
     np.testing.assert_allclose(wf, 1 / np.sqrt(2) * np.ones(2))
 
 
-# TODO isinstance compatibility
 def test_einsum_simulator_1():
     prog = Program(H(0), CNOT(0, 1))
     qam = PyQVM(n_qubits=2, quantum_simulator_type=NumpyWavefunctionSimulator)
@@ -74,7 +72,6 @@ def test_einsum_simulator_1():
     np.testing.assert_allclose(wf, 1 / np.sqrt(2) * np.reshape([1, 0, 0, 1], (2, 2)))
 
 
-# TODO isinstance compatibility
 def test_einsum_simulator_CNOT():
     prog = Program(X(0), CNOT(0, 1))
     qam = PyQVM(n_qubits=2, quantum_simulator_type=NumpyWavefunctionSimulator)
@@ -83,7 +80,6 @@ def test_einsum_simulator_CNOT():
     np.testing.assert_allclose(wf, np.reshape([0, 0, 0, 1], (2, 2)))
 
 
-# TODO isinstance compatibility
 def test_einsum_simulator_CCNOT():
     prog = Program(X(2), X(0), CCNOT(2, 1, 0))
     qam = PyQVM(n_qubits=3, quantum_simulator_type=NumpyWavefunctionSimulator)
@@ -94,7 +90,7 @@ def test_einsum_simulator_CCNOT():
     np.testing.assert_allclose(wf, should_be)
 
 
-# TODO isinstance compatibility
+# TODO: Review PyQVM
 def test_einsum_simulator_10q():
     prog = Program(H(0))
     for i in range(10 - 1):
@@ -108,7 +104,7 @@ def test_einsum_simulator_10q():
     np.testing.assert_allclose(wf, should_be)
 
 
-# TODO isinstance compatibility
+# TODO: Review PyQVM
 def test_measure():
     qam = PyQVM(n_qubits=3, quantum_simulator_type=NumpyWavefunctionSimulator)
     qam.execute(Program(Declare("ro", "BIT", 64), H(0), CNOT(0, 1), MEASURE(0, MemoryReference("ro", 63))))
@@ -137,7 +133,7 @@ def include_measures(request):
     return request.param
 
 
-# TODO isinstance compatibility
+# TODO: Instruction API - Prefix Expression
 def test_vs_ref_simulator(n_qubits, prog_length, include_measures):
     if include_measures:
         seed = 52
@@ -167,7 +163,6 @@ def test_all_bitstrings():
         np.testing.assert_array_equal(bitstrings_ref, bitstrings_new)
 
 
-# TODO isinstance compatibility
 def test_sample_bitstrings():
     prog = Program(H(0), H(1))
     qam = PyQVM(n_qubits=3, quantum_simulator_type=NumpyWavefunctionSimulator, seed=52)
@@ -194,13 +189,11 @@ def test_expectation():
     assert val == 0.4
 
 
-# TODO isinstance compatibility
+# TODO: Instruction API - PrefixExpression
 def test_expectation_vs_ref_qvm(n_qubits):
     for _ in range(20):
         prog = _generate_random_program(n_qubits=n_qubits, length=10)
         operator = _generate_random_pauli(n_qubits=n_qubits, n_terms=5)
-        print(prog)
-        print(operator)
 
         ref_wf = ReferenceWavefunctionSimulator(n_qubits=n_qubits).do_program(prog)
         ref_exp = ref_wf.expectation(operator=operator)
@@ -210,7 +203,7 @@ def test_expectation_vs_ref_qvm(n_qubits):
         np.testing.assert_allclose(ref_exp, np_exp, atol=1e-15)
 
 
-# TODO isinstance compatibility
+# TODO: Instruction API - DefGate
 def test_defgate():
     # regression test for https://github.com/rigetti/pyquil/issues/1059
     theta = np.pi / 2

--- a/test/unit/test_operator_estimation.py
+++ b/test/unit/test_operator_estimation.py
@@ -36,7 +36,7 @@ from pyquil.paulis import sI, sX, sY, sZ, PauliSum
 from pyquil.quilbase import Pragma
 
 
-# TODO: Instruction API and compatibility
+# TODO: pickle compatibility
 def test_measure_observables(client_configuration: QCSClientConfiguration):
     expts = [
         ExperimentSetting(TensorProductState(), o1 * o2)

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -143,7 +143,7 @@ def test_construct_strength_two_orthogonal_array():
     assert np.allclose(_construct_strength_two_orthogonal_array(3), answer)
 
 
-# TODO: isinstance compatibility
+# TODO: pickle compatibility
 def test_measure_bitstrings(client_configuration: QCSClientConfiguration):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(2))
     dummy_compiler = DummyCompiler(quantum_processor=quantum_processor, client_configuration=client_configuration)
@@ -208,7 +208,6 @@ def test_run(client_configuration: QCSClientConfiguration):
         MEASURE(2, MemoryReference("ro", 2)),
     ).wrap_in_numshots_loop(1000)
     result = qc.run(p)
-    print(result)
     bitstrings = result.readout_data.get("ro")
 
     assert bitstrings.shape == (1000, 3)
@@ -236,7 +235,7 @@ def test_run_pyqvm_noiseless(client_configuration: QCSClientConfiguration):
     assert np.mean(parity) == 0
 
 
-# TODO: isinstance compatibility
+# TODO: Review PyQVM
 def test_run_pyqvm_noisy(client_configuration: QCSClientConfiguration):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(3))
     qc = QuantumComputer(
@@ -467,7 +466,7 @@ def test_qc_error(client_configuration: QCSClientConfiguration):
         get_qc("5q", as_qvm=False, client_configuration=client_configuration)
 
 
-# TODO:  Declarations API
+# TODO: Instruction API - Declare
 @pytest.mark.parametrize("param", [np.pi, [np.pi], np.array([np.pi])])
 def test_run_with_parameters(client_configuration: QCSClientConfiguration, param):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(3))
@@ -509,7 +508,7 @@ def test_run_with_bad_parameters(client_configuration: QCSClientConfiguration, p
         executable.write_memory(region_name="theta", value=param)
 
 
-# TODO: Declarations API
+# TODO: Instruction API - Declare
 def test_reset(client_configuration: QCSClientConfiguration):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(3))
     qc = QuantumComputer(
@@ -605,7 +604,7 @@ def test_orthogonal_array():
         num_q = oa.shape[1]
         num_cols = min(num_q, strength)
         column_idxs = random.sample(range(num_q), num_cols)
-        occurences = {entry: 0 for entry in range(2 ** num_cols)}
+        occurences = {entry: 0 for entry in range(2**num_cols)}
         for row in oa[:, column_idxs]:
             occurences[bit_array_to_int(row)] += 1
         assert all([count == occurences[0] for count in occurences.values()])
@@ -698,7 +697,7 @@ def asymmetric_ro_model(qubits: list, p00: float = 0.95, p11: float = 0.90) -> N
     return NoiseModel([], aprobs)
 
 
-# TODO: get_classical_adresses implementation
+# TODO: Instruction API - RESET
 def test_qc_calibration_1q(client_configuration: QCSClientConfiguration):
     # noise model with 95% symmetrized readout fidelity per qubit
     noise_model = asymmetric_ro_model([0], 0.945, 0.955)
@@ -723,7 +722,7 @@ def test_qc_calibration_1q(client_configuration: QCSClientConfiguration):
     assert results[0].total_counts == 20000
 
 
-# TODO: get_classical_adresses implementation
+# TODO: Instruction API - RESET
 def test_qc_calibration_2q(client_configuration: QCSClientConfiguration):
     # noise model with 95% symmetrized readout fidelity per qubit
     noise_model = asymmetric_ro_model([0, 1], 0.945, 0.955)
@@ -748,7 +747,7 @@ def test_qc_calibration_2q(client_configuration: QCSClientConfiguration):
     assert results[0].total_counts == 40000
 
 
-# TODO: get_classical_adresses implementation
+# TODO: Instruction API - RESET
 def test_qc_joint_expectation(client_configuration: QCSClientConfiguration, dummy_compiler: DummyCompiler):
     qc = QuantumComputer(name="testy!", qam=QVM(client_configuration=client_configuration), compiler=dummy_compiler)
 
@@ -787,7 +786,7 @@ def test_get_qc_noisy_qpu_error(client_configuration: QCSClientConfiguration, du
         get_qc("Aspen-8", noisy=True)
 
 
-# TODO: get_classical_adresses implementation
+# TODO: Instruction API - RESET
 def test_qc_joint_calibration(client_configuration: QCSClientConfiguration):
     # noise model with 95% symmetrized readout fidelity per qubit
     noise_model = asymmetric_ro_model([0, 1], 0.945, 0.955)
@@ -819,7 +818,7 @@ def test_qc_joint_calibration(client_configuration: QCSClientConfiguration):
     assert results[0].additional_results[1].total_counts == 40000
 
 
-# TODO: get_classical_adresses implementation
+# TODO: Instruction API - RESET
 def test_qc_expectation_on_qvm(client_configuration: QCSClientConfiguration, dummy_compiler: DummyCompiler):
     # regression test for https://github.com/rigetti/forest-tutorials/issues/2
     qc = QuantumComputer(name="testy!", qam=QVM(client_configuration=client_configuration), compiler=dummy_compiler)
@@ -871,7 +870,9 @@ def test_get_qc_endpoint_id(client_configuration: QCSClientConfiguration, qcs_as
 
 
 @respx.mock
-def test_get_qc_with_group_account(client_configuration: QCSClientConfiguration, qcs_aspen8_isa: InstructionSetArchitecture):
+def test_get_qc_with_group_account(
+    client_configuration: QCSClientConfiguration, qcs_aspen8_isa: InstructionSetArchitecture
+):
     """
     Assert that a client may specify a ``QCSClientConfigurationSettingsProfile`` representing a QCS group
     account and create a group account engagement via headers.
@@ -896,21 +897,23 @@ def test_get_qc_with_group_account(client_configuration: QCSClientConfiguration,
     respx.post(
         url=f"{client_configuration.profile.api_url}/v1/engagements",
         headers__contains={
-            'X-QCS-ACCOUNT-ID': 'group0',
-            'X-QCS-ACCOUNT-TYPE': QCSAccountType.group.value,
+            "X-QCS-ACCOUNT-ID": "group0",
+            "X-QCS-ACCOUNT-TYPE": QCSAccountType.group.value,
         },
-    ).respond(json={
-        'address': 'address',
-        'endpointId': 'endpointId',
-        'quantumProcessorId': 'quantumProcessorId',
-        'userId': 'userId',
-        'expiresAt': '01-01-2200T00:00:00Z',
-        'credentials': {
-            'clientPublic': 'faux',
-            'clientSecret': 'faux',
-            'serverPublic': 'faux',
+    ).respond(
+        json={
+            "address": "address",
+            "endpointId": "endpointId",
+            "quantumProcessorId": "quantumProcessorId",
+            "userId": "userId",
+            "expiresAt": "01-01-2200T00:00:00Z",
+            "credentials": {
+                "clientPublic": "faux",
+                "clientSecret": "faux",
+                "serverPublic": "faux",
+            },
         }
-    })
+    )
 
-    engagement = engagement_manager.get_engagement(quantum_processor_id='test')
-    assert 'faux' == engagement.credentials.client_public
+    engagement = engagement_manager.get_engagement(quantum_processor_id="test")
+    assert "faux" == engagement.credentials.client_public

--- a/test/unit/test_quil.py
+++ b/test/unit/test_quil.py
@@ -250,7 +250,7 @@ def test_prog_init(snapshot):
     assert p.out() == snapshot
 
 
-# TODO: declarations API
+# TODO: Instruction API - Declare
 def test_classical_regs():
     p = Program()
     p.inst(
@@ -260,8 +260,8 @@ def test_classical_regs():
     ).measure(0, MemoryReference("reg", 1))
     assert p.out() == "DECLARE reg BIT[2]\nDECLARE ro BIT[2]\nX 0\nMEASURE 0 reg[1]\n"
     assert p.declarations == {
-        "ro": Declare("ro", "BIT", 2),
         "reg": Declare("reg", "BIT", 2),
+        "ro": Declare("ro", "BIT", 2),
     }
 
 
@@ -1019,7 +1019,6 @@ def test_out_vs_str():
     assert re.fullmatch(should_be_re, string_version, flags=re.MULTILINE)
 
 
-# TODO: Re-implement get_classical_addresses_from_program
 def test_get_classical_addresses_from_program():
     p = Program(Declare("ro", "BIT", 4), [H(i) for i in range(4)])
     assert get_classical_addresses_from_program(p) == {}
@@ -1028,7 +1027,6 @@ def test_get_classical_addresses_from_program():
     assert get_classical_addresses_from_program(p) == {"ro": [0, 1, 3]}
 
 
-# TODO: Re-implement get_classical_addresses_from_program
 def test_get_classical_addresses_from_quil_program():
     """
     Tests that can get_classical_addresses_from_program can handle both MEASURE
@@ -1293,7 +1291,6 @@ def _eval_as_np_pi(exp):
     return eval(exp.replace("pi", repr(np.pi)).replace("theta[0]", "1"))
 
 
-# TODO: Instruction API
 def test_params_pi_and_precedence():
     trivial_pi = "3 * theta[0] / (2 * pi)"
     prog = Program(f"RX({trivial_pi}) 0")


### PR DESCRIPTION
Turns out we didn't have to touch `get_classical_addresses_from_quil_program` at all because the compatibility layer is doing its job. I did however patch a few holes elsewhere to get it to work. I also took the opportunity to review all the unit tests and update them to reflect their current state. The removal of a `TODO` above a test means that it's passing now, in other cases I updated the comment with more information. 