### PR TITLE
update tests now that a `quil-rs` `Program` can be pickled

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5,7 +5,7 @@ name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
@@ -79,7 +79,7 @@ name = "babel"
 version = "2.11.0"
 description = "Internationalization utilities"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "Babel-2.11.0-py3-none-any.whl", hash = "sha256:1ad3eca1c885218f6dce2ab67291178944f810a10a9b5f3cb8382a5a232b64fe"},
@@ -279,7 +279,7 @@ name = "charset-normalizer"
 version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6.0"
 files = [
     {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
@@ -332,7 +332,7 @@ name = "commonmark"
 version = "0.9.1"
 description = "Python parser for the CommonMark Markdown spec"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
@@ -449,7 +449,7 @@ name = "docutils"
 version = "0.16"
 description = "Docutils -- Python Documentation Utilities"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
@@ -605,7 +605,7 @@ name = "imagesize"
 version = "1.4.1"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
@@ -737,7 +737,7 @@ name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
@@ -849,7 +849,7 @@ name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
@@ -1454,7 +1454,7 @@ name = "pygments"
 version = "2.13.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
@@ -1753,7 +1753,7 @@ name = "pytz"
 version = "2022.6"
 description = "World timezone definitions, modern and historical"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "pytz-2022.6-py2.py3-none-any.whl", hash = "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427"},
@@ -1906,17 +1906,30 @@ files = []
 develop = false
 
 [package.dependencies]
-commonmark = ">=0.8.1"
-docutils = ">=0.11"
-sphinx = ">=1.3.1"
+quil = {git = "https://github.com/rigetti/quil-rs", branch = "1455-python-support-for-program-and-beyond"}
 
 [package.source]
 type = "git"
 url = "https://github.com/rigetti/qcs-sdk-rust"
 reference = "specify-quil-as-a-dependency"
-resolved_reference = "758b3c5e587e8798003c1132402781097b61a089"
+resolved_reference = "eeabbd3af08e2fd93beee1e68a619a69a4421115"
 subdirectory = "crates/python"
+[[package]]
+name = "quil"
+version = "0.1.0"
+description = "A Python package for building and parsing Quil programs."
+category = "main"
+optional = false
+python-versions = "^3.8"
+files = []
+develop = false
 
+[package.source]
+type = "git"
+url = "https://github.com/rigetti/quil-rs"
+reference = "1455-python-support-for-program-and-beyond"
+resolved_reference = "ccb803e40e51cc33b977df88d154221edee045aa"
+subdirectory = "quil-py"
 [[package]]
 name = "recommonmark"
 version = "0.7.1"
@@ -1939,7 +1952,7 @@ name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7, <4"
 files = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
@@ -2200,7 +2213,7 @@ name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
@@ -2224,7 +2237,7 @@ name = "sphinx"
 version = "4.5.0"
 description = "Python documentation generator"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "Sphinx-4.5.0-py3-none-any.whl", hash = "sha256:ebf612653238bcc8f4359627a9b7ce44ede6fdd75d9d30f68255c7383d3a6226"},
@@ -2279,7 +2292,7 @@ name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
@@ -2295,7 +2308,7 @@ name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
@@ -2311,7 +2324,7 @@ name = "sphinxcontrib-htmlhelp"
 version = "2.0.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"},
@@ -2327,7 +2340,7 @@ name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
@@ -2342,7 +2355,7 @@ name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
@@ -2358,7 +2371,7 @@ name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
@@ -2506,7 +2519,7 @@ name = "urllib3"
 version = "1.26.13"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
     {file = "urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1897,7 +1897,7 @@ toml = ">=0.10.2,<0.11.0"
 
 [[package]]
 name = "qcs-sdk-python"
-version = "0.5.0-rc.8"
+version = "0.5.0-rc.11"
 description = "Python interface for the QCS Rust SDK"
 category = "main"
 optional = false
@@ -1905,12 +1905,26 @@ python-versions = "^3.8"
 files = []
 develop = false
 
+[package.dependencies]
+quil = {path = "../../../quil-rs/quil-py"}
+
 [package.source]
-type = "git"
-url = "https://github.com/rigetti/qcs-sdk-rust"
-reference = "reexport-quil-py"
-resolved_reference = "97692714637d3ae121537a6f10d734a526b3943f"
-subdirectory = "crates/python"
+type = "directory"
+url = "../qcs-sdk-rust/crates/python"
+
+[[package]]
+name = "quil"
+version = "0.1.0"
+description = "A Python package for building and parsing Quil programs."
+category = "main"
+optional = false
+python-versions = "^3.8"
+files = []
+develop = false
+
+[package.source]
+type = "directory"
+url = "../quil-rs/quil-py"
 
 [[package]]
 name = "recommonmark"
@@ -2560,4 +2574,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<3.11"
-content-hash = "1f2de6d8dccda55ef48bcf43175b557ee3ae00d64370b37e80a0422833b43c03"
+content-hash = "a53a9c599ea176b566ddb4a381cc375ef9702a8527a087a502bd845322b19d62"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5,7 +5,7 @@ name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
@@ -79,7 +79,7 @@ name = "babel"
 version = "2.11.0"
 description = "Internationalization utilities"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "Babel-2.11.0-py3-none-any.whl", hash = "sha256:1ad3eca1c885218f6dce2ab67291178944f810a10a9b5f3cb8382a5a232b64fe"},
@@ -279,7 +279,7 @@ name = "charset-normalizer"
 version = "2.1.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6.0"
 files = [
     {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},
@@ -332,7 +332,7 @@ name = "commonmark"
 version = "0.9.1"
 description = "Python parser for the CommonMark Markdown spec"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
@@ -449,7 +449,7 @@ name = "docutils"
 version = "0.16"
 description = "Docutils -- Python Documentation Utilities"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},
@@ -605,7 +605,7 @@ name = "imagesize"
 version = "1.4.1"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
@@ -737,7 +737,7 @@ name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
@@ -849,7 +849,7 @@ name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 files = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
@@ -1454,7 +1454,7 @@ name = "pygments"
 version = "2.13.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
@@ -1753,7 +1753,7 @@ name = "pytz"
 version = "2022.6"
 description = "World timezone definitions, modern and historical"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "pytz-2022.6-py2.py3-none-any.whl", hash = "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427"},
@@ -1906,25 +1906,16 @@ files = []
 develop = false
 
 [package.dependencies]
-quil = {path = "../../../quil-rs/quil-py"}
+commonmark = ">=0.8.1"
+docutils = ">=0.11"
+sphinx = ">=1.3.1"
 
 [package.source]
-type = "directory"
-url = "../qcs-sdk-rust/crates/python"
-
-[[package]]
-name = "quil"
-version = "0.1.0"
-description = "A Python package for building and parsing Quil programs."
-category = "main"
-optional = false
-python-versions = "^3.8"
-files = []
-develop = false
-
-[package.source]
-type = "directory"
-url = "../quil-rs/quil-py"
+type = "git"
+url = "https://github.com/rigetti/qcs-sdk-rust"
+reference = "specify-quil-as-a-dependency"
+resolved_reference = "758b3c5e587e8798003c1132402781097b61a089"
+subdirectory = "crates/python"
 
 [[package]]
 name = "recommonmark"
@@ -1948,7 +1939,7 @@ name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7, <4"
 files = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
@@ -2209,7 +2200,7 @@ name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
@@ -2233,7 +2224,7 @@ name = "sphinx"
 version = "4.5.0"
 description = "Python documentation generator"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "Sphinx-4.5.0-py3-none-any.whl", hash = "sha256:ebf612653238bcc8f4359627a9b7ce44ede6fdd75d9d30f68255c7383d3a6226"},
@@ -2288,7 +2279,7 @@ name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
@@ -2304,7 +2295,7 @@ name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
@@ -2320,7 +2311,7 @@ name = "sphinxcontrib-htmlhelp"
 version = "2.0.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"},
@@ -2336,7 +2327,7 @@ name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
@@ -2351,7 +2342,7 @@ name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
@@ -2367,7 +2358,7 @@ name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
@@ -2515,7 +2506,7 @@ name = "urllib3"
 version = "1.26.13"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
     {file = "urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc"},
@@ -2574,4 +2565,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<3.11"
-content-hash = "a53a9c599ea176b566ddb4a381cc375ef9702a8527a087a502bd845322b19d62"
+content-hash = "2015363db62d4a9de3a07394bec65dae98e5b20b6cb5185e175b7f3abe5fd538"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ lark = "^0.11.1"
 rpcq = "^3.10.0"
 networkx = "^2.5"
 importlib-metadata = { version = ">=3.7.3,<5", python = "<3.8" }
-qcs-sdk-python = { path = "../qcs-sdk-rust/crates/python" }
+qcs-sdk-python = { git = "https://github.com/rigetti/qcs-sdk-rust", subdirectory = "crates/python", branch = "specify-quil-as-a-dependency" }
 qcs-api-client = ">=0.21.0,<0.22.0"
 retry = "^0.9.2"
 types-python-dateutil = "^2.8.19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ lark = "^0.11.1"
 rpcq = "^3.10.0"
 networkx = "^2.5"
 importlib-metadata = { version = ">=3.7.3,<5", python = "<3.8" }
-qcs-sdk-python = { git = "https://github.com/rigetti/qcs-sdk-rust", subdirectory = "crates/python", branch = "reexport-quil-py" }
+qcs-sdk-python = { path = "../qcs-sdk-rust/crates/python" }
 qcs-api-client = ">=0.21.0,<0.22.0"
 retry = "^0.9.2"
 types-python-dateutil = "^2.8.19"

--- a/pyquil/api/_abstract_compiler.py
+++ b/pyquil/api/_abstract_compiler.py
@@ -20,7 +20,8 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 import asyncio
 import json
 
-import qcs_sdk
+from qcs_sdk.compiler.quilc import compile_program, CompilerOpts, TargetDevice
+from qcs_sdk.qpu.isa import InstructionSetArchitecture
 
 from pyquil._memory import Memory
 from pyquil._version import pyquil_version
@@ -129,10 +130,10 @@ class AbstractCompiler(ABC):
         # This will have to be addressed as part of this issue: https://github.com/rigetti/pyquil/issues/1496
         target_device = compiler_isa_to_target_quantum_processor(self.quantum_processor.to_compiler_isa())
 
-        native_quil = qcs_sdk.compile(
+        native_quil = compile_program(
             program.out(calibrations=False),
-            json.dumps(target_device.asdict(), indent=2),  # type: ignore
-            timeout=self._compiler_client.timeout,
+            TargetDevice.from_json(json.dumps(target_device.asdict())),
+            options=CompilerOpts(timeout=self._compiler_client.timeout, protoquil=protoquil),
         )
 
         native_program = Program(native_quil)

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -86,8 +86,8 @@ from pyquil.quiltcalibrations import (
     _convert_to_calibration_match,
 )
 
-from qcs_sdk.quil.program import Program as RSProgram
-import qcs_sdk.quil.instructions as quil_rs
+from quil.program import Program as RSProgram
+import quil.instructions as quil_rs
 
 InstructionDesignator = Union[
     AbstractInstruction,

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -36,8 +36,8 @@ from typing import (
 
 import numpy as np
 
-import qcs_sdk.quil.instructions as quil_rs
-import qcs_sdk.quil.expression as quil_rs_expr
+import quil.instructions as quil_rs
+import quil.expression as quil_rs_expr
 
 
 class QuilAtom(object):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -75,8 +75,8 @@ if TYPE_CHECKING:
 
 from dataclasses import dataclass
 
-import qcs_sdk.quil.instructions as quil_rs
-import qcs_sdk.quil.expression as quil_rs_expr
+import quil.instructions as quil_rs
+import quil.expression as quil_rs_expr
 
 
 class _InstructionMeta(abc.ABCMeta):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -150,7 +150,7 @@ def _convert_to_py_instruction(instr: quil_rs.Instruction) -> AbstractInstructio
         instr = instr.inner()
     if isinstance(instr, quil_rs.Declaration):
         return Declare._from_rs_declaration(instr)
-    if isinstance(instr, quil_rs.DefCalibration):
+    if isinstance(instr, quil_rs.Calibration):
         return DefCalibration._from_rs_calibration(instr)
     if isinstance(instr, quil_rs.Gate):
         return Gate._from_rs_gate(instr)

--- a/pyquil/quiltcalibrations.py
+++ b/pyquil/quiltcalibrations.py
@@ -41,8 +41,8 @@ from pyquil.quilbase import (
     _convert_to_py_qubit,
 )
 
-from qcs_sdk.quil.program import CalibrationSet
-import qcs_sdk.quil.instructions as quil_rs
+from quil.program import CalibrationSet
+import quil.instructions as quil_rs
 
 
 class CalibrationError(Exception):

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -128,20 +128,6 @@
     '\tSAMPLE-RATE: 44.1',
   })
 # ---
-# name: TestDefMeasureCalibration.test_out[MemoryReference]
-  '''
-  DEFCAL MEASURE 1 theta:
-  	X 0
-  
-  '''
-# ---
-# name: TestDefMeasureCalibration.test_out[No-MemoryReference]
-  '''
-  DEFCAL MEASURE 0 :
-  	X 0
-  
-  '''
-# ---
 # name: TestDefMeasureCalibration.test_out[qubit0-memory_reference0-instrs0]
   '''
   DEFCAL MEASURE 0 theta:
@@ -209,17 +195,11 @@
 # name: TestGate.test_str[X-Gate]
   'X 0'
 # ---
-# name: TestMeasurement.test_out[FormalArgument]
-  'MEASURE q theta'
-# ---
 # name: TestMeasurement.test_out[MemoryReference]
   'MEASURE 1 theta[0]'
 # ---
 # name: TestMeasurement.test_out[No-MemoryReference]
   'MEASURE 0'
-# ---
-# name: TestMeasurement.test_str[FormalArgument]
-  'MEASURE q theta'
 # ---
 # name: TestMeasurement.test_str[MemoryReference]
   'MEASURE 1 theta[0]'

--- a/test/unit/test_operator_estimation.py
+++ b/test/unit/test_operator_estimation.py
@@ -36,7 +36,6 @@ from pyquil.paulis import sI, sX, sY, sZ, PauliSum
 from pyquil.quilbase import Pragma
 
 
-# TODO: pickle compatibility
 def test_measure_observables(client_configuration: QCSClientConfiguration):
     expts = [
         ExperimentSetting(TensorProductState(), o1 * o2)

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -143,7 +143,7 @@ def test_construct_strength_two_orthogonal_array():
     assert np.allclose(_construct_strength_two_orthogonal_array(3), answer)
 
 
-# TODO: pickle compatibility
+# TODO: Review PyQVM
 def test_measure_bitstrings(client_configuration: QCSClientConfiguration):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(2))
     dummy_compiler = DummyCompiler(quantum_processor=quantum_processor, client_configuration=client_configuration)
@@ -466,7 +466,7 @@ def test_qc_error(client_configuration: QCSClientConfiguration):
         get_qc("5q", as_qvm=False, client_configuration=client_configuration)
 
 
-# TODO: pickle compatibility
+# TODOV4: Write memory values
 @pytest.mark.parametrize("param", [np.pi, [np.pi], np.array([np.pi])])
 def test_run_with_parameters(client_configuration: QCSClientConfiguration, param):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(3))
@@ -508,7 +508,7 @@ def test_run_with_bad_parameters(client_configuration: QCSClientConfiguration, p
         executable.write_memory(region_name="theta", value=param)
 
 
-# TODO: pickle compatibility
+# TODOV4: Write Memory values
 def test_reset(client_configuration: QCSClientConfiguration):
     quantum_processor = NxQuantumProcessor(nx.complete_graph(3))
     qc = QuantumComputer(

--- a/test/unit/test_quil.py
+++ b/test/unit/test_quil.py
@@ -21,7 +21,7 @@ from typing import Dict
 import numpy as np
 import pytest
 from syrupy.assertion import SnapshotAssertion
-import qcs_sdk.quil.instructions as quil_rs
+import quil.instructions as quil_rs
 
 from pyquil.gates import (
     I,


### PR DESCRIPTION
## Description

We can now pickle a `quil-rs` `Program` with [quil-rs#173](https://github.com/rigetti/quil-rs/pull/173). I've updated the tests that were blocked. One passed, the other two are now blocked until we can write memory values to a `quil-rs` `Program`.

Since the PR wasn't much on it's own, I also pointed `qcs-sdk-python` to [this branch](https://github.com/rigetti/qcs-sdk-rust/pull/261), which specifies `quil` as a dependency instead of re-exporting it. I've updated poetry and import paths to match. 