### PR TITLE
feat!: use qcs-sdk-python implementation of conjugate_pauli_by_clifford and generate_randomized_benchmarking_sequence

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1965,24 +1965,24 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qcs-sdk-python"
-version = "0.5.0rc17"
+version = "0.5.0rc20"
 description = "Python interface for the QCS Rust SDK"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "qcs_sdk_python-0.5.0rc17-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:d54e6513a738be58fe3ce9147b8915f458e40f87e6704a4807f315600481fd15"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ae0508a55e69065eb9c34a7e9571a18bcdbd3b9ec1aaf0dec6a7c1a82c81485"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47c87e214a8b9b34bbad8c9d33b9ea6cb58b357480ba6b7710f9ccfb97a43868"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:a9e9b1f35621016b6bf67040e600a0a42fa26d24dbfa612fed3941e04f86258b"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:505aedb1967af81c7e224cab50aea175fdf7fe825821fda78398fde570c0521d"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1373d4fac6bda1259227d8947d36e32b5c39f06e8f2f8ad411d00af9774b36d"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:67a5b67a8e7f546fccf7eda027ce4c1b3a193d36de094c36aec0cb33644b3295"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc7abf6b06acc7dc34b5da5bba90874d47daf59603a471533c48ba81d82674e7"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0eb33e1519b5d8b72768cc60c19ab21b022521d6d932cb581e5f6742b60e3f7"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:19d3322bcb994dfbe16d5dcf92b77f82419ec2470ce95e1335d157a10a137109"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b6bfc26ceff1f8d847943df9247f87a0511e46f7b640ad52dc76d3922ef5877a"},
-    {file = "qcs_sdk_python-0.5.0rc17-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1100a3ca85757cd59519de0343f530fed056d653dad3cbd7d94ca3426266cf36"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:7a71e27316c887bed8a736b1d223408cf5baff6967ce3db9238613aac112147d"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aedd416159ec57b013429621805b41e02e875f6f51095f7e88a77650c002384a"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3a2e3032deb95aca024535c24f933cb6ad6a9501ad59d95b1af01fd47479ce8"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:4cf6b20c3b1e984449db891ecb2d56b4149c3be9b873feeb3aa14f7bd494d629"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96e5e061a14cf2975273b93c246b8e56187e9cd291dcdef6d27db56b7dfd3bae"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a33b63e49ef1cddfd56f4f89ecad232931516d7630c383143ddf2f2a31096be"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:3da8ec54b8c10a62c4e656533c64d0b7596fa58e4b79afd05ee0dbd86a9390cc"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5319c60213762edf44881407af00f467e99106f6bb678ea4890f0d1a652ef1df"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4edd1da6bb48af5baf98a1b7c4f592c9506498338ce76e3389e3ccc43186982"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:b6fcc8b0d1afda5028c82c01c4b5169633a10f16f2064c2a4679de7bb8fc6b9d"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d709d28c35d5b66a87d4955a0d67bfbd1689ef7d3e9a6546b55a411f4da72c4a"},
+    {file = "qcs_sdk_python-0.5.0rc20-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:433735603803e26a335cef4614392daf18f830c2be7a2db2b488ec00126364b2"},
 ]
 
 [[package]]
@@ -2586,4 +2586,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<3.12"
-content-hash = "893cd6cad7c5121beb3c1795e5be41568f5a811ba3123fe3af1ebc932f7c634d"
+content-hash = "25a1413777c3e8b35f376849844267d86766c9885ed82a054b5df03db3befcf7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ rpcq = "^3.10.0"
 pydantic = "^1.10.7"
 networkx = "^2.5"
 importlib-metadata = { version = ">=3.7.3,<5", python = "<3.8" }
-qcs-sdk-python = "0.5.0rc.17"
+qcs-sdk-python = "0.5.0rc.20"
 retry = "^0.9.2"
 types-python-dateutil = "^2.8.19"
 types-retry = "^0.9.9"

--- a/pyquil/api/_benchmark.py
+++ b/pyquil/api/_benchmark.py
@@ -19,8 +19,9 @@ from qcs_sdk import QCSClient
 
 from pyquil.api._abstract_compiler import AbstractBenchmarker
 from pyquil.api._compiler_client import (
-    GenerateRandomizedBenchmarkingSequenceRequest,
-    ConjugatePauliByCliffordRequest,
+    RandomizedBenchmarkingRequest,
+    ConjugateByCliffordRequest,
+    PauliTerm as QuilcPauliTerm,
     CompilerClient,
 )
 
@@ -65,9 +66,11 @@ class BenchmarkConnection(AbstractBenchmarker):
 
         indices_and_terms = list(zip(*list(pauli_in.operations_as_set())))
 
-        request = ConjugatePauliByCliffordRequest(
-            pauli_indices=list(indices_and_terms[0]),
-            pauli_symbols=list(indices_and_terms[1]),
+        request = ConjugateByCliffordRequest(
+            pauli=QuilcPauliTerm(
+                indices=list(indices_and_terms[0]),
+                symbols=list(indices_and_terms[1]),
+            ),
             clifford=clifford.out(calibrations=False),
         )
         response = self._compiler_client.conjugate_pauli_by_clifford(request)
@@ -133,7 +136,7 @@ class BenchmarkConnection(AbstractBenchmarker):
 
         depth = int(depth)  # needs to be jsonable, no np.int64 please!
 
-        request = GenerateRandomizedBenchmarkingSequenceRequest(
+        request = RandomizedBenchmarkingRequest(
             depth=depth,
             num_qubits=qubits,
             gateset=gateset_for_api,

--- a/pyquil/api/_benchmark.py
+++ b/pyquil/api/_benchmark.py
@@ -16,12 +16,12 @@
 from typing import List, Optional, Sequence, cast
 
 from qcs_sdk import QCSClient
+from qcs_sdk.compiler.quilc import PauliTerm as QuilcPauliTerm
 
 from pyquil.api._abstract_compiler import AbstractBenchmarker
 from pyquil.api._compiler_client import (
     RandomizedBenchmarkingRequest,
     ConjugateByCliffordRequest,
-    PauliTerm as QuilcPauliTerm,
     CompilerClient,
 )
 
@@ -75,7 +75,7 @@ class BenchmarkConnection(AbstractBenchmarker):
         )
         response = self._compiler_client.conjugate_pauli_by_clifford(request)
 
-        phase_factor, paulis = response.phase_factor, response.pauli
+        phase_factor, paulis = response.phase, response.pauli
 
         pauli_out = PauliTerm("I", 0, 1.0j**phase_factor)
         clifford_qubits = clifford.get_qubits()
@@ -138,7 +138,7 @@ class BenchmarkConnection(AbstractBenchmarker):
 
         request = RandomizedBenchmarkingRequest(
             depth=depth,
-            num_qubits=qubits,
+            qubits=qubits,
             gateset=gateset_for_api,
             seed=seed,
             interleaver=interleaver_out,

--- a/pyquil/api/_benchmark.py
+++ b/pyquil/api/_benchmark.py
@@ -16,14 +16,14 @@
 from typing import List, Optional, Sequence, cast
 
 from qcs_sdk import QCSClient
-from qcs_sdk.compiler.quilc import PauliTerm as QuilcPauliTerm
-
-from pyquil.api._abstract_compiler import AbstractBenchmarker
-from pyquil.api._compiler_client import (
+from qcs_sdk.compiler.quilc import (
+    PauliTerm as QuilcPauliTerm,
     RandomizedBenchmarkingRequest,
     ConjugateByCliffordRequest,
-    CompilerClient,
 )
+
+from pyquil.api._abstract_compiler import AbstractBenchmarker
+from pyquil.api._compiler_client import CompilerClient
 
 from pyquil.paulis import PauliTerm, is_identity
 from pyquil.quil import address_qubits, Program

--- a/pyquil/api/_compiler_client.py
+++ b/pyquil/api/_compiler_client.py
@@ -25,7 +25,6 @@ from qcs_sdk.compiler.quilc import (
     TargetDevice,
     conjugate_pauli_by_clifford,
     generate_randomized_benchmarking_sequence,
-    PauliTerm as PauliTerm,
     ConjugateByCliffordRequest,
     ConjugatePauliByCliffordResponse,
     RandomizedBenchmarkingRequest,

--- a/pyquil/api/_compiler_client.py
+++ b/pyquil/api/_compiler_client.py
@@ -25,6 +25,7 @@ from qcs_sdk.compiler.quilc import (
     TargetDevice,
     conjugate_pauli_by_clifford,
     generate_randomized_benchmarking_sequence,
+    PauliTerm as PauliTerm,
     ConjugateByCliffordRequest,
     ConjugatePauliByCliffordResponse,
     RandomizedBenchmarkingRequest,

--- a/test/unit/test_compiler_client.py
+++ b/test/unit/test_compiler_client.py
@@ -57,16 +57,6 @@ def test_init__validates_compiler_url(monkeypatch: MonkeyPatch):
         CompilerClient(client_configuration=client_configuration)
 
 
-def test_sets_timeout_on_requests(mocker: MockerFixture):
-    client_configuration = QCSClient.load()
-    compiler_client = CompilerClient(client_configuration=client_configuration, request_timeout=0.1)
-
-    patch_rpcq_client(mocker=mocker, return_value={})
-
-    with compiler_client._rpcq_client() as client:
-        assert client.timeout == compiler_client.timeout
-
-
 @pytest.mark.skip  # cannot mock `qcs_sdk` here
 def test_get_version__returns_version(mocker: MockerFixture):
     client_configuration = QCSClient.load()

--- a/test/unit/test_compiler_client.py
+++ b/test/unit/test_compiler_client.py
@@ -22,7 +22,6 @@ except ImportError:  # 3.7 requires this backport of AsyncMock
     from mock import AsyncMock
 
 from qcs_sdk import QCSClient
-import rpcq
 from _pytest.monkeypatch import MonkeyPatch
 import pytest
 from pytest import raises
@@ -32,11 +31,6 @@ from pyquil.api._compiler_client import (
     CompilerClient,
     CompileToNativeQuilRequest,
     CompileToNativeQuilResponse,
-    ConjugatePauliByCliffordRequest,
-    ConjugatePauliByCliffordResponse,
-    GenerateRandomizedBenchmarkingSequenceRequest,
-    GenerateRandomizedBenchmarkingSequenceResponse,
-    NativeQuilMetadataResponse,
 )
 from pyquil.external.rpcq import CompilerISA, compiler_isa_to_target_quantum_processor
 
@@ -101,61 +95,4 @@ def test_compile_to_native_quil__returns_native_quil(
     assert compiler_client.compile_to_native_quil(request) == CompileToNativeQuilResponse(
         native_program="DECLARE ro BIT[1]\n",
         metadata=None,
-    )
-
-
-def test_conjugate_pauli_by_clifford__returns_conjugation_result(mocker: MockerFixture):
-    client_configuration = QCSClient.load()
-    compiler_client = CompilerClient(client_configuration=client_configuration)
-    rpcq_client = patch_rpcq_client(
-        mocker=mocker, return_value=rpcq.messages.ConjugateByCliffordResponse(phase=42, pauli="pauli")
-    )
-
-    request = ConjugatePauliByCliffordRequest(
-        pauli_indices=[0, 1, 2],
-        pauli_symbols=["x", "y", "z"],
-        clifford="cliff",
-    )
-    assert compiler_client.conjugate_pauli_by_clifford(request) == ConjugatePauliByCliffordResponse(
-        phase_factor=42,
-        pauli="pauli",
-    )
-    rpcq_client.call.assert_called_once_with(
-        "conjugate_pauli_by_clifford",
-        rpcq.messages.ConjugateByCliffordRequest(
-            pauli=rpcq.messages.PauliTerm(indices=[0, 1, 2], symbols=["x", "y", "z"]),
-            clifford="cliff",
-        ),
-    )
-
-
-def test_generate_randomized_benchmarking_sequence__returns_benchmarking_sequence(
-    mocker: MockerFixture,
-):
-    client_configuration = QCSClient.load()
-    compiler_client = CompilerClient(client_configuration=client_configuration)
-
-    rpcq_client = patch_rpcq_client(
-        mocker=mocker, return_value=rpcq.messages.RandomizedBenchmarkingResponse(sequence=[[3, 1, 4], [1, 6, 1]])
-    )
-
-    request = GenerateRandomizedBenchmarkingSequenceRequest(
-        depth=42,
-        num_qubits=3,
-        gateset=["some", "gate", "set"],
-        seed=314,
-        interleaver="some-interleaver",
-    )
-    assert compiler_client.generate_randomized_benchmarking_sequence(
-        request
-    ) == GenerateRandomizedBenchmarkingSequenceResponse(sequence=[[3, 1, 4], [1, 6, 1]])
-    rpcq_client.call.assert_called_once_with(
-        "generate_rb_sequence",
-        rpcq.messages.RandomizedBenchmarkingRequest(
-            depth=42,
-            qubits=3,
-            gateset=["some", "gate", "set"],
-            seed=314,
-            interleaver="some-interleaver",
-        ),
     )


### PR DESCRIPTION
### Breaking Change:
Use the `qcs-sdk-python` implementation of `conjugate_pauli_by_clifford` and `generate_randomized_benchmarking_sequence` from https://github.com/rigetti/qcs-sdk-rust/pull/280. This is breaking because the request/response shapes change.

### Fix:
Release support for lowercase env var names `https_proxy` and `http_proxy` for the client proxy features from https://github.com/rigetti/qcs-sdk-rust/pull/266 