### PR TITLE
V4 Program API: Back GateDef with GateDefinition

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -224,17 +224,20 @@ class PauliTerm(object):
         else:
             if self.operations_as_set() != other.operations_as_set():
                 return False
+            if isinstance(self.coefficient, complex) and isinstance(other.coefficient, complex):
+                return np.isclose(self.coefficient, other.coefficient)
             return self.coefficient == other.coefficient
 
     def __hash__(self) -> int:
-        assert isinstance(self.coefficient, Complex)
-        return hash(
-            (
-                round(self.coefficient.real * HASH_PRECISION),
-                round(self.coefficient.imag * HASH_PRECISION),
-                self.operations_as_set(),
+        if isinstance(self.coefficient, Complex):
+            return hash(
+                (
+                    round(self.coefficient.real * HASH_PRECISION),
+                    round(self.coefficient.imag * HASH_PRECISION),
+                    self.operations_as_set(),
+                )
             )
-        )
+        return hash((self.coefficient, self.operations_as_set()))
 
     def __len__(self) -> int:
         """

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -222,22 +222,19 @@ class PauliTerm(object):
         elif isinstance(other, PauliSum):
             return other == self
         else:
-            if self.operations_as_set() != other.operations_as_set():
-                return False
-            if isinstance(self.coefficient, complex) and isinstance(other.coefficient, complex):
-                return np.isclose(self.coefficient, other.coefficient)
-            return self.coefficient == other.coefficient
+            return self.operations_as_set() == other.operations_as_set() and np.allclose(
+                self.coefficient, other.coefficient  # type: ignore
+            )
 
     def __hash__(self) -> int:
-        if isinstance(self.coefficient, Complex):
-            return hash(
-                (
-                    round(self.coefficient.real * HASH_PRECISION),
-                    round(self.coefficient.imag * HASH_PRECISION),
-                    self.operations_as_set(),
-                )
+        assert isinstance(self.coefficient, Complex)
+        return hash(
+            (
+                round(self.coefficient.real * HASH_PRECISION),
+                round(self.coefficient.imag * HASH_PRECISION),
+                self.operations_as_set(),
             )
-        return hash((self.coefficient, self.operations_as_set()))
+        )
 
     def __len__(self) -> int:
         """
@@ -619,7 +616,7 @@ class PauliSum(object):
         elif len(self.terms) != len(other.terms):
             return False
 
-        return self.terms == other.terms
+        return set(self.terms) == set(other.terms)
 
     def __hash__(self) -> int:
         return hash(frozenset(self.terms))

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -179,7 +179,7 @@ class Program:
         """
         A list of defined gates on the program.
         """
-        return self._program.defined_gates
+        return [DefGate._from_rs_gate_definition(gate) for gate in self._program.defined_gates]
 
     @property
     def instructions(self) -> List[AbstractInstruction]:
@@ -230,6 +230,7 @@ class Program:
             elif isinstance(instruction, RSProgram):
                 self._program += instruction
             elif isinstance(instruction, AbstractInstruction):
+                print(instruction.out())
                 self.inst(RSProgram.parse(instruction.out()))
             else:
                 raise ValueError("Invalid instruction: {}".format(instruction))

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -315,9 +315,7 @@ ParameterDesignator = Union["Expression", "MemoryReference", Number, complex]
 def _convert_to_rs_expression(parameter: ParameterDesignator) -> quil_rs_expr.Expression:
     if isinstance(parameter, quil_rs_expr.Expression):
         return parameter
-    elif isinstance(parameter, complex):
-        return quil_rs_expr.Expression.from_number(parameter)
-    elif isinstance(parameter, (int, float)):
+    elif isinstance(parameter, (int, float, complex)):
         return quil_rs_expr.Expression.from_number(complex(parameter))
     elif isinstance(parameter, (Expression, MemoryReference)):
         return quil_rs_expr.Expression.parse(str(parameter))

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -32,7 +32,6 @@ from typing import (
     Tuple,
     Union,
     cast,
-    overload,
 )
 
 import numpy as np

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -610,6 +610,9 @@ class DefPermutationGate(DefGate):
         body = ", ".join([str(p) for p in self.permutation])
         return f"DEFGATE {self.name} AS PERMUTATION:\n    {body}"
 
+    def __str__(self) -> str:
+        return self.out()
+
     def num_args(self) -> int:
         """
         :return: The number of qubit arguments the gate takes.

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -567,7 +567,7 @@ class DefGateByPaulis(DefGate):
 
     @property
     def body(self) -> "PauliSum":
-        from pyquil.paulis import PauliSum
+        from pyquil.paulis import PauliSum  # avoids circular import
 
         return PauliSum._from_rs_pauli_sum(super().specification.to_pauli_sum())
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -157,6 +157,8 @@ def _convert_to_py_instruction(instr: quil_rs.Instruction) -> AbstractInstructio
         return DefMeasureCalibration._from_rs_measure_calibration_definition(instr)
     if isinstance(instr, quil_rs.Measurement):
         return Measurement._from_rs_measurement(instr)
+    if isinstance(instr, quil_rs.GateDefinition):
+        return DefGate._from_rs_gate_definition(instr)
     if isinstance(instr, quil_rs.Instruction):
         raise NotImplementedError(f"The {type(instr)} Instruction hasn't been mapped to an AbstractInstruction yet.")
     raise ValueError(f"{type(instr)} is not a valid Instruction type")
@@ -451,7 +453,7 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
         cls,
         name: str,
         matrix: Union[List[List[Expression]], np.ndarray, np.matrix],
-        parameters: Optional[List[Parameter]],
+        parameters: Optional[List[Parameter]] = None,
     ) -> "DefGate":
         specification = DefGate._convert_to_matrix_specification(matrix)
         rs_parameters = [param.name for param in parameters or []]
@@ -506,6 +508,9 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
     @parameters.setter
     def parameters(self, parameters: Optional[List[Parameter]]):
         quil_rs.GateDefinition.parameters.__set__(self, [param.name for param in parameters or []])
+
+    def __hash__(self) -> int:
+        return hash(self.out())
 
 
 class DefPermutationGate(DefGate):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -558,6 +558,9 @@ class DefGate(AbstractInstruction):
             result += "\n"
         return result
 
+    def __str__(self) -> str:
+        return self.out()
+
     def get_constructor(self) -> Union[Callable[..., Gate], Callable[..., Callable[..., Gate]]]:
         """
         :returns: A function that constructs this gate on variable qubit indices. E.g.

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -136,41 +136,41 @@
 # ---
 # name: TestDefGate.test_out[No-Params]
   '''
-  DEFGATE NoParamGate:
-      1.0, 0, 0, 0
-      0, 1.0, 0, 0
-      0, 0, 1.0, 0
-      0, 0, 0, 1.0
+  DEFGATE NoParamGate AS MATRIX:
+  	1, 0, 0, 0
+  	0, 1, 0, 0
+  	0, 0, 1, 0
+  	0, 0, 0, 1
   
   '''
 # ---
 # name: TestDefGate.test_out[Params]
   '''
-  DEFGATE ParameterizedGate(%X):
-      %X, 0, 0, 0
-      0, %X, 0, 0
-      0, 0, %X, 0
-      0, 0, 0, %X
+  DEFGATE ParameterizedGate(%X) AS MATRIX:
+  	%X, 0, 0, 0
+  	0, %X, 0, 0
+  	0, 0, %X, 0
+  	0, 0, 0, %X
   
   '''
 # ---
 # name: TestDefGate.test_str[No-Params]
   '''
-  DEFGATE NoParamGate:
-      1.0, 0, 0, 0
-      0, 1.0, 0, 0
-      0, 0, 1.0, 0
-      0, 0, 0, 1.0
+  DEFGATE NoParamGate AS MATRIX:
+  	1, 0, 0, 0
+  	0, 1, 0, 0
+  	0, 0, 1, 0
+  	0, 0, 0, 1
   
   '''
 # ---
 # name: TestDefGate.test_str[Params]
   '''
-  DEFGATE ParameterizedGate(%X):
-      %X, 0, 0, 0
-      0, %X, 0, 0
-      0, 0, %X, 0
-      0, 0, 0, %X
+  DEFGATE ParameterizedGate(%X) AS MATRIX:
+  	%X, 0, 0, 0
+  	0, %X, 0, 0
+  	0, 0, %X, 0
+  	0, 0, 0, %X
   
   '''
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -128,6 +128,52 @@
     '\tSAMPLE-RATE: 44.1',
   })
 # ---
+# name: TestDefGate.test_get_constructor[No-Params]
+  'NoParamGate 123'
+# ---
+# name: TestDefGate.test_get_constructor[Params]
+  'ParameterizedGate(%theta) 123'
+# ---
+# name: TestDefGate.test_out[No-Params]
+  '''
+  DEFGATE NoParamGate:
+      1.0, 0, 0, 0
+      0, 1.0, 0, 0
+      0, 0, 1.0, 0
+      0, 0, 0, 1.0
+  
+  '''
+# ---
+# name: TestDefGate.test_out[Params]
+  '''
+  DEFGATE ParameterizedGate(%X):
+      %X, 0, 0, 0
+      0, %X, 0, 0
+      0, 0, %X, 0
+      0, 0, 0, %X
+  
+  '''
+# ---
+# name: TestDefGate.test_str[No-Params]
+  '''
+  DEFGATE NoParamGate:
+      1.0, 0, 0, 0
+      0, 1.0, 0, 0
+      0, 0, 1.0, 0
+      0, 0, 0, 1.0
+  
+  '''
+# ---
+# name: TestDefGate.test_str[Params]
+  '''
+  DEFGATE ParameterizedGate(%X):
+      %X, 0, 0, 0
+      0, %X, 0, 0
+      0, 0, %X, 0
+      0, 0, 0, %X
+  
+  '''
+# ---
 # name: TestDefMeasureCalibration.test_out[qubit0-memory_reference0-instrs0]
   '''
   DEFCAL MEASURE 0 theta:

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -244,13 +244,15 @@
 # name: TestDefPermutationGate.test_out[PermGate-permutation0]
   '''
   DEFGATE PermGate AS PERMUTATION:
-      4, 3, 2, 1
+  	4, 3, 2, 1
+  
   '''
 # ---
 # name: TestDefPermutationGate.test_str[PermGate-permutation0]
   '''
   DEFGATE PermGate AS PERMUTATION:
-      4, 3, 2, 1
+  	4, 3, 2, 1
+  
   '''
 # ---
 # name: TestGate.test_controlled_modifier[CPHASE-Expression]

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -186,48 +186,48 @@
 # name: TestDefGateByPaulis.test_out[DefaultWithParams]
   '''
   DEFGATE PauliGate(%theta) p AS PAULI-SUM:
-      (0j) 
+  	(0)
   
   '''
 # ---
 # name: TestDefGateByPaulis.test_out[Default]
   '''
-  DEFGATE PauliGate() p AS PAULI-SUM:
-      (0j) 
+  DEFGATE PauliGate p AS PAULI-SUM:
+  	(0)
   
   '''
 # ---
 # name: TestDefGateByPaulis.test_out[WithSumAndParams]
   '''
   DEFGATE PauliGate(%theta) p q AS PAULI-SUM:
-      Z((1+0j)) p
-      Y((2+0j)) p
-      X((3+0j)) q
-      ((3+0j)) 
+  	Z((1*%theta)) p
+  	Y(2) p
+  	X(3) q
+  	(3)
   
   '''
 # ---
 # name: TestDefGateByPaulis.test_str[DefaultWithParams]
   '''
   DEFGATE PauliGate(%theta) p AS PAULI-SUM:
-      (0j) 
+  	(0)
   
   '''
 # ---
 # name: TestDefGateByPaulis.test_str[Default]
   '''
-  DEFGATE PauliGate() p AS PAULI-SUM:
-      (0j) 
+  DEFGATE PauliGate p AS PAULI-SUM:
+  	(0)
   
   '''
 # ---
 # name: TestDefGateByPaulis.test_str[WithSumAndParams]
   '''
   DEFGATE PauliGate(%theta) p q AS PAULI-SUM:
-      Z((1+0j)) p
-      Y((2+0j)) p
-      X((3+0j)) q
-      ((3+0j)) 
+  	Z((1*%theta)) p
+  	Y(2) p
+  	X(3) q
+  	(3)
   
   '''
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -183,6 +183,9 @@
 # name: TestDefGateByPaulis.test_get_constructor[WithSumAndParams]
   'PauliGate(%theta) 123'
 # ---
+# name: TestDefGateByPaulis.test_get_constructor[WithSum]
+  'PauliGate 123'
+# ---
 # name: TestDefGateByPaulis.test_out[DefaultWithParams]
   '''
   DEFGATE PauliGate(%theta) p AS PAULI-SUM:
@@ -207,6 +210,13 @@
   
   '''
 # ---
+# name: TestDefGateByPaulis.test_out[WithSum]
+  '''
+  DEFGATE PauliGate p AS PAULI-SUM:
+  	Y(2) p
+  
+  '''
+# ---
 # name: TestDefGateByPaulis.test_str[DefaultWithParams]
   '''
   DEFGATE PauliGate(%theta) p AS PAULI-SUM:
@@ -228,6 +238,13 @@
   	Y(2) p
   	X(3) q
   	(3)
+  
+  '''
+# ---
+# name: TestDefGateByPaulis.test_str[WithSum]
+  '''
+  DEFGATE PauliGate p AS PAULI-SUM:
+  	Y(2) p
   
   '''
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -174,11 +174,83 @@
   
   '''
 # ---
+# name: TestDefGateByPaulis.test_get_constructor[DefaultWithParams]
+  'PauliGate(%theta) 123'
+# ---
+# name: TestDefGateByPaulis.test_get_constructor[Default]
+  'PauliGate 123'
+# ---
+# name: TestDefGateByPaulis.test_get_constructor[WithSumAndParams]
+  'PauliGate(%theta) 123'
+# ---
+# name: TestDefGateByPaulis.test_out[DefaultWithParams]
+  '''
+  DEFGATE PauliGate(%theta) p AS PAULI-SUM:
+      (0j) 
+  
+  '''
+# ---
+# name: TestDefGateByPaulis.test_out[Default]
+  '''
+  DEFGATE PauliGate() p AS PAULI-SUM:
+      (0j) 
+  
+  '''
+# ---
+# name: TestDefGateByPaulis.test_out[WithSumAndParams]
+  '''
+  DEFGATE PauliGate(%theta) p q AS PAULI-SUM:
+      Z((1+0j)) p
+      Y((2+0j)) p
+      X((3+0j)) q
+      ((3+0j)) 
+  
+  '''
+# ---
+# name: TestDefGateByPaulis.test_str[DefaultWithParams]
+  '''
+  DEFGATE PauliGate(%theta) p AS PAULI-SUM:
+      (0j) 
+  
+  '''
+# ---
+# name: TestDefGateByPaulis.test_str[Default]
+  '''
+  DEFGATE PauliGate() p AS PAULI-SUM:
+      (0j) 
+  
+  '''
+# ---
+# name: TestDefGateByPaulis.test_str[WithSumAndParams]
+  '''
+  DEFGATE PauliGate(%theta) p q AS PAULI-SUM:
+      Z((1+0j)) p
+      Y((2+0j)) p
+      X((3+0j)) q
+      ((3+0j)) 
+  
+  '''
+# ---
 # name: TestDefMeasureCalibration.test_out[qubit0-memory_reference0-instrs0]
   '''
   DEFCAL MEASURE 0 theta:
   	X 0
   
+  '''
+# ---
+# name: TestDefPermutationGate.test_get_constructor[PermGate-permutation0]
+  'PermGate 123'
+# ---
+# name: TestDefPermutationGate.test_out[PermGate-permutation0]
+  '''
+  DEFGATE PermGate AS PERMUTATION:
+      4, 3, 2, 1
+  '''
+# ---
+# name: TestDefPermutationGate.test_str[PermGate-permutation0]
+  '''
+  DEFGATE PermGate AS PERMUTATION:
+      4, 3, 2, 1
   '''
 # ---
 # name: TestGate.test_controlled_modifier[CPHASE-Expression]

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -99,7 +99,7 @@ DEFGATE XGATE:
 """
 
 
-# TODO: Instruction API - DefGate
+# TODO: Instruction API - Reset
 def test_remove_reset_from_program(snapshot):
     p = Program(DEFGATE_X)
     p += RESET()

--- a/test/unit/test_noise.py
+++ b/test/unit/test_noise.py
@@ -110,7 +110,7 @@ def test_noise_helpers():
     assert set(inferred_gates) == set(gates)
 
 
-# TODO: Instruction API - DefGate
+# TODO: Instruction API - Hashing
 def test_decoherence_noise():
     prog = Program(RX(np.pi / 2, 0), CZ(0, 1), RZ(np.pi, 0))
     gates = _get_program_gates(prog)
@@ -308,7 +308,7 @@ def test_estimate_assignment_probs(mocker: MockerFixture):
     ]
     ap_target = np.array([[p00, 1 - p11], [1 - p00, p11]])
 
-    povm_pragma = Pragma("READOUT-POVM", (0, "({} {} {} {})".format(*ap_target.flatten())))
+    povm_pragma = Pragma("READOUT-POVM", [0], "({} {} {} {})".format(*ap_target.flatten()))
     ap = estimate_assignment_probs(0, trials, mock_qc, Program(povm_pragma))
 
     assert mock_compiler.native_quil_to_executable.call_count == 2
@@ -317,7 +317,7 @@ def test_estimate_assignment_probs(mocker: MockerFixture):
     for call in mock_compiler.native_quil_to_executable.call_args_list:
         args, kwargs = call
         prog = args[0]
-        assert prog._instructions[0] == povm_pragma
+        assert prog.instructions[0] == povm_pragma
 
     assert np.allclose(ap, ap_target)
 

--- a/test/unit/test_numpy.py
+++ b/test/unit/test_numpy.py
@@ -203,7 +203,7 @@ def test_expectation_vs_ref_qvm(n_qubits):
         np.testing.assert_allclose(ref_exp, np_exp, atol=1e-15)
 
 
-# TODO: Instruction API - DefGate
+# TODO: PyQVM Review
 def test_defgate():
     # regression test for https://github.com/rigetti/pyquil/issues/1059
     theta = np.pi / 2

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -262,7 +262,7 @@ class TestDefGateByPaulis:
 
     def test_body(self, def_gate_pauli: DefGateByPaulis, body: PauliSum):
         if all([isinstance(term.coefficient, Number) for term in body.terms]):
-            # PauliTerms equality is only defined for terms with Numbered coefficients
+            # PauliTerm equality is only defined for terms with Numbered coefficients
             assert def_gate_pauli.body == body
         new_body = PauliSum([PauliTerm("X", FormalArgument("a"), 5.0)])
         def_gate_pauli.body = new_body

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -1,4 +1,5 @@
 from math import pi
+from numbers import Number
 from typing import Any, List, Optional, Union, Iterable, Tuple
 
 import numpy as np
@@ -198,6 +199,7 @@ class TestDefPermutationGate:
     [
         ("PauliGate", [], [FormalArgument("p")], PauliSum([])),
         ("PauliGate", [Parameter("theta")], [FormalArgument("p")], PauliSum([])),
+        ("PauliGate", [], [FormalArgument("p")], PauliSum([PauliTerm("Y", FormalArgument("p"), 2.0)])),
         (
             "PauliGate",
             [Parameter("theta")],
@@ -212,7 +214,7 @@ class TestDefPermutationGate:
             ),
         ),
     ],
-    ids=("Default", "DefaultWithParams", "WithSumAndParams"),
+    ids=("Default", "DefaultWithParams", "WithSum", "WithSumAndParams"),
 )
 class TestDefGateByPaulis:
     @pytest.fixture
@@ -259,7 +261,9 @@ class TestDefGateByPaulis:
         assert def_gate_pauli.arguments == [FormalArgument("NewArgument")]
 
     def test_body(self, def_gate_pauli: DefGateByPaulis, body: PauliSum):
-        assert def_gate_pauli.body == body
+        if all([isinstance(term.coefficient, Number) for term in body.terms]):
+            # PauliTerms equality is only defined for terms with Numbered coefficients
+            assert def_gate_pauli.body == body
         new_body = PauliSum([PauliTerm("X", FormalArgument("a"), 5.0)])
         def_gate_pauli.body = new_body
         assert def_gate_pauli.body == new_body

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -14,12 +14,17 @@ from pyquil.quilbase import (
     DefFrame,
     DefGate,
     DefMeasureCalibration,
+    DefPermutationGate,
+    DefGateByPaulis,
+    FormalArgument,
     Gate,
     Measurement,
     MemoryReference,
     ParameterDesignator,
     Parameter,
+    QubitDesignator,
 )
+from pyquil.paulis import PauliSum, PauliTerm, PauliTargetDesignator
 from pyquil.quilatom import BinaryExp, Frame, Qubit
 from pyquil.api._compiler import QPUCompiler
 
@@ -106,7 +111,7 @@ class TestDefGate:
     @pytest.fixture
     def def_gate(
         self, name: str, matrix: Union[List[List[Any]], np.ndarray, np.matrix], parameters: Optional[List[Parameter]]
-    ):
+    ) -> DefGate:
         return DefGate(name, matrix, parameters)
 
     def test_out(self, def_gate: DefGate, snapshot: SnapshotAssertion):
@@ -142,6 +147,122 @@ class TestDefGate:
         assert def_gate.parameters == parameters
         def_gate.parameters = [Parameter("brand_new_param")]
         assert def_gate.parameters == [Parameter("brand_new_param")]
+
+
+@pytest.mark.parametrize(
+    ("name", "permutation"),
+    [
+        ("PermGate", np.asarray([4, 3, 2, 1])),
+    ],
+)
+class TestDefPermutationGate:
+    @pytest.fixture
+    def def_permutation_gate(self, name: str, permutation: np.ndarray) -> DefPermutationGate:
+        return DefPermutationGate(name, permutation)
+
+    def test_out(self, def_permutation_gate: DefPermutationGate, snapshot: SnapshotAssertion):
+        assert def_permutation_gate.out() == snapshot
+
+    def test_str(self, def_permutation_gate: DefPermutationGate, snapshot: SnapshotAssertion):
+        assert str(def_permutation_gate) == snapshot
+
+    def test_get_constructor(self, def_permutation_gate: DefPermutationGate, snapshot: SnapshotAssertion):
+        constructor = def_permutation_gate.get_constructor()
+        g = constructor(Qubit(123))
+        assert g.out() == snapshot
+
+    def test_num_args(
+        self, def_permutation_gate: DefPermutationGate, permutation: Union[List[List[Any]], np.ndarray, np.matrix]
+    ):
+        assert def_permutation_gate.num_args() == np.log2(len(permutation))
+
+    def test_name(self, def_permutation_gate: DefPermutationGate, name: str):
+        assert def_permutation_gate.name == name
+        def_permutation_gate.name = "new_name"
+        assert def_permutation_gate.name == "new_name"
+
+    def test_permutation(
+        self, def_permutation_gate: DefPermutationGate, permutation: Union[List[List[Any]], np.ndarray, np.matrix]
+    ):
+        assert np.array_equal(def_permutation_gate.permutation, permutation)
+        new_permutation = np.asarray([0, 1, 2, 3])
+        def_permutation_gate.permutation = new_permutation
+        assert np.array_equal(def_permutation_gate.permutation, new_permutation)
+
+    def test_parameters(self, def_permutation_gate: DefPermutationGate):
+        assert not def_permutation_gate.parameters
+
+
+@pytest.mark.parametrize(
+    ("gate_name", "parameters", "arguments", "body"),
+    [
+        ("PauliGate", [], [FormalArgument("p")], PauliSum([])),
+        ("PauliGate", [Parameter("theta")], [FormalArgument("p")], PauliSum([])),
+        (
+            "PauliGate",
+            [Parameter("theta")],
+            [FormalArgument("p"), FormalArgument("q")],
+            PauliSum(
+                [
+                    PauliTerm("Z", FormalArgument("p"), 1.0),
+                    PauliTerm("Y", FormalArgument("p"), 2.0),
+                    PauliTerm("X", FormalArgument("q"), 3.0),
+                    PauliTerm("I", None, 3.0),
+                ]
+            ),
+        ),
+    ],
+    ids=("Default", "DefaultWithParams", "WithSumAndParams"),
+)
+class TestDefGateByPaulis:
+    @pytest.fixture
+    def def_gate_pauli(
+        self, gate_name: str, parameters: List[Parameter], arguments: List[QubitDesignator], body: PauliSum
+    ) -> DefGateByPaulis:
+        return DefGateByPaulis(gate_name, parameters, arguments, body)
+
+    def test_out(self, def_gate_pauli: DefGateByPaulis, snapshot: SnapshotAssertion):
+        assert def_gate_pauli.out() == snapshot
+
+    def test_str(self, def_gate_pauli: DefGateByPaulis, snapshot: SnapshotAssertion):
+        assert str(def_gate_pauli) == snapshot
+
+    def test_get_constructor(self, def_gate_pauli: DefGateByPaulis, snapshot: SnapshotAssertion):
+        constructor = def_gate_pauli.get_constructor()
+        if def_gate_pauli.parameters:
+            g = constructor(Parameter("theta"))(Qubit(123))
+            assert g.out() == snapshot
+        else:
+            g = constructor(Qubit(123))
+            assert g.out() == snapshot
+
+    def test_num_args(
+        self,
+        def_gate_pauli: DefGateByPaulis,
+        arguments: List[QubitDesignator],
+    ):
+        assert def_gate_pauli.num_args() == len(arguments)
+
+    def test_name(self, def_gate_pauli: DefGateByPaulis, gate_name: str):
+        assert def_gate_pauli.name == gate_name
+        def_gate_pauli.name = "new_name"
+        assert def_gate_pauli.name == "new_name"
+
+    def test_parameters(self, def_gate_pauli: DefGate, parameters: Optional[List[Parameter]]):
+        assert def_gate_pauli.parameters == parameters
+        def_gate_pauli.parameters = [Parameter("brand_new_param")]
+        assert def_gate_pauli.parameters == [Parameter("brand_new_param")]
+
+    def test_arguments(self, def_gate_pauli: DefGateByPaulis, arguments: List[QubitDesignator]):
+        assert def_gate_pauli.arguments == arguments
+        def_gate_pauli.arguments = [FormalArgument("NewArgument")]  # type: ignore
+        assert def_gate_pauli.arguments == [FormalArgument("NewArgument")]
+
+    def test_body(self, def_gate_pauli: DefGateByPaulis, body: PauliSum):
+        assert def_gate_pauli.body == body
+        new_body = PauliSum([PauliTerm("X", 123, 13.37)])
+        def_gate_pauli.body = new_body
+        assert def_gate_pauli.body == new_body
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -25,7 +25,7 @@ from pyquil.quilbase import (
     QubitDesignator,
 )
 from pyquil.paulis import PauliSum, PauliTerm, PauliTargetDesignator
-from pyquil.quilatom import BinaryExp, Frame, Qubit
+from pyquil.quilatom import BinaryExp, Frame, Qubit, Mul
 from pyquil.api._compiler import QPUCompiler
 
 
@@ -204,7 +204,7 @@ class TestDefPermutationGate:
             [FormalArgument("p"), FormalArgument("q")],
             PauliSum(
                 [
-                    PauliTerm("Z", FormalArgument("p"), 1.0),
+                    PauliTerm("Z", FormalArgument("p"), Mul(1.0, Parameter("theta"))),
                     PauliTerm("Y", FormalArgument("p"), 2.0),
                     PauliTerm("X", FormalArgument("q"), 3.0),
                     PauliTerm("I", None, 3.0),
@@ -260,7 +260,7 @@ class TestDefGateByPaulis:
 
     def test_body(self, def_gate_pauli: DefGateByPaulis, body: PauliSum):
         assert def_gate_pauli.body == body
-        new_body = PauliSum([PauliTerm("X", 123, 13.37)])
+        new_body = PauliSum([PauliTerm("X", FormalArgument("a"), 5.0)])
         def_gate_pauli.body = new_body
         assert def_gate_pauli.body == new_body
 

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -185,7 +185,7 @@ class TestDefPermutationGate:
         self, def_permutation_gate: DefPermutationGate, permutation: Union[List[List[Any]], np.ndarray, np.matrix]
     ):
         assert np.array_equal(def_permutation_gate.permutation, permutation)
-        new_permutation = np.asarray([0, 1, 2, 3])
+        new_permutation = [1, 2, 3, 4]
         def_permutation_gate.permutation = new_permutation
         assert np.array_equal(def_permutation_gate.permutation, new_permutation)
 


### PR DESCRIPTION
Backs `DefGate`, `DefPermutationGate`, and `DefGateByPauli` with `quil-rs`'s `GateDefinition`. The first two were fairly straightforward. `DefGateByPauli` needs [this PR merged](https://github.com/rigetti/quil-rs/pull/177) in `quil-rs`. The `pyquil.paulis` module has no equivalent in `quil-rs`, so we instead convert between the `quil-rs` and `pyQuil` types at the FFI boundary.