### PR TITLE
V4 Instruction API: Pragma, Reset, Fence, Delay

### DIFF
--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -315,7 +315,7 @@ ParameterDesignator = Union["Expression", "MemoryReference", Number, complex]
 def _convert_to_rs_expression(parameter: ParameterDesignator) -> quil_rs_expr.Expression:
     if isinstance(parameter, quil_rs_expr.Expression):
         return parameter
-    elif isinstance(parameter, (int, float, complex, np.int64)):
+    elif isinstance(parameter, (int, float, complex, np.number)):
         return quil_rs_expr.Expression.from_number(complex(parameter))
     elif isinstance(parameter, (Expression, MemoryReference)):
         return quil_rs_expr.Expression.parse(str(parameter))

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -492,7 +492,10 @@ class ResetQubit(Reset):
     This is the pyQuil object for a Quil targeted reset instruction.
     """
 
-    ...
+    def __new__(cls, qubit: Union[Qubit, QubitPlaceholder, FormalArgument]):
+        if qubit is None:
+            raise TypeError("qubit should not be None")
+        return super().__new__(cls, qubit)
 
 
 class DefGate(quil_rs.GateDefinition, AbstractInstruction):
@@ -1081,7 +1084,7 @@ class Pragma(quil_rs.Pragma, AbstractInstruction):
             elif isinstance(arg, (str, FormalArgument)):
                 pragma_arguments.append(quil_rs.PragmaArgument.from_identifier(str(arg)))
             else:
-                raise TypeError("type(arg) isn't a valid QubitDesignator")
+                raise TypeError(f"{type(arg)} isn't a valid QubitDesignator")
         return pragma_arguments
 
     @staticmethod
@@ -1095,7 +1098,7 @@ class Pragma(quil_rs.Pragma, AbstractInstruction):
         return arguments
 
     def out(self) -> str:
-        return self.__str__()
+        return str(self)
 
     @property
     def command(self) -> str:
@@ -1420,8 +1423,7 @@ class Delay(quil_rs.Delay, AbstractInstruction):
 
     @property
     def frames(self) -> List[Frame]:
-        py_qubits = self.qubits
-        return [Frame(py_qubits, name) for name in super().frame_names]
+        return [Frame(self.qubits, name) for name in super().frame_names]
 
     @frames.setter
     def frames(self, frames: List[Frame]):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1434,7 +1434,6 @@ class Delay(quil_rs.Delay, AbstractInstruction):
         frame_names = [frame.name for frame in frames]
         rs_qubits = _convert_to_rs_qubits(Delay._join_frame_qubits(frames, qubits))
         expression = quil_rs_expr.Expression.from_number(complex(duration))
-        print("rs_qubits", rs_qubits)
         return super().__new__(cls, expression, frame_names, rs_qubits)
 
     def out(self) -> str:
@@ -1446,7 +1445,6 @@ class Delay(quil_rs.Delay, AbstractInstruction):
     ) -> List[Union[int, Qubit, FormalArgument]]:
         merged_qubits = set(qubits)
         for frame in frames:
-            print("frame qubits", frame)
             merged_qubits.update(frame.qubits)  # type: ignore
         return list(merged_qubits)
 
@@ -1460,7 +1458,6 @@ class Delay(quil_rs.Delay, AbstractInstruction):
 
     @property
     def frames(self) -> List[Frame]:
-        print(super().qubits)
         py_qubits = self.qubits
         return [Frame(py_qubits, name) for name in super().frame_names]
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1491,21 +1491,29 @@ class DelayQubits(Delay):
         return super().__new__(cls, [], qubits, duration)
 
 
-class FenceAll(SimpleInstruction):
+class Fence(quil_rs.Fence, AbstractInstruction):
+    def __new__(cls, qubits: List[Union[Qubit, FormalArgument]]):
+        return super().__new__(cls, _convert_to_rs_qubits(qubits))
+
+    def out(self) -> str:
+        return str(self)
+
+    @property
+    def qubits(self) -> List[Union[Qubit, FormalArgument]]:
+        return _convert_to_py_qubits(super().qubits)
+
+    @qubits.setter
+    def qubits(self, qubits: List[Union[Qubit, FormalArgument]]):
+        quil_rs.Fence.qubits.__set__(self, _convert_to_rs_qubits(qubits))
+
+
+class FenceAll(Fence):
     """
     The FENCE instruction.
     """
 
-    op = "FENCE"
-
-
-class Fence(AbstractInstruction):
-    def __init__(self, qubits: List[Union[Qubit, FormalArgument]]):
-        self.qubits = qubits
-
-    def out(self) -> str:
-        ret = "FENCE " + _format_qubits_str(self.qubits)
-        return ret
+    def __new__(cls):
+        return super().__new__(cls, [])
 
 
 class DefWaveform(AbstractInstruction):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1434,6 +1434,7 @@ class Delay(quil_rs.Delay, AbstractInstruction):
         frame_names = [frame.name for frame in frames]
         rs_qubits = _convert_to_rs_qubits(Delay._join_frame_qubits(frames, qubits))
         expression = quil_rs_expr.Expression.from_number(complex(duration))
+        print("rs_qubits", rs_qubits)
         return super().__new__(cls, expression, frame_names, rs_qubits)
 
     def out(self) -> str:
@@ -1445,8 +1446,9 @@ class Delay(quil_rs.Delay, AbstractInstruction):
     ) -> List[Union[int, Qubit, FormalArgument]]:
         merged_qubits = set(qubits)
         for frame in frames:
+            print("frame qubits", frame)
             merged_qubits.update(frame.qubits)  # type: ignore
-        return list(qubits)
+        return list(merged_qubits)
 
     @property
     def qubits(self) -> List[QubitDesignator]:
@@ -1458,11 +1460,13 @@ class Delay(quil_rs.Delay, AbstractInstruction):
 
     @property
     def frames(self) -> List[Frame]:
-        return [Frame([], name) for name in super().frame_names]
+        print(super().qubits)
+        py_qubits = self.qubits
+        return [Frame(py_qubits, name) for name in super().frame_names]
 
     @frames.setter
     def frames(self, frames: List[Frame]):
-        new_qubits = Delay._join_frame_qubits(frames, self.qubits)
+        new_qubits = Delay._join_frame_qubits(frames, [])
         frame_names = [frame.name for frame in frames]
         quil_rs.Delay.qubits.__set__(self, _convert_to_rs_qubits(new_qubits))
         quil_rs.Delay.frame_names.__set__(self, frame_names)

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -18,7 +18,6 @@ Contains the core pyQuil objects that correspond to Quil instructions.
 """
 import abc
 import collections
-import json
 
 from numbers import Complex
 from typing import (

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -136,7 +136,7 @@
   '''
 # ---
 # name: TestDelayFrames.test_out[frames0-5.0]
-  'DELAY "frame" 5'
+  'DELAY 0 "frame" 5'
 # ---
 # name: TestDelayQubits.test_out[FormalArgument]
   'DELAY a 2.5'

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -135,6 +135,21 @@
   
   '''
 # ---
+# name: TestDelayFrames.test_out[frames0-5.0]
+  'DELAY 0 "frame" 5.0'
+# ---
+# name: TestDelayQubits.test_out[FormalArgument]
+  'DELAY a 2.5'
+# ---
+# name: TestDelayQubits.test_out[Qubit]
+  'DELAY 0 5.0'
+# ---
+# name: TestFence.test_out[FormalArgument]
+  'FENCE a'
+# ---
+# name: TestFence.test_out[Qubit]
+  'FENCE 0'
+# ---
 # name: TestGate.test_controlled_modifier[CPHASE-Expression]
   'CONTROLLED CPHASE(1.5707963267948966) 5 0 1'
 # ---
@@ -235,11 +250,5 @@
   'RESET 0'
 # ---
 # name: TestReset.test_str[qubit0]
-  'RESET 0'
-# ---
-# name: TestResetQubit.test_out[qubit0]
-  'RESET 0'
-# ---
-# name: TestResetQubit.test_str[qubit0]
   'RESET 0'
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -207,3 +207,27 @@
 # name: TestMeasurement.test_str[No-MemoryReference]
   'MEASURE 0'
 # ---
+# name: TestPragma.test_out[Command-Only]
+  'PRAGMA NO-NOISE'
+# ---
+# name: TestPragma.test_out[With-Arg-And-String]
+  'PRAGMA READOUT-POVM 1 "(0.9 0.19999999999999996 0.09999999999999998 0.8)"'
+# ---
+# name: TestPragma.test_out[With-Arg]
+  'PRAGMA DOES-A-THING 0 b'
+# ---
+# name: TestPragma.test_out[With-String]
+  'PRAGMA INITIAL_REWIRING "GREEDY"'
+# ---
+# name: TestPragma.test_str[Command-Only]
+  '<PRAGMA NO-NOISE>'
+# ---
+# name: TestPragma.test_str[With-Arg-And-String]
+  '<PRAGMA READOUT-POVM>'
+# ---
+# name: TestPragma.test_str[With-Arg]
+  '<PRAGMA DOES-A-THING>'
+# ---
+# name: TestPragma.test_str[With-String]
+  '<PRAGMA INITIAL_REWIRING>'
+# ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -246,7 +246,25 @@
 # name: TestPragma.test_str[With-String]
   'PRAGMA INITIAL_REWIRING "GREEDY"'
 # ---
+# name: TestReset.test_out[FormalArgument]
+  'RESET a'
+# ---
+# name: TestReset.test_out[None]
+  'RESET'
+# ---
+# name: TestReset.test_out[Qubit]
+  'RESET 0'
+# ---
 # name: TestReset.test_out[qubit0]
+  'RESET 0'
+# ---
+# name: TestReset.test_str[FormalArgument]
+  'RESET a'
+# ---
+# name: TestReset.test_str[None]
+  'RESET'
+# ---
+# name: TestReset.test_str[Qubit]
   'RESET 0'
 # ---
 # name: TestReset.test_str[qubit0]

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -231,3 +231,15 @@
 # name: TestPragma.test_str[With-String]
   '<PRAGMA INITIAL_REWIRING>'
 # ---
+# name: TestReset.test_out[qubit0]
+  'RESET 0'
+# ---
+# name: TestReset.test_str[qubit0]
+  'RESET 0'
+# ---
+# name: TestResetQubit.test_out[qubit0]
+  'RESET 0'
+# ---
+# name: TestResetQubit.test_str[qubit0]
+  'RESET 0'
+# ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -235,16 +235,16 @@
   'PRAGMA INITIAL_REWIRING "GREEDY"'
 # ---
 # name: TestPragma.test_str[Command-Only]
-  '<PRAGMA NO-NOISE>'
+  'PRAGMA NO-NOISE'
 # ---
 # name: TestPragma.test_str[With-Arg-And-String]
-  '<PRAGMA READOUT-POVM>'
+  'PRAGMA READOUT-POVM 1 "(0.9 0.19999999999999996 0.09999999999999998 0.8)"'
 # ---
 # name: TestPragma.test_str[With-Arg]
-  '<PRAGMA DOES-A-THING>'
+  'PRAGMA DOES-A-THING 0 b'
 # ---
 # name: TestPragma.test_str[With-String]
-  '<PRAGMA INITIAL_REWIRING>'
+  'PRAGMA INITIAL_REWIRING "GREEDY"'
 # ---
 # name: TestReset.test_out[qubit0]
   'RESET 0'

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -255,9 +255,6 @@
 # name: TestReset.test_out[Qubit]
   'RESET 0'
 # ---
-# name: TestReset.test_out[qubit0]
-  'RESET 0'
-# ---
 # name: TestReset.test_str[FormalArgument]
   'RESET a'
 # ---
@@ -265,8 +262,5 @@
   'RESET'
 # ---
 # name: TestReset.test_str[Qubit]
-  'RESET 0'
-# ---
-# name: TestReset.test_str[qubit0]
   'RESET 0'
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -136,13 +136,13 @@
   '''
 # ---
 # name: TestDelayFrames.test_out[frames0-5.0]
-  'DELAY 0 "frame" 5.0'
+  'DELAY "frame" 5'
 # ---
 # name: TestDelayQubits.test_out[FormalArgument]
   'DELAY a 2.5'
 # ---
 # name: TestDelayQubits.test_out[Qubit]
-  'DELAY 0 5.0'
+  'DELAY 0 5'
 # ---
 # name: TestFence.test_out[FormalArgument]
   'FENCE a'

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -342,7 +342,7 @@ class TestDeclare:
     ("command", "args", "freeform_string"),
     [
         ("NO-NOISE", [], ""),
-        ("DOES-A-THING", [Qubit(0), "b"], ""),
+        ("DOES-A-THING", [Qubit(0), FormalArgument("b")], ""),
         ("INITIAL_REWIRING", [], "GREEDY"),
         ("READOUT-POVM", [Qubit(1)], "(0.9 0.19999999999999996 0.09999999999999998 0.8)"),
     ],

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -379,7 +379,10 @@ class TestPragma:
     ("qubit"),
     [
         (Qubit(0)),
+        (FormalArgument("a")),
+        (None),
     ],
+    ids=("Qubit", "FormalArgument", "None"),
 )
 class TestReset:
     @pytest.fixture
@@ -396,6 +399,15 @@ class TestReset:
         assert reset_qubit.qubit == qubit
         reset_qubit.qubit = FormalArgument("a")
         assert reset_qubit.qubit == FormalArgument("a")
+
+    def test_get_qubits(self, reset_qubit: ResetQubit, qubit: Qubit):
+        if qubit is None:
+            assert reset_qubit.get_qubits(False) is None
+            assert reset_qubit.get_qubit_indices() is None
+        else:
+            assert reset_qubit.get_qubits(False) == {qubit}
+            if isinstance(qubit, Qubit):
+                assert reset_qubit.get_qubit_indices() == {qubit.index}
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -12,6 +12,9 @@ from pyquil.quilbase import (
     DefCalibration,
     DefFrame,
     DefMeasureCalibration,
+    DelayFrames,
+    DelayQubits,
+    Fence,
     FormalArgument,
     Gate,
     Measurement,
@@ -347,7 +350,7 @@ class TestDeclare:
 )
 class TestPragma:
     @pytest.fixture
-    def pragma(self, command: str, args: List[Union[QubitDesignator, str]], freeform_string: str):
+    def pragma(self, command: str, args: List[Union[QubitDesignator, str]], freeform_string: str) -> Pragma:
         return Pragma(command, args, freeform_string)
 
     def test_out(self, pragma: Pragma, snapshot: SnapshotAssertion):
@@ -380,7 +383,7 @@ class TestPragma:
 )
 class TestReset:
     @pytest.fixture
-    def reset_qubit(self, qubit: Qubit):
+    def reset_qubit(self, qubit: Qubit) -> ResetQubit:
         return ResetQubit(qubit)
 
     def test_out(self, reset_qubit: ResetQubit, snapshot: SnapshotAssertion):
@@ -389,7 +392,81 @@ class TestReset:
     def test_str(self, reset_qubit: ResetQubit, snapshot: SnapshotAssertion):
         assert str(reset_qubit) == snapshot
 
-    def test_command(self, reset_qubit: ResetQubit, qubit: Qubit):
+    def test_qubit(self, reset_qubit: ResetQubit, qubit: Qubit):
         assert reset_qubit.qubit == qubit
         reset_qubit.qubit = FormalArgument("a")
         assert reset_qubit.qubit == FormalArgument("a")
+
+
+@pytest.mark.parametrize(
+    ("frames", "duration"),
+    [
+        ([Frame([Qubit(0)], "frame")], 5.0),
+    ],
+)
+class TestDelayFrames:
+    @pytest.fixture
+    def delay_frames(self, frames: List[Frame], duration: float) -> DelayFrames:
+        return DelayFrames(frames, duration)
+
+    def test_out(self, delay_frames: DelayFrames, snapshot: SnapshotAssertion):
+        assert delay_frames.out() == snapshot
+
+    def test_frames(self, delay_frames: DelayFrames, frames: List[Frame]):
+        assert delay_frames.frames == frames
+        delay_frames.frames = [Frame([Qubit(123)], "new_frame")]
+        assert delay_frames.frames == [Frame([Qubit(123)], "new_frame")]
+
+    def test_duration(self, delay_frames: DelayFrames, duration: float):
+        assert delay_frames.duration == duration
+        delay_frames.duration = 3.14
+        assert delay_frames.duration == 3.14
+
+
+@pytest.mark.parametrize(
+    ("qubits", "duration"),
+    [
+        ([Qubit(0)], 5.0),
+        ([FormalArgument("a")], 2.5),
+    ],
+    ids=("Qubit", "FormalArgument"),
+)
+class TestDelayQubits:
+    @pytest.fixture
+    def delay_qubits(self, qubits: List[Union[Qubit, FormalArgument]], duration: float) -> DelayQubits:
+        return DelayQubits(qubits, duration)
+
+    def test_out(self, delay_qubits: DelayQubits, snapshot: SnapshotAssertion):
+        assert delay_qubits.out() == snapshot
+
+    def test_qubits(self, delay_qubits: DelayQubits, qubits: List[Qubit]):
+        assert delay_qubits.qubits == qubits
+        delay_qubits.qubits = [Qubit(123)]  # type: ignore
+        assert delay_qubits.qubits == [Qubit(123)]
+
+    def test_duration(self, delay_qubits: DelayQubits, duration: float):
+        assert delay_qubits.duration == duration
+        delay_qubits.duration = 3.14
+        assert delay_qubits.duration == 3.14
+
+
+@pytest.mark.parametrize(
+    ("qubits"),
+    [
+        ([Qubit(0)]),
+        ([FormalArgument("a")]),
+    ],
+    ids=("Qubit", "FormalArgument"),
+)
+class TestFence:
+    @pytest.fixture
+    def fence(self, qubits: List[Union[Qubit, FormalArgument]]) -> Fence:
+        return Fence(qubits)
+
+    def test_out(self, fence: Fence, snapshot: SnapshotAssertion):
+        assert fence.out() == snapshot
+
+    def test_qubits(self, fence: Fence, qubits: List[Union[Qubit, FormalArgument]]):
+        assert fence.qubits == qubits
+        fence.qubits = [Qubit(123)]  # type: ignore
+        assert fence.qubits == [Qubit(123)]

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -12,6 +12,7 @@ from pyquil.quilbase import (
     DefCalibration,
     DefFrame,
     DefMeasureCalibration,
+    FormalArgument,
     Gate,
     Measurement,
     MemoryReference,
@@ -19,6 +20,7 @@ from pyquil.quilbase import (
     Parameter,
     Pragma,
     QubitDesignator,
+    ResetQubit,
 )
 from pyquil.quilatom import BinaryExp, Frame, Qubit
 from pyquil.api._compiler import QPUCompiler
@@ -368,3 +370,26 @@ class TestPragma:
         assert pragma.freeform_string == freeform_string
         pragma.freeform_string = "new string"
         assert pragma.freeform_string == "new string"
+
+
+@pytest.mark.parametrize(
+    ("qubit"),
+    [
+        (Qubit(0)),
+    ],
+)
+class TestReset:
+    @pytest.fixture
+    def reset_qubit(self, qubit: Qubit):
+        return ResetQubit(qubit)
+
+    def test_out(self, reset_qubit: ResetQubit, snapshot: SnapshotAssertion):
+        assert reset_qubit.out() == snapshot
+
+    def test_str(self, reset_qubit: ResetQubit, snapshot: SnapshotAssertion):
+        assert str(reset_qubit) == snapshot
+
+    def test_command(self, reset_qubit: ResetQubit, qubit: Qubit):
+        assert reset_qubit.qubit == qubit
+        reset_qubit.qubit = FormalArgument("a")
+        assert reset_qubit.qubit == FormalArgument("a")

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -15,6 +15,7 @@ from pyquil.quilbase import (
     DelayFrames,
     DelayQubits,
     Fence,
+    FenceAll,
     FormalArgument,
     Gate,
     Measurement,
@@ -482,3 +483,9 @@ class TestFence:
         assert fence.qubits == qubits
         fence.qubits = [Qubit(123)]  # type: ignore
         assert fence.qubits == [Qubit(123)]
+
+
+def test_fence_all():
+    fa = FenceAll()
+    assert fa.out() == "FENCE"
+    assert fa.qubits == []

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -29,6 +29,7 @@ from pyquil.quilbase import (
     Parameter,
     Pragma,
     QubitDesignator,
+    Reset,
     ResetQubit,
 )
 from pyquil.paulis import PauliSum, PauliTerm
@@ -563,6 +564,10 @@ class TestPragma:
 class TestReset:
     @pytest.fixture
     def reset_qubit(self, qubit: Qubit) -> ResetQubit:
+        if qubit is None:
+            with pytest.raises(TypeError):
+                ResetQubit(qubit)
+            return Reset(None)
         return ResetQubit(qubit)
 
     def test_out(self, reset_qubit: ResetQubit, snapshot: SnapshotAssertion):


### PR DESCRIPTION
Backs `Pragma`, `Reset`, `ResetQubit`, `Fence`, `FenceAll`, `DelayQubits`, and `DelayFrames` with quil-rs.
