### PR TITLE
V4 Instruction API: DefCircuit, DefWaveform

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1397,6 +1397,50 @@ class DefWaveform(quil_rs.WaveformDefinition, AbstractInstruction):
         quil_rs.WaveformDefinition.definition.__set__(self, waveform)
 
 
+class DefCircuit(quil_rs.CircuitDefinition, AbstractInstruction):
+    def __new__(
+        cls,
+        name: str,
+        parameters: List[Parameter],
+        qubits: List[FormalArgument],
+        instructions: List[AbstractInstruction],
+    ) -> "DefCircuit":
+        rs_parameters = [parameter.name for parameter in parameters]
+        rs_qubits = [qubit.name for qubit in qubits]
+        rs_instructions = _convert_to_rs_instructions(instructions)
+        return super().__new__(cls, name, rs_parameters, rs_qubits, rs_instructions)
+
+    def out(self) -> str:
+        return str(self)
+
+    @property
+    def parameters(self) -> List[Parameter]:
+        return [Parameter(parameter) for parameter in super().parameters]
+
+    @parameters.setter
+    def parameters(self, parameters: List[Parameter]):
+        rs_parameters = [parameter.name for parameter in parameters]
+        quil_rs.CircuitDefinition.parameters.__set__(self, rs_parameters)
+
+    @property
+    def qubit_variables(self) -> List[FormalArgument]:
+        return [FormalArgument(qubit) for qubit in super().qubit_variables]
+
+    @qubit_variables.setter
+    def qubit_variables(self, qubits: List[FormalArgument]):
+        rs_qubits = [qubit.name for qubit in qubits]
+        quil_rs.CircuitDefinition.qubit_variables.__set__(self, rs_qubits)
+
+    @property
+    def instructions(self) -> List[AbstractInstruction]:
+        return _convert_to_py_instructions(super().instructions)
+
+    @instructions.setter
+    def instructions(self, instructions: List[AbstractInstruction]):
+        rs_instructions = _convert_to_rs_instructions(instructions)
+        quil_rs.CircuitDefinition.instructions.__set__(self, rs_instructions)
+
+
 class DefCalibration(quil_rs.Calibration, AbstractInstruction):
     def __new__(
         cls,

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -157,8 +157,12 @@ def _convert_to_py_instruction(instr: quil_rs.Instruction) -> AbstractInstructio
         return DefMeasureCalibration._from_rs_measure_calibration_definition(instr)
     if isinstance(instr, quil_rs.Measurement):
         return Measurement._from_rs_measurement(instr)
+    if isinstance(instr, quil_rs.CircuitDefinition):
+        return DefCircuit._from_rs_circuit_definition(instr)
     if isinstance(instr, quil_rs.GateDefinition):
         return DefGate._from_rs_gate_definition(instr)
+    if isinstance(instr, quil_rs.WaveformDefinition):
+        return DefWaveform._from_rs_waveform_definition(instr)
     if isinstance(instr, quil_rs.Instruction):
         raise NotImplementedError(f"The {type(instr)} Instruction hasn't been mapped to an AbstractInstruction yet.")
     raise ValueError(f"{type(instr)} is not a valid Instruction type")
@@ -1368,6 +1372,10 @@ class DefWaveform(quil_rs.WaveformDefinition, AbstractInstruction):
         rs_waveform = DefWaveform._build_rs_waveform(parameters, entries)
         return super().__new__(cls, name, rs_waveform)
 
+    @classmethod
+    def _from_rs_waveform_definition(cls, waveform_definition: quil_rs.WaveformDefinition) -> "DefWaveform":
+        return super().__new__(cls, waveform_definition.name, waveform_definition.definition)
+
     @staticmethod
     def _build_rs_waveform(parameters: List[Parameter], entries: List[Union[Complex, Expression]]) -> quil_rs.Waveform:
         rs_parameters = [parameter.name for parameter in parameters]
@@ -1409,6 +1417,16 @@ class DefCircuit(quil_rs.CircuitDefinition, AbstractInstruction):
         rs_qubits = [qubit.name for qubit in qubits]
         rs_instructions = _convert_to_rs_instructions(instructions)
         return super().__new__(cls, name, rs_parameters, rs_qubits, rs_instructions)
+
+    @classmethod
+    def _from_rs_circuit_definition(cls, circuit_definition: quil_rs.CircuitDefinition) -> "DefCircuit":
+        return super().__new__(
+            cls,
+            circuit_definition.name,
+            circuit_definition.parameters,
+            circuit_definition.qubit_variables,
+            circuit_definition.instructions,
+        )
 
     def out(self) -> str:
         return str(self)

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -135,6 +135,24 @@
   
   '''
 # ---
+# name: TestDefWaveform.test_out[No-Params-Entries]
+  '''
+  DEFWAVEFORM Wavey:
+      
+  '''
+# ---
+# name: TestDefWaveform.test_out[With-Param]
+  '''
+  DEFWAVEFORM Wavey(%x):
+      %x
+  '''
+# ---
+# name: TestDefWaveform.test_out[With-Params-Complex]
+  '''
+  DEFWAVEFORM Wavey(%x, %y):
+      1.0 + (2.0)*i, %x, 3.0+4.0i*%y
+  '''
+# ---
 # name: TestGate.test_controlled_modifier[CPHASE-Expression]
   'CONTROLLED CPHASE(1.5707963267948966) 5 0 1'
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -103,11 +103,11 @@
   	DECLARE ro BIT[1]
   	MEASURE a ro[0]
   	DEFGATE ParameterizedGate(%theta) AS MATRIX:
-  	%theta, 0, 0, 0
-  	0, %theta, 0, 0
-  	0, 0, %theta, 0
-  	0, 0, 0, %theta
-  
+  		%theta, 0, 0, 0
+  		0, %theta, 0, 0
+  		0, 0, %theta, 0
+  		0, 0, 0, %theta
+  	
   
   '''
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -138,13 +138,13 @@
 # name: TestDefWaveform.test_out[No-Params-Entries]
   '''
   DEFWAVEFORM Wavey:
-      
+  	
   '''
 # ---
 # name: TestDefWaveform.test_out[With-Param]
   '''
   DEFWAVEFORM Wavey(%x):
-      %x
+  	%x
   '''
 # ---
 # name: TestDefWaveform.test_out[With-Params-Complex]

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -90,6 +90,27 @@
   	X 0
   '''
 # ---
+# name: TestDefCircuit.test_out[No-Params]
+  '''
+  DEFCIRCUIT NiftyCircuit a:
+  	MEASURE a
+  
+  '''
+# ---
+# name: TestDefCircuit.test_out[With-Params]
+  '''
+  DEFCIRCUIT NiftyCircuit(%theta) a:
+  	DECLARE ro BIT[1]
+  	MEASURE a ro[0]
+  	DEFGATE ParameterizedGate(%theta) AS MATRIX:
+  	%theta, 0, 0, 0
+  	0, %theta, 0, 0
+  	0, 0, %theta, 0
+  	0, 0, 0, %theta
+  
+  
+  '''
+# ---
 # name: TestDefFrame.test_out[Frame-Only]
   'DEFFRAME 0 "frame":'
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -287,7 +287,7 @@
 # name: TestDefWaveform.test_out[With-Params-Complex]
   '''
   DEFWAVEFORM Wavey(%x,%y):
-  	1+2i, %x, (3+(4i*%y))
+  	1+2i, %x, (3*%y)
   '''
 # ---
 # name: TestGate.test_controlled_modifier[CPHASE-Expression]

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -1,6 +1,5 @@
 from math import pi
 from numbers import Complex
-from typing import List, Optional, Iterable, Tuple, Union
 from numbers import Number
 from typing import Any, List, Optional, Union, Iterable, Tuple
 

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -13,6 +13,7 @@ from pyquil.quilbase import (
     AbstractInstruction,
     Declare,
     DefCalibration,
+    DefCircuit,
     DefFrame,
     DefGate,
     DefMeasureCalibration,
@@ -545,3 +546,55 @@ class TestDefWaveform:
         assert def_waveform.entries == entries
         def_waveform.entries = [Parameter("z")]  # type: ignore
         assert def_waveform.entries == [Parameter("z")]
+
+
+@pytest.mark.parametrize(
+    ("name", "parameters", "qubit_variables", "instructions"),
+    [
+        ("NiftyCircuit", [], [FormalArgument("a")], [Measurement(FormalArgument("a"), None)]),
+        (
+            "NiftyCircuit",
+            [Parameter("theta")],
+            [FormalArgument("a")],
+            [
+                Declare("ro", "BIT", 1),
+                Measurement(FormalArgument("a"), MemoryReference("ro")),
+                DefGate("ParameterizedGate", np.diag([Parameter("theta")] * 4), [Parameter("theta")]),
+            ],
+        ),
+    ],
+    ids=("No-Params", "With-Params"),
+)
+class TestDefCircuit:
+    @pytest.fixture
+    def def_circuit(
+        self,
+        name: str,
+        parameters: List[Parameter],
+        qubit_variables: List[FormalArgument],
+        instructions: List[AbstractInstruction],
+    ):
+        return DefCircuit(name, parameters, qubit_variables, instructions)
+
+    def test_out(self, def_circuit: DefCircuit, snapshot: SnapshotAssertion):
+        assert def_circuit.out() == snapshot
+
+    def test_name(self, def_circuit: DefCircuit, name: str):
+        assert def_circuit.name == name
+        def_circuit.name = "new_name"
+        assert def_circuit.name == "new_name"
+
+    def test_parameters(self, def_circuit: DefCircuit, parameters: List[Parameter]):
+        assert def_circuit.parameters == parameters
+        def_circuit.parameters = [Parameter("z")]
+        assert def_circuit.parameters == [Parameter("z")]
+
+    def test_qubit_variables(self, def_circuit: DefCircuit, qubit_variables: List[FormalArgument]):
+        assert def_circuit.qubit_variables == qubit_variables
+        def_circuit.qubit_variables = [FormalArgument("qubit")]
+        assert def_circuit.qubit_variables == [FormalArgument("qubit")]
+
+    def test_instructions(self, def_circuit: DefCircuit, instructions: List[AbstractInstruction]):
+        assert def_circuit.instructions == instructions
+        def_circuit.instructions = [Gate("new_gate", [], [Qubit(0)], [])]
+        assert def_circuit.instructions == [Gate("new_gate", [], [Qubit(0)], [])]


### PR DESCRIPTION
This backs `DefWaveform` with quil-rs's `WaveformDefinition`. There was no existing `DefCircuit` instruction, so I created one, also backed by quil-rs, of course.