### PR TITLE
remove to_headers

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -726,19 +726,6 @@ class Program:
         """
         return Program(self._program.dagger())
 
-    @deprecated(
-        deprecated_in="4.0", removed_in="5.0", current_version=pyquil_version, details="This function will be removed."
-    )
-    def pop(self) -> AbstractInstruction:
-        """
-        Removes the last instruction from the program and returns it
-        """
-        last = self.instructions[-1]
-        new_program = Program(self.instructions[:-1])
-        self._program = new_program._program
-        self._memory = new_program._memory
-        return last
-
     def __add__(self, other: InstructionDesignator) -> "Program":
         """
         Concatenate two programs together, returning a new one.

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -192,7 +192,7 @@ class Program:
         """
         Fill in any placeholders and return a list of quil AbstractInstructions.
         """
-        return _convert_to_py_instructions(self._program.to_instructions(False))
+        return _convert_to_py_instructions(self._program.to_instructions())
 
     def inst(self, *instructions: InstructionDesignator) -> "Program":
         """

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -161,7 +161,13 @@ class Program:
 
         :return: a new Program
         """
-        new_prog = Program(self._program.to_headers())
+        new_prog = Program(
+            list(self.declarations.values()),
+            list(self.frames.values()),
+            list(self.waveforms.values()),
+            self.calibrations,
+            self.measure_calibrations,
+        )
         new_prog.num_shots = self.num_shots
         new_prog._memory = self._memory.copy()
         return new_prog
@@ -728,8 +734,7 @@ class Program:
         Removes the last instruction from the program and returns it
         """
         last = self.instructions[-1]
-        instructions = self._program.to_headers() + self.instructions
-        new_program = Program(instructions[:-1])
+        new_program = Program(self.instructions[:-1])
         self._program = new_program._program
         self._memory = new_program._memory
         return last

--- a/test/unit/test_quil.py
+++ b/test/unit/test_quil.py
@@ -159,13 +159,6 @@ def test_inst_string(snapshot):
     assert p.out() == snapshot
 
 
-def test_program_pop(snapshot):
-    prog = Program(X(0), X(1))
-    instruction = prog.pop()
-    assert prog.out() == snapshot
-    assert Program(instruction).out() == snapshot
-
-
 def test_len_zero():
     prog = Program()
     assert len(prog) == 0
@@ -1256,8 +1249,8 @@ def test_subtracting_memory_regions():
     beta = p.declare("beta", "REAL")
     p += RZ(alpha - beta, 0)
     p2 = Program(p.out())
-    parsed_rz = p2.pop()  # type: Gate
-    parsed_param = parsed_rz.params[0]
+    parsed_rz = p2[-1]
+    parsed_param = parsed_rz.params[0]  # type: Gate
     assert isinstance(parsed_param, Sub)
     assert parsed_param.op1 == alpha
     assert parsed_param.op2 == beta


### PR DESCRIPTION
Quil doesn't have a "headers" concept. `quil-rs`' `to_headers` method was a stop gap that we no longer want to commit to, so we've removed it. 