### PR TITLE
Back Frame and DefFrame with quil_rs

### DIFF
--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -849,6 +849,10 @@ class Frame(rs_instructions.FrameIdentifier):
     def __new__(cls, qubits: Sequence[Union[int, Qubit, FormalArgument]], name: str) -> "Frame":
         return super().__new__(cls, name, _convert_to_rs_qubits(qubits))
 
+    @classmethod
+    def _from_rs_frame_identifier(cls, frame: rs_instructions.FrameIdentifier) -> "Frame":
+        return cls(frame.qubits, frame.name)
+
     @property
     def qubits(self) -> Tuple[QubitDesignator]:
         return tuple(_convert_to_py_qubits(super().qubits))

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -858,6 +858,7 @@ class Frame(QuilAtom):
         return self.out()
 
     def out(self) -> str:
+        print("qubits", self.qubits)
         return " ".join([q.out() for q in self.qubits]) + f' "{self.name}"'
 
 

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -856,16 +856,16 @@ class Frame(quil_rs.FrameIdentifier):
         return tuple(_convert_to_py_qubits(super().qubits))
 
     @qubits.setter
-    def qubits(self, _):
-        raise FrozenInstanceError()
+    def qubits(self, qubits: Tuple[Qubit, FormalArgument]):
+        return quil_rs.FrameIdentifier.qubits.__set__(self, _convert_to_rs_qubits(qubits))
 
     @property
     def name(self) -> str:
         return super().name
 
     @name.setter
-    def name(self, _):
-        raise FrozenInstanceError()
+    def name(self, name: str):
+        return quil_rs.FrameIdentifier.name.__set__(self, name)
 
     def out(self) -> str:
         return str(self)

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1521,3 +1521,6 @@ class DefFrame(AbstractInstruction):
                 else:
                     r += f"\n    {name}: {json.dumps(value)}"
         return r + "\n"
+
+    def __str__(self) -> str:
+        return self.out()

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1546,23 +1546,23 @@ class DefFrame(quil_rs.FrameDefinition, AbstractInstruction):
 
     @property
     def direction(self) -> Optional[str]:
-        return self._get_attribute("direction")
+        return self._get_attribute("direction")  # type: ignore
 
     @direction.setter
     def direction(self, direction: str):
         self._set_attribute("direction", direction)
 
     @property
-    def initial_frequency(self) -> Optional[None]:
-        return self._get_attribute("initial_frequency")
+    def initial_frequency(self) -> Optional[float]:
+        return self._get_attribute("initial_frequency")  # type: ignore
 
     @initial_frequency.setter
     def initial_frequency(self, initial_frequency: float):
         self._set_attribute("initial_frequency", initial_frequency)
 
     @property
-    def hardware_object(self) -> Frame:
-        return self._get_attribute("hardware_object")
+    def hardware_object(self) -> Optional[str]:
+        return self._get_attribute("hardware_object")  # type: ignore
 
     @hardware_object.setter
     def hardware_object(self, hardware_object: str):
@@ -1570,7 +1570,7 @@ class DefFrame(quil_rs.FrameDefinition, AbstractInstruction):
 
     @property
     def sample_rate(self) -> Frame:
-        return self._get_attribute("sample_rate")
+        return self._get_attribute("sample_rate")  # type: ignore
 
     @sample_rate.setter
     def sample_rate(self, sample_rate: float):
@@ -1578,7 +1578,7 @@ class DefFrame(quil_rs.FrameDefinition, AbstractInstruction):
 
     @property
     def center_frequency(self) -> Frame:
-        return self._get_attribute("center_frequency")
+        return self._get_attribute("center_frequency")  # type: ignore
 
     @center_frequency.setter
     def center_frequency(self, center_frequency: float):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -76,6 +76,7 @@ if TYPE_CHECKING:
 from dataclasses import dataclass
 
 import qcs_sdk.quil.instructions as quil_rs
+import qcs_sdk.quil.expression as quil_rs_expr
 
 
 class _InstructionMeta(abc.ABCMeta):
@@ -1484,43 +1485,96 @@ class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstru
         return str(self)
 
 
-@dataclass
-class DefFrame(AbstractInstruction):
-    frame: Frame
-    """ The frame being defined. """
+class DefFrame(quil_rs.FrameDefinition, AbstractInstruction):
+    @staticmethod
+    def __new__(
+        cls,
+        frame: Frame,
+        direction: Optional[str] = None,
+        initial_frequency: Optional[float] = None,
+        hardware_object: Optional[str] = None,
+        sample_rate: Optional[float] = None,
+        center_frequency: Optional[float] = None,
+    ) -> "DefFrame":
+        attributes = {
+            key: DefFrame._to_attribute_value(value)
+            for key, value in zip(
+                ["direction", "initial_frequency", "hardware_object", "sample_rate", "center_frequency"],
+                [direction, initial_frequency, hardware_object, sample_rate, center_frequency],
+            )
+            if value is not None
+        }
+        return super().__new__(cls, frame, attributes)
 
-    direction: Optional[str] = None
-    """ The direction of the frame, i.e. 'tx' or 'rx'. """
-
-    initial_frequency: Optional[float] = None
-    """ The initial frequency of the frame. """
-
-    hardware_object: Optional[str] = None
-    """ The name of the hardware object associated to the frame. """
-
-    sample_rate: Optional[float] = None
-    """ The sample rate of the frame [Hz]. """
-
-    center_frequency: Optional[float] = None
-    """ The 'center' frequency of the frame, used for detuning arithmetic. """
+    @staticmethod
+    def _to_attribute_value(value: Union[str, float]) -> quil_rs.AttributeValue:
+        if isinstance(value, str):
+            return quil_rs.AttributeValue.from_string(value)
+        if isinstance(value, float):
+            return quil_rs.AttributeValue.from_expression(quil_rs_expr.Expression.from_number(complex(value)))
+        raise ValueError(f"{type(value)} is not a valid AttributeValue")
 
     def out(self) -> str:
-        r = f"DEFFRAME {self.frame.out()}"
-        options = [
-            (self.direction, "DIRECTION"),
-            (self.initial_frequency, "INITIAL-FREQUENCY"),
-            (self.center_frequency, "CENTER-FREQUENCY"),
-            (self.hardware_object, "HARDWARE-OBJECT"),
-            (self.sample_rate, "SAMPLE-RATE"),
-        ]
-        if any(value for (value, name) in options):
-            r += ":"
-            for value, name in options:
-                if value is None:
-                    continue
-                else:
-                    r += f"\n    {name}: {json.dumps(value)}"
-        return r + "\n"
+        return str(self)
 
-    def __str__(self) -> str:
-        return self.out()
+    @property
+    def frame(self) -> Frame:
+        return Frame._from_rs_frame_identifier(super().identifier)
+
+    @frame.setter
+    def frame(self, frame: Frame):
+        quil_rs.FrameDefinition.identifier.__set__(self, frame)
+
+    def _set_attribute(self, name: str, value: Union[str, float]):
+        updated = super().attributes
+        updated.update({name: DefFrame._to_attribute_value(value)})
+        quil_rs.FrameDefinition.attributes.__set__(self, updated)
+
+    def _get_attribute(self, name: str) -> Optional[Union[str, float]]:
+        value = super().attributes.get(name, None)
+        if value is None:
+            return None
+        if value.is_string():
+            return value.to_string()
+        if value.is_expression():
+            return value.to_expression().to_number().real
+
+    @property
+    def direction(self) -> Optional[str]:
+        return self._get_attribute("direction")
+
+    @direction.setter
+    def direction(self, direction: str):
+        self._set_attribute("direction", direction)
+
+    @property
+    def initial_frequency(self) -> Optional[None]:
+        return self._get_attribute("initial_frequency")
+
+    @initial_frequency.setter
+    def initial_frequency(self, initial_frequency: float):
+        self._set_attribute("initial_frequency", initial_frequency)
+
+    @property
+    def hardware_object(self) -> Frame:
+        return self._get_attribute("hardware_object")
+
+    @hardware_object.setter
+    def hardware_object(self, hardware_object: str):
+        self._set_attribute("hardware_object", hardware_object)
+
+    @property
+    def sample_rate(self) -> Frame:
+        return self._get_attribute("sample_rate")
+
+    @sample_rate.setter
+    def sample_rate(self, sample_rate: float):
+        self._set_attribute("sample_rate", sample_rate)
+
+    @property
+    def center_frequency(self) -> Frame:
+        return self._get_attribute("center_frequency")
+
+    @center_frequency.setter
+    def center_frequency(self, center_frequency: float):
+        self._set_attribute("center_frequency", center_frequency)

--- a/test/unit/__snapshots__/test_quilatom.ambr
+++ b/test/unit/__snapshots__/test_quilatom.ambr
@@ -1,0 +1,24 @@
+# name: TestFrame.test_out[With-FormalArgument]
+  'One "FRAME"'
+# ---
+# name: TestFrame.test_out[With-Mixed]
+  '0 One 2 "FRAME"'
+# ---
+# name: TestFrame.test_out[With-Qubit]
+  '0 "FRAME"'
+# ---
+# name: TestFrame.test_out[With-int]
+  '2 "FRAME"'
+# ---
+# name: TestFrame.test_str[With-FormalArgument]
+  'One "FRAME"'
+# ---
+# name: TestFrame.test_str[With-Mixed]
+  '0 One 2 "FRAME"'
+# ---
+# name: TestFrame.test_str[With-Qubit]
+  '0 "FRAME"'
+# ---
+# name: TestFrame.test_str[With-int]
+  '2 "FRAME"'
+# ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -25,28 +25,40 @@
 # name: TestDefFrame.test_out[Frame-Only]
   'DEFFRAME 0 "frame":'
 # ---
+# name: TestDefFrame.test_out[Frame-Only].1
+  set({
+  })
+# ---
 # name: TestDefFrame.test_out[With-Optionals]
-  '''
-  DEFFRAME 1 "frame":
-  	direction: "direction"
-  	sample_rate: 44.1
-  	hardware_object: "hardware_object"
-  	initial_frequency: 1.39
-  	center_frequency: 440
-  '''
+  'DEFFRAME 1 "frame":'
+# ---
+# name: TestDefFrame.test_out[With-Optionals].1
+  set({
+    '\tcenter_frequency: 440',
+    '\tdirection: "direction"',
+    '\thardware_object: "hardware_object"',
+    '\tinitial_frequency: 1.39',
+    '\tsample_rate: 44.1',
+  })
 # ---
 # name: TestDefFrame.test_str[Frame-Only]
   'DEFFRAME 0 "frame":'
 # ---
+# name: TestDefFrame.test_str[Frame-Only].1
+  set({
+  })
+# ---
 # name: TestDefFrame.test_str[With-Optionals]
-  '''
-  DEFFRAME 1 "frame":
-  	initial_frequency: 1.39
-  	hardware_object: "hardware_object"
-  	direction: "direction"
-  	center_frequency: 440
-  	sample_rate: 44.1
-  '''
+  'DEFFRAME 1 "frame":'
+# ---
+# name: TestDefFrame.test_str[With-Optionals].1
+  set({
+    '\tcenter_frequency: 440',
+    '\tdirection: "direction"',
+    '\thardware_object: "hardware_object"',
+    '\tinitial_frequency: 1.39',
+    '\tsample_rate: 44.1',
+  })
 # ---
 # name: TestDefMeasureCalibration.test_out[MemoryReference]
   '''

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -23,37 +23,29 @@
   '''
 # ---
 # name: TestDefFrame.test_out[Frame-Only]
-  '''
-  DEFFRAME 0 "frame"
-  
-  '''
+  'DEFFRAME 0 "frame":'
 # ---
 # name: TestDefFrame.test_out[With-Optionals]
   '''
   DEFFRAME 1 "frame":
-      DIRECTION: "direction"
-      INITIAL-FREQUENCY: 1.39
-      CENTER-FREQUENCY: 440.0
-      HARDWARE-OBJECT: "hardware_object"
-      SAMPLE-RATE: 44.1
-  
+  	direction: "direction"
+  	sample_rate: 44.1
+  	hardware_object: "hardware_object"
+  	initial_frequency: 1.39
+  	center_frequency: 440
   '''
 # ---
 # name: TestDefFrame.test_str[Frame-Only]
-  '''
-  DEFFRAME 0 "frame"
-  
-  '''
+  'DEFFRAME 0 "frame":'
 # ---
 # name: TestDefFrame.test_str[With-Optionals]
   '''
   DEFFRAME 1 "frame":
-      DIRECTION: "direction"
-      INITIAL-FREQUENCY: 1.39
-      CENTER-FREQUENCY: 440.0
-      HARDWARE-OBJECT: "hardware_object"
-      SAMPLE-RATE: 44.1
-  
+  	initial_frequency: 1.39
+  	hardware_object: "hardware_object"
+  	direction: "direction"
+  	center_frequency: 440
+  	sample_rate: 44.1
   '''
 # ---
 # name: TestDefMeasureCalibration.test_out[MemoryReference]

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -22,6 +22,40 @@
   	X 0
   '''
 # ---
+# name: TestDefFrame.test_out[Frame-Only]
+  '''
+  DEFFRAME 0 "frame"
+  
+  '''
+# ---
+# name: TestDefFrame.test_out[With-Optionals]
+  '''
+  DEFFRAME 1 "frame":
+      DIRECTION: "direction"
+      INITIAL-FREQUENCY: 1.39
+      CENTER-FREQUENCY: 440.0
+      HARDWARE-OBJECT: "hardware_object"
+      SAMPLE-RATE: 44.1
+  
+  '''
+# ---
+# name: TestDefFrame.test_str[Frame-Only]
+  '''
+  DEFFRAME 0 "frame"
+  
+  '''
+# ---
+# name: TestDefFrame.test_str[With-Optionals]
+  '''
+  DEFFRAME 1 "frame":
+      DIRECTION: "direction"
+      INITIAL-FREQUENCY: 1.39
+      CENTER-FREQUENCY: 440.0
+      HARDWARE-OBJECT: "hardware_object"
+      SAMPLE-RATE: 44.1
+  
+  '''
+# ---
 # name: TestDefMeasureCalibration.test_out[MemoryReference]
   '''
   DEFCAL MEASURE 1 theta:

--- a/test/unit/test_quilatom.py
+++ b/test/unit/test_quilatom.py
@@ -1,0 +1,38 @@
+from dataclasses import FrozenInstanceError
+from typing import Sequence, Union
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from pyquil.quilatom import FormalArgument, Frame, Qubit
+
+
+@pytest.mark.parametrize(
+    ("qubits", "name"),
+    [
+        ([Qubit(0)], "FRAME"),
+        ([FormalArgument("One")], "FRAME"),
+        ([2], "FRAME"),
+        ([Qubit(0), FormalArgument("One"), 2], "FRAME"),
+    ],
+    ids=("With-Qubit", "With-FormalArgument", "With-int", "With-Mixed"),
+)
+class TestFrame:
+    @pytest.fixture
+    def frame(self, qubits: Sequence[Union[int, Qubit, FormalArgument]], name: str):
+        return Frame(qubits, name)
+
+    def test_out(self, frame: Frame, snapshot: SnapshotAssertion):
+        assert frame.out() == snapshot
+
+    def test_str(self, frame: Frame, snapshot: SnapshotAssertion):
+        assert str(frame) == snapshot
+
+    def test_qubits(self, frame: Frame, qubits: Sequence[Union[int, Qubit, FormalArgument]]):
+        assert frame.qubits == tuple(Qubit(q) if isinstance(q, int) else q for q in qubits)
+        with pytest.raises(FrozenInstanceError):
+            frame.qubits = (Qubit(2), FormalArgument("One"))
+
+    def test_name(self, frame: Frame, name: str):
+        assert frame.name == name
+        with pytest.raises(FrozenInstanceError):
+            frame.name = "new name"

--- a/test/unit/test_quilatom.py
+++ b/test/unit/test_quilatom.py
@@ -1,4 +1,3 @@
-from dataclasses import FrozenInstanceError
 from typing import Sequence, Union
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -29,13 +28,13 @@ class TestFrame:
 
     def test_qubits(self, frame: Frame, qubits: Sequence[Union[int, Qubit, FormalArgument]]):
         assert frame.qubits == tuple(Qubit(q) if isinstance(q, int) else q for q in qubits)
-        with pytest.raises(FrozenInstanceError):
-            frame.qubits = (Qubit(2), FormalArgument("One"))
+        frame.qubits = (Qubit(2), FormalArgument("One"))
+        assert frame.qubits == (Qubit(2), FormalArgument("One"))
 
     def test_name(self, frame: Frame, name: str):
         assert frame.name == name
-        with pytest.raises(FrozenInstanceError):
-            frame.name = "new name"
+        frame.name = "new name"
+        assert frame.name == "new name"
 
     def test_eq(self, frame: Frame):
         assert frame == frame

--- a/test/unit/test_quilatom.py
+++ b/test/unit/test_quilatom.py
@@ -36,3 +36,7 @@ class TestFrame:
         assert frame.name == name
         with pytest.raises(FrozenInstanceError):
             frame.name = "new name"
+
+    def test_eq(self, frame: Frame):
+        assert frame == frame
+        assert frame != Frame([], "definitely-not-eq")

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -9,6 +9,7 @@ from pyquil.quil import Program
 from pyquil.quilbase import (
     AbstractInstruction,
     DefCalibration,
+    DefFrame,
     DefMeasureCalibration,
     Gate,
     Measurement,
@@ -16,7 +17,7 @@ from pyquil.quilbase import (
     ParameterDesignator,
     Parameter,
 )
-from pyquil.quilatom import BinaryExp, Qubit
+from pyquil.quilatom import BinaryExp, Frame, Qubit
 from pyquil.api._compiler import QPUCompiler
 
 
@@ -195,3 +196,66 @@ class TestMeasurement:
         assert measurement.classical_reg == classical_reg
         measurement.classical_reg = MemoryReference("new_mem_ref")
         assert measurement.classical_reg == MemoryReference("new_mem_ref")
+
+
+@pytest.mark.parametrize(
+    ("frame", "direction", "initial_frequency", "hardware_object", "sample_rate", "center_frequency"),
+    [
+        (Frame([Qubit(0)], "frame"), None, None, None, None, None),
+        (Frame([Qubit(1)], "frame"), "direction", 1.39, "hardware_object", 44.1, 440.0),
+    ],
+    ids=("Frame-Only", "With-Optionals"),
+)
+class TestDefFrame:
+    @pytest.fixture
+    def def_frame(
+        self,
+        frame: Frame,
+        direction: Optional[str],
+        initial_frequency: Optional[float],
+        hardware_object: Optional[str],
+        sample_rate: Optional[float],
+        center_frequency: Optional[float],
+    ):
+        optional_args = [
+            arg
+            for arg in [direction, initial_frequency, hardware_object, sample_rate, center_frequency]
+            if arg is not None
+        ]
+        return DefFrame(frame, *optional_args)
+
+    def test_out(self, def_frame: DefFrame, snapshot: SnapshotAssertion):
+        assert def_frame.out() == snapshot
+
+    def test_str(self, def_frame: DefFrame, snapshot: SnapshotAssertion):
+        assert str(def_frame) == snapshot
+
+    def test_frame(self, def_frame: DefFrame, frame: Frame):
+        assert def_frame.frame == frame
+        def_frame.frame = Frame([Qubit(123)], "new_frame")
+        assert def_frame.frame == Frame([Qubit(123)], "new_frame")
+
+    def test_direction(self, def_frame: DefFrame, direction: Optional[str]):
+        assert def_frame.direction == direction
+        def_frame.direction = "tx"
+        assert def_frame.direction == "tx"
+
+    def test_initial_frequency(self, def_frame: DefFrame, initial_frequency: Optional[float]):
+        assert def_frame.initial_frequency == initial_frequency
+        def_frame.initial_frequency = 3.14
+        assert def_frame.initial_frequency == 3.14
+
+    def test_hardware_object(self, def_frame: DefFrame, hardware_object: Optional[str]):
+        assert def_frame.hardware_object == hardware_object
+        def_frame.hardware_object = "bfg"
+        assert def_frame.hardware_object == "bfg"
+
+    def test_sample_rate(self, def_frame: DefFrame, sample_rate: Optional[float]):
+        assert def_frame.sample_rate == sample_rate
+        def_frame.sample_rate = 96.0
+        assert def_frame.sample_rate == 96.0
+
+    def test_center_frequency(self, def_frame: DefFrame, center_frequency: Optional[float]):
+        assert def_frame.center_frequency == center_frequency
+        def_frame.center_frequency = 432.0
+        assert def_frame.center_frequency == 432.0

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -225,10 +225,17 @@ class TestDefFrame:
         return DefFrame(frame, *optional_args)
 
     def test_out(self, def_frame: DefFrame, snapshot: SnapshotAssertion):
-        assert def_frame.out() == snapshot
+        # The ordering of attributes isn't stable and can be printed in different orders across calls.
+        # We assert that the first line is definitely the `DEFFRAME` line, and that the following
+        # attributes are the same, regardless of their order.
+        quil_lines = def_frame.out().splitlines()
+        assert quil_lines[0] == snapshot
+        assert set(quil_lines[1:]) == snapshot
 
     def test_str(self, def_frame: DefFrame, snapshot: SnapshotAssertion):
-        assert str(def_frame) == snapshot
+        quil_lines = str(def_frame).splitlines()
+        assert quil_lines[0] == snapshot
+        assert set(quil_lines[1:]) == snapshot
 
     def test_frame(self, def_frame: DefFrame, frame: Frame):
         assert def_frame.frame == frame


### PR DESCRIPTION
## Description

Does what it says on the tin, backs the `Frame` and `DefFrame` classes with `quil_rs.FrameIdentifier`, and `quil_rs.FrameDefinition`, respectively.

The original classes were `@dataclass`es. In order to subclass them properly, I removed the `@dataclass` decorator. This may result in unexpected breaking changes. Might be worth labeling it as such, even if we think most of the functionality is the same.