### PR TITLE
Use quil-rs for Capture, RawCapture, and Pulse

### DIFF
--- a/pyquil/_parser/parser.py
+++ b/pyquil/_parser/parser.py
@@ -56,8 +56,8 @@ from pyquil.quilbase import (
     ClassicalLessThan,
     ClassicalLessEqual,
 )
-from pyquil.quiltwaveforms import _wf_from_dict
 from pyquil.quilatom import (
+    TemplateWaveform,
     WaveformReference,
     Expression,
     quil_sqrt,
@@ -140,7 +140,7 @@ class QuilTransformer(Transformer):  # type: ignore
         }
         options = {}
 
-        for (spec_name, spec_value) in specs:
+        for spec_name, spec_value in specs:
             name = names.get(spec_name, None)
             if name:
                 options[name] = json.loads(str(spec_value))
@@ -451,7 +451,7 @@ class QuilTransformer(Transformer):  # type: ignore
     def waveform(self, name, *params):
         param_dict = {k: v for (k, v) in params}
         if param_dict:
-            return _wf_from_dict(name, param_dict)
+            return TemplateWaveform(name, **param_dict)
         else:
             return WaveformReference(name)
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1350,6 +1350,16 @@ class SetScale(AbstractInstruction):
 
 
 class Capture(AbstractInstruction):
+    # def __new__(
+    #     cls,
+    #     frame: Frame,
+    #     kernel: Waveform,
+    #     memory_region: MemoryReference,
+    #     nonblocking: bool = False,
+    # ):
+    #     rs_memory_reference = _convert_to_rs_expression(memory_region)
+    #     return super().__new__(cls, not nonblocking, frame, rs_memory_reference, kernel)
+
     def __init__(
         self,
         frame: Frame,

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -61,7 +61,6 @@ from pyquil.quilatom import (
     _convert_to_rs_expressions,
     _convert_to_rs_qubit,
     _convert_to_rs_qubits,
-    _convert_to_rs_waveform,
     _convert_to_py_expression,
     _convert_to_py_parameters,
     _convert_to_py_waveform,
@@ -1263,8 +1262,7 @@ class RawInstr(AbstractInstruction):
 
 class Pulse(quil_rs.Pulse, AbstractInstruction):
     def __new__(cls, frame: Frame, waveform: Waveform, nonblocking: bool = False):
-        rs_waveform = _convert_to_rs_waveform(waveform)
-        return super().__new__(cls, not nonblocking, frame, rs_waveform)
+        return super().__new__(cls, not nonblocking, frame, waveform)
 
     def out(self) -> str:
         return str(self)
@@ -1298,8 +1296,7 @@ class Pulse(quil_rs.Pulse, AbstractInstruction):
 
     @waveform.setter
     def waveform(self, waveform: Waveform):
-        rs_waveform = _convert_to_rs_waveform(waveform)
-        quil_rs.Pulse.waveform.__set__(self, rs_waveform)
+        quil_rs.Pulse.waveform.__set__(self, waveform)
 
     @property
     def nonblocking(self) -> bool:
@@ -1391,8 +1388,7 @@ class Capture(quil_rs.Capture, AbstractInstruction):
         nonblocking: bool = False,
     ):
         rs_memory_reference = _convert_to_rs_expression(memory_region).to_address()
-        rs_waveform = _convert_to_rs_waveform(kernel)
-        return super().__new__(cls, not nonblocking, frame, rs_memory_reference, rs_waveform)
+        return super().__new__(cls, not nonblocking, frame, rs_memory_reference, kernel)
 
     @property
     def frame(self) -> Frame:
@@ -1408,8 +1404,7 @@ class Capture(quil_rs.Capture, AbstractInstruction):
 
     @kernel.setter
     def kernel(self, kernel: Waveform):
-        rs_waveform = _convert_to_rs_waveform(kernel)
-        quil_rs.Capture.waveform.__set__(self, rs_waveform)
+        quil_rs.Capture.waveform.__set__(self, kernel)
 
     @property
     def memory_region(self) -> MemoryReference:

--- a/pyquil/quiltwaveforms.py
+++ b/pyquil/quiltwaveforms.py
@@ -1,5 +1,7 @@
 from typing import Optional
+from warnings import warn
 
+from deprecation import deprecated
 import numpy as np
 from scipy.special import erf
 
@@ -9,7 +11,21 @@ from pyquil.quilatom import (
     _template_waveform_property,
 )
 
+from pyquil._version import pyquil_version
 
+warn(
+    DeprecationWarning("The quiltwaveforms module is deprecated. Use quilatom.WaveformInvocation instead."),
+    category=DeprecationWarning,
+    stacklevel=2,
+)
+
+
+@deprecated(
+    deprecated_in="4.0",
+    removed_in="5.0",
+    current_version=pyquil_version,
+    details="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
+)
 class FlatWaveform(TemplateWaveform):
     """
     A flat (constant) waveform.
@@ -35,6 +51,12 @@ class FlatWaveform(TemplateWaveform):
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
+@deprecated(
+    deprecated_in="4.0",
+    removed_in="5.0",
+    current_version=pyquil_version,
+    details="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
+)
 class GaussianWaveform(TemplateWaveform):
     """A Gaussian pulse."""
 
@@ -68,6 +90,12 @@ class GaussianWaveform(TemplateWaveform):
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
+@deprecated(
+    deprecated_in="4.0",
+    removed_in="5.0",
+    current_version=pyquil_version,
+    details="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
+)
 class DragGaussianWaveform(TemplateWaveform):
     """A DRAG Gaussian pulse."""
 
@@ -118,6 +146,12 @@ class DragGaussianWaveform(TemplateWaveform):
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
+@deprecated(
+    deprecated_in="4.0",
+    removed_in="5.0",
+    current_version=pyquil_version,
+    details="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
+)
 class HrmGaussianWaveform(TemplateWaveform):
     """A Hermite Gaussian waveform.
 
@@ -188,6 +222,12 @@ class HrmGaussianWaveform(TemplateWaveform):
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
+@deprecated(
+    deprecated_in="4.0",
+    removed_in="5.0",
+    current_version=pyquil_version,
+    details="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
+)
 class ErfSquareWaveform(TemplateWaveform):
     """A pulse with a flat top and edges that are error functions (erf)."""
 
@@ -244,6 +284,12 @@ class ErfSquareWaveform(TemplateWaveform):
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
+@deprecated(
+    deprecated_in="4.0",
+    removed_in="5.0",
+    current_version=pyquil_version,
+    details="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
+)
 class BoxcarAveragerKernel(TemplateWaveform):
     def __new__(
         cls,

--- a/pyquil/quiltwaveforms.py
+++ b/pyquil/quiltwaveforms.py
@@ -1,144 +1,65 @@
-from copy import copy
-from dataclasses import dataclass
-from numbers import Complex, Real
-from typing import Callable, Dict, Union, List, Optional, no_type_check
+from typing import Optional
 
 import numpy as np
 from scipy.special import erf
 
-from pyquil.quilatom import TemplateWaveform, _update_envelope, _complex_str, Expression, substitute
-
-_waveform_classes: Dict[str, type] = {}
-"""A mapping from Quil-T waveform names to their corresponding classes.
-
-This should not be mutated directly, but rather filled by the @waveform
-decorator.
-"""
+from pyquil.quilatom import (
+    TemplateWaveform,
+    _update_envelope,
+    _template_waveform_property,
+)
 
 
-def waveform(name: str) -> Callable[[type], type]:
-    """Define a Quil-T wavefom with the given name."""
-
-    def wrap(cls: type) -> type:
-        cls: type = dataclass(cls)
-        _waveform_classes[name] = cls
-        return cls
-
-    return wrap
-
-
-@no_type_check
-def _wf_from_dict(name: str, params: Dict[str, Union[Expression, Real, Complex]]) -> TemplateWaveform:
-    """Construct a TemplateWaveform from a name and a dictionary of properties.
-
-    :param name: The Quil-T name of the template.
-    :param params: A mapping from parameter names to their corresponding values.
-    :returns: A template waveform.
-    """
-    params = copy(params)
-    if name not in _waveform_classes:
-        raise ValueError(f"Unknown template waveform {name}.")
-    cls = _waveform_classes[name]
-    fields = getattr(cls, "__dataclass_fields__", {})
-
-    for param, value in params.items():
-        if param not in fields:
-            raise ValueError(f"Unexpected parameter '{param}' in {name}.")
-
-        if isinstance(value, Expression):
-            value = substitute(value, {})
-
-        if isinstance(value, Real):
-            # normalize to float
-            params[param] = float(value)
-        elif isinstance(value, Complex):
-            # no normalization needed
-            pass
-        else:
-            raise ValueError(f"Unable to resolve parameter '{param}' in template {name} to a constant value.")
-
-    for field, spec in fields.items():
-        if field not in params and spec.default is not None:
-            raise ValueError(f"Missing parameter '{field}' in {name}.")
-
-    return cls(**params)
-
-
-def _optional_field_strs(wf: TemplateWaveform) -> List[str]:
-    """Get the printed representations of optional template parameters."""
-    result = []
-    for field, spec in getattr(wf, "__dataclass_fields__", {}).items():
-        if spec.default is None:
-            value = getattr(wf, field, None)
-            if value is not None:
-                result.append(f"{field}: {value}")
-    return result
-
-
-@waveform("flat")
 class FlatWaveform(TemplateWaveform):
     """
     A flat (constant) waveform.
     """
 
-    iq: Complex
-    """ A raw IQ value. """
+    def __new__(
+        cls,
+        duration: float,
+        iq: complex,
+        scale: Optional[float] = None,
+        phase: Optional[float] = None,
+        detuning: Optional[float] = None,
+    ):
+        return super().__new__(cls, "flat", duration=duration, iq=iq, scale=scale, phase=phase, detuning=detuning)
 
-    scale: Optional[float] = None
-    """ An optional global scaling factor. """
-
-    phase: Optional[float] = None
-    """ An optional phase shift factor. """
-
-    detuning: Optional[float] = None
-    """ An optional frequency detuning factor. """
-
-    def out(self) -> str:
-        output = "flat("
-        output += ", ".join([f"duration: {self.duration}", f"iq: {_complex_str(self.iq)}"] + _optional_field_strs(self))
-        output += ")"
-        return output
-
-    def __str__(self) -> str:
-        return self.out()
+    iq = _template_waveform_property("iq", "A raw IQ value.")
+    scale = _template_waveform_property("scale", "An optional global scaling factor.")
+    phase = _template_waveform_property("phase", "An optional phase shift factor.")
+    detuning = _template_waveform_property("detuning", "An optional frequency detuning factor.")
 
     def samples(self, rate: float) -> np.ndarray:
         iqs = np.full(self.num_samples(rate), self.iq, dtype=np.complex128)
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
-    def name(self) -> str:
-        return "flat"
 
-
-@waveform("gaussian")
 class GaussianWaveform(TemplateWaveform):
     """A Gaussian pulse."""
 
-    fwhm: float
-    """ The Full-Width-Half-Max of the Gaussian (seconds). """
-
-    t0: float
-    """ The center time coordinate of the Gaussian (seconds). """
-
-    scale: Optional[float] = None
-    """ An optional global scaling factor. """
-
-    phase: Optional[float] = None
-    """ An optional phase shift factor. """
-
-    detuning: Optional[float] = None
-    """ An optional frequency detuning factor. """
-
-    def out(self) -> str:
-        output = "gaussian("
-        output += ", ".join(
-            [f"duration: {self.duration}", f"fwhm: {self.fwhm}", f"t0: {self.t0}"] + _optional_field_strs(self)
+    def __new__(
+        cls,
+        duration: float,
+        fwhm: float,
+        t0: float,
+        scale: Optional[float] = None,
+        phase: Optional[float] = None,
+        detuning: Optional[float] = None,
+    ):
+        return super().__new__(
+            cls, "gaussian", duration=duration, fwhm=fwhm, t0=t0, scale=scale, phase=phase, detuning=detuning
         )
-        output += ")"
-        return output
 
-    def __str__(self) -> str:
-        return self.out()
+    fwhm = _template_waveform_property("fwhm", "The Full-Width-Half-Max of the Gaussian (seconds).")
+
+    t0 = _template_waveform_property("t0", "The center time coordinate of the Gaussian (seconds).")
+
+    scale = _template_waveform_property("scale", "An optional global scaling factor.")
+
+    phase = _template_waveform_property("phase", "An optional phase shift factor.")
+
+    detuning = _template_waveform_property("detuning", "An optional frequency detuning factor.")
 
     def samples(self, rate: float) -> np.ndarray:
         ts = np.arange(self.num_samples(rate), dtype=np.complex128) / rate
@@ -146,52 +67,47 @@ class GaussianWaveform(TemplateWaveform):
         iqs = np.exp(-0.5 * (ts - self.t0) ** 2 / sigma**2)
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
-    def name(self) -> str:
-        return "gaussian"
 
-
-@waveform("drag_gaussian")
 class DragGaussianWaveform(TemplateWaveform):
     """A DRAG Gaussian pulse."""
 
-    fwhm: float
-    """ The Full-Width-Half-Max of the gaussian (seconds). """
-
-    t0: float
-    """ The center time coordinate of the Gaussian (seconds). """
-
-    anh: float
-    """ The anharmonicity of the qubit, f01-f12 (Hertz). """
-
-    alpha: float
-    """ Dimensionles DRAG parameter. """
-
-    scale: Optional[float] = None
-    """ An optional global scaling factor. """
-
-    phase: Optional[float] = None
-    """ An optional phase shift factor. """
-
-    detuning: Optional[float] = None
-    """ An optional frequency detuning factor. """
-
-    def out(self) -> str:
-        output = "drag_gaussian("
-        output += ", ".join(
-            [
-                f"duration: {self.duration}",
-                f"fwhm: {self.fwhm}",
-                f"t0: {self.t0}",
-                f"anh: {self.anh}",
-                f"alpha: {self.alpha}",
-            ]
-            + _optional_field_strs(self)
+    def __new__(
+        cls,
+        duration: float,
+        fwhm: float,
+        t0: float,
+        anh: float,
+        alpha: float,
+        scale: Optional[float] = None,
+        phase: Optional[float] = None,
+        detuning: Optional[float] = None,
+    ):
+        return super().__new__(
+            cls,
+            "drag_gaussian",
+            duration=duration,
+            fwhm=fwhm,
+            t0=t0,
+            anh=anh,
+            alpha=alpha,
+            scale=scale,
+            phase=phase,
+            detuning=detuning,
         )
-        output += ")"
-        return output
 
-    def __str__(self) -> str:
-        return self.out()
+    fwhm = _template_waveform_property("fwhm", "The Full-Width-Half-Max of the gaussian (seconds).")
+
+    t0 = _template_waveform_property("t0", "The center time coordinate of the Gaussian (seconds).")
+
+    anh = _template_waveform_property("anh", "The anharmonicity of the qubit, f01-f12 (Hertz).")
+
+    alpha = _template_waveform_property("alpha", "Dimensionles DRAG parameter.")
+
+    scale = _template_waveform_property("scale", "An optional global scaling factor.")
+
+    phase = _template_waveform_property("phase", "An optional phase shift factor.")
+
+    detuning = _template_waveform_property("detuning", "An optional frequency detuning factor.")
 
     def samples(self, rate: float) -> np.ndarray:
         ts = np.arange(self.num_samples(rate), dtype=np.complex128) / rate
@@ -201,11 +117,7 @@ class DragGaussianWaveform(TemplateWaveform):
         iqs = env + 1.0j * env_der
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
-    def name(self) -> str:
-        return "drag_gaussian"
 
-
-@waveform("hrm_gaussian")
 class HrmGaussianWaveform(TemplateWaveform):
     """A Hermite Gaussian waveform.
 
@@ -214,48 +126,49 @@ class HrmGaussianWaveform(TemplateWaveform):
         10.1063/1.447644
     """
 
-    fwhm: float
-    """ The Full-Width-Half-Max of the Gaussian (seconds). """
-
-    t0: float
-    """ The center time coordinate of the Gaussian (seconds). """
-
-    anh: float
-    """ The anharmonicity of the qubit, f01-f12 (Hertz). """
-
-    alpha: float
-    """ Dimensionles DRAG parameter. """
-
-    second_order_hrm_coeff: float
-    """ Second order coefficient (see Warren 1984). """
-
-    scale: Optional[float] = None
-    """ An optional global scaling factor. """
-
-    phase: Optional[float] = None
-    """ An optional phase shift factor. """
-
-    detuning: Optional[float] = None
-    """ An optional frequency detuning factor. """
-
-    def out(self) -> str:
-        output = "hrm_gaussian("
-        output += ", ".join(
-            [
-                f"duration: {self.duration}",
-                f"fwhm: {self.fwhm}",
-                f"t0: {self.t0}",
-                f"anh: {self.anh}",
-                f"alpha: {self.alpha}",
-                f"second_order_hrm_coeff: {self.second_order_hrm_coeff}",
-            ]
-            + _optional_field_strs(self)
+    def __new__(
+        cls,
+        duration: float,
+        fwhm: float,
+        t0: float,
+        anh: float,
+        alpha: float,
+        second_order_hrm_coeff: float,
+        scale: Optional[float] = None,
+        phase: Optional[float] = None,
+        detuning: Optional[float] = None,
+    ):
+        return super().__new__(
+            cls,
+            "hrm_gaussian",
+            duration=duration,
+            fwhm=fwhm,
+            t0=t0,
+            anh=anh,
+            second_order_hrm_coeff=second_order_hrm_coeff,
+            alpha=alpha,
+            scale=scale,
+            phase=phase,
+            detuning=detuning,
         )
-        output += ")"
-        return output
 
-    def __str__(self) -> str:
-        return self.out()
+    fwhm = _template_waveform_property("fwhm", "The Full-Width-Half-Max of the Gaussian (seconds).")
+
+    t0 = _template_waveform_property("t0", "The center time coordinate of the Gaussian (seconds).")
+
+    anh = _template_waveform_property("anh", "The anharmonicity of the qubit, f01-f12 (Hertz).")
+
+    alpha = _template_waveform_property("alpha", "Dimensionles DRAG parameter.")
+
+    second_order_hrm_coeff = _template_waveform_property(
+        "second_order_hrm_coeff", "Second order coefficient (see Warren 1984)."
+    )
+
+    scale = _template_waveform_property("scale", "An optional global scaling factor.")
+
+    phase = _template_waveform_property("phase", "An optional phase shift factor.")
+
+    detuning = _template_waveform_property("detuning", "An optional frequency detuning factor.")
 
     def samples(self, rate: float) -> np.ndarray:
         ts = np.arange(self.num_samples(rate), dtype=np.complex128) / rate
@@ -274,46 +187,49 @@ class HrmGaussianWaveform(TemplateWaveform):
         iqs = env + 1.0j * env_der
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
-    def name(self) -> str:
-        return "hrm_gaussian"
 
-
-@waveform("erf_square")
 class ErfSquareWaveform(TemplateWaveform):
     """A pulse with a flat top and edges that are error functions (erf)."""
 
-    risetime: float
-    """ The width of each of the rise and fall sections of the pulse (seconds). """
-    pad_left: float
-    """ Amount of zero-padding to add to the left of the pulse (seconds)."""
-    pad_right: float
-    """ Amount of zero-padding to add to the right of the pulse (seconds). """
-
-    scale: Optional[float] = None
-    """ An optional global scaling factor. """
-
-    phase: Optional[float] = None
-    """ An optional phase shift factor. """
-
-    detuning: Optional[float] = None
-    """ An optional frequency detuning factor. """
-
-    def out(self) -> str:
-        output = "erf_square("
-        output += ", ".join(
-            [
-                f"duration: {self.duration}",
-                f"risetime: {self.risetime}",
-                f"pad_left: {self.pad_left}",
-                f"pad_right: {self.pad_right}",
-            ]
-            + _optional_field_strs(self)
+    def __new__(
+        cls,
+        duration: float,
+        risetime: float,
+        pad_left: float,
+        pad_right: float,
+        scale: Optional[float] = None,
+        phase: Optional[float] = None,
+        detuning: Optional[float] = None,
+    ):
+        return super().__new__(
+            cls,
+            "erf_square",
+            duration=duration,
+            risetime=risetime,
+            pad_left=pad_left,
+            pad_right=pad_right,
+            scale=scale,
+            phase=phase,
+            detuning=detuning,
         )
-        output += ")"
-        return output
 
-    def __str__(self) -> str:
-        return self.out()
+    risetime = _template_waveform_property(
+        "risetime", "The width of each of the rise and fall sections of the pulse (seconds)."
+    )
+
+    pad_left = _template_waveform_property(
+        "pad_left", "Amount of zero-padding to add to the left of the pulse (seconds)"
+    )
+
+    pad_right = _template_waveform_property(
+        "pad_right", "Amount of zero-padding to add to the right of the pulse (seconds)."
+    )
+
+    scale = _template_waveform_property("scale", "An optional global scaling factor.")
+
+    phase = _template_waveform_property("phase", "An optional phase shift factor.")
+
+    detuning = _template_waveform_property("detuning", "An optional frequency detuning factor.")
 
     def samples(self, rate: float) -> np.ndarray:
         ts = np.arange(self.num_samples(rate), dtype=np.complex128) / rate
@@ -327,34 +243,24 @@ class ErfSquareWaveform(TemplateWaveform):
         iqs = np.concatenate((zeros_left, vals, zeros_right))  # type: ignore
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
-    def name(self) -> str:
-        return "erf_square"
 
-
-@waveform("boxcar_kernel")
 class BoxcarAveragerKernel(TemplateWaveform):
-    scale: Optional[float] = None
-    """ An optional global scaling factor. """
+    def __new__(
+        cls,
+        duration: float,
+        scale: Optional[float] = None,
+        phase: Optional[float] = None,
+        detuning: Optional[float] = None,
+    ):
+        return super().__new__(cls, "boxcar_kernel", duration=duration, scale=scale, phase=phase, detuning=detuning)
 
-    phase: Optional[float] = None
-    """ An optional phase shift factor. """
+    scale = _template_waveform_property("scale", "An optional global scaling factor.")
 
-    detuning: Optional[float] = None
-    """ An optional frequency detuning factor. """
+    phase = _template_waveform_property("phase", "An optional phase shift factor.")
 
-    def out(self) -> str:
-        output = "boxcar_kernel("
-        output += ", ".join([f"duration: {self.duration}"] + _optional_field_strs(self))
-        output += ")"
-        return output
-
-    def __str__(self) -> str:
-        return self.out()
+    detuning = _template_waveform_property("detuning", "An optional frequency detuning factor.")
 
     def samples(self, rate: float) -> np.ndarray:
         n = self.num_samples(rate)
         iqs = np.full(n, 1.0 / n, dtype=np.complex128)
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
-
-    def name(self) -> str:
-        return "boxcar_kernel"

--- a/pyquil/quiltwaveforms.py
+++ b/pyquil/quiltwaveforms.py
@@ -106,6 +106,9 @@ class FlatWaveform(TemplateWaveform):
         iqs = np.full(self.num_samples(rate), self.iq, dtype=np.complex128)
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
+    def name(self) -> str:
+        return "flat"
+
 
 @waveform("gaussian")
 class GaussianWaveform(TemplateWaveform):
@@ -142,6 +145,9 @@ class GaussianWaveform(TemplateWaveform):
         sigma = 0.5 * self.fwhm / np.sqrt(2.0 * np.log(2.0))
         iqs = np.exp(-0.5 * (ts - self.t0) ** 2 / sigma**2)
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
+
+    def name(self) -> str:
+        return "gaussian"
 
 
 @waveform("drag_gaussian")
@@ -194,6 +200,9 @@ class DragGaussianWaveform(TemplateWaveform):
         env_der = (self.alpha * (1.0 / (2 * np.pi * self.anh * sigma**2))) * (ts - self.t0) * env
         iqs = env + 1.0j * env_der
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
+
+    def name(self) -> str:
+        return "drag_gaussian"
 
 
 @waveform("hrm_gaussian")
@@ -265,6 +274,9 @@ class HrmGaussianWaveform(TemplateWaveform):
         iqs = env + 1.0j * env_der
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
+    def name(self) -> str:
+        return "hrm_gaussian"
+
 
 @waveform("erf_square")
 class ErfSquareWaveform(TemplateWaveform):
@@ -315,10 +327,12 @@ class ErfSquareWaveform(TemplateWaveform):
         iqs = np.concatenate((zeros_left, vals, zeros_right))  # type: ignore
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
+    def name(self) -> str:
+        return "erf_square"
+
 
 @waveform("boxcar_kernel")
 class BoxcarAveragerKernel(TemplateWaveform):
-
     scale: Optional[float] = None
     """ An optional global scaling factor. """
 
@@ -341,3 +355,6 @@ class BoxcarAveragerKernel(TemplateWaveform):
         n = self.num_samples(rate)
         iqs = np.full(n, 1.0 / n, dtype=np.complex128)
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
+
+    def name(self) -> str:
+        return "boxcar_kernel"

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -434,6 +434,12 @@
 # name: TestPulse.test_out[NonBlocking]
   'NONBLOCKING PULSE 123 q "FRAMEX" WAVEFORMY'
 # ---
+# name: TestRawCapture.test_out[Blocking]
+  'RAW-CAPTURE 123 q "FRAMEX" 0.5 ro[0]'
+# ---
+# name: TestRawCapture.test_out[NonBlocking]
+  'NONBLOCKING RAW-CAPTURE 123 q "FRAMEX" 2.5 WAVEFORMY'
+# ---
 # name: TestReset.test_out[FormalArgument]
   'RESET a'
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -5,7 +5,7 @@
   'NONBLOCKING CAPTURE 123 q "FRAMEX" WAVEFORMY ro[0]'
 # ---
 # name: TestCapture.test_out[TemplateWaveform]
-  'NONBLOCKING CAPTURE 123 q "FRAMEX" flat(duration: 2.5, iq: 1.0 + (2.0)*i) ro[0]'
+  'NONBLOCKING CAPTURE 123 q "FRAMEX" flat(duration: 2.5, iq: 1+2i) ro[0]'
 # ---
 # name: TestDeclare.test_asdict[Defaults]
   dict({

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -435,7 +435,7 @@
   'PULSE 123 q "FRAMEX" WAVEFORMY'
 # ---
 # name: TestPulse.test_out[FlatWaveform]
-  'NONBLOCKING PULSE 123 q "FRAMEX" flat(duration: 2.5, iq: 1.0 + (2.0)*i)'
+  'NONBLOCKING PULSE 123 q "FRAMEX" flat(duration: 2.5, iq: 1+2i)'
 # ---
 # name: TestPulse.test_out[NonBlocking]
   'NONBLOCKING PULSE 123 q "FRAMEX" WAVEFORMY'

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -1,3 +1,9 @@
+# name: TestCapture.test_out[Blocking]
+  'CAPTURE 123 q "FRAMEX" WAVEFORMY ro[0]'
+# ---
+# name: TestCapture.test_out[NonBlocking]
+  'NONBLOCKING CAPTURE 123 q "FRAMEX" WAVEFORMY ro[0]'
+# ---
 # name: TestDeclare.test_asdict[Defaults]
   dict({
     'memory_size': 1,
@@ -276,21 +282,6 @@
   
   '''
 # ---
-# name: TestDelayFrames.test_out[frames0-5.0]
-  'DELAY 0 "frame" 5'
-# ---
-# name: TestDelayQubits.test_out[FormalArgument]
-  'DELAY a 2.5'
-# ---
-# name: TestDelayQubits.test_out[Qubit]
-  'DELAY 0 5'
-# ---
-# name: TestFence.test_out[FormalArgument]
-  'FENCE a'
-# ---
-# name: TestFence.test_out[Qubit]
-  'FENCE 0'
-# ---
 # name: TestDefPermutationGate.test_get_constructor[PermGate-permutation0]
   'PermGate 123'
 # ---
@@ -325,6 +316,21 @@
   DEFWAVEFORM Wavey(%x,%y):
   	1+2i, %x, (3*%y)
   '''
+# ---
+# name: TestDelayFrames.test_out[frames0-5.0]
+  'DELAY 0 "frame" 5'
+# ---
+# name: TestDelayQubits.test_out[FormalArgument]
+  'DELAY a 2.5'
+# ---
+# name: TestDelayQubits.test_out[Qubit]
+  'DELAY 0 5'
+# ---
+# name: TestFence.test_out[FormalArgument]
+  'FENCE a'
+# ---
+# name: TestFence.test_out[Qubit]
+  'FENCE 0'
 # ---
 # name: TestGate.test_controlled_modifier[CPHASE-Expression]
   'CONTROLLED CPHASE(1.5707963267948966) 5 0 1'

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -4,6 +4,9 @@
 # name: TestCapture.test_out[NonBlocking]
   'NONBLOCKING CAPTURE 123 q "FRAMEX" WAVEFORMY ro[0]'
 # ---
+# name: TestCapture.test_out[TemplateWaveform]
+  'NONBLOCKING CAPTURE 123 q "FRAMEX" flat(duration: 2.5, iq: 1.0 + (2.0)*i) ro[0]'
+# ---
 # name: TestDeclare.test_asdict[Defaults]
   dict({
     'memory_size': 1,
@@ -431,11 +434,17 @@
 # name: TestPulse.test_out[Blocking]
   'PULSE 123 q "FRAMEX" WAVEFORMY'
 # ---
+# name: TestPulse.test_out[FlatWaveform]
+  'NONBLOCKING PULSE 123 q "FRAMEX" flat(duration: 2.5, iq: 1.0 + (2.0)*i)'
+# ---
 # name: TestPulse.test_out[NonBlocking]
   'NONBLOCKING PULSE 123 q "FRAMEX" WAVEFORMY'
 # ---
 # name: TestRawCapture.test_out[Blocking]
   'RAW-CAPTURE 123 q "FRAMEX" 0.5 ro[0]'
+# ---
+# name: TestRawCapture.test_out[FlatWaveform]
+  'NONBLOCKING RAW-CAPTURE 123 q "FRAMEX" 2.5 flat(duration: 2.5, iq: 1.0 + (2.0)*i)'
 # ---
 # name: TestRawCapture.test_out[NonBlocking]
   'NONBLOCKING RAW-CAPTURE 123 q "FRAMEX" 2.5 WAVEFORMY'

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -428,6 +428,12 @@
 # name: TestPragma.test_str[With-String]
   'PRAGMA INITIAL_REWIRING "GREEDY"'
 # ---
+# name: TestPulse.test_out[Blocking]
+  'PULSE 123 q "FRAMEX" WAVEFORMY'
+# ---
+# name: TestPulse.test_out[NonBlocking]
+  'NONBLOCKING PULSE 123 q "FRAMEX" WAVEFORMY'
+# ---
 # name: TestReset.test_out[FormalArgument]
   'RESET a'
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -444,10 +444,10 @@
   'RAW-CAPTURE 123 q "FRAMEX" 0.5 ro[0]'
 # ---
 # name: TestRawCapture.test_out[FlatWaveform]
-  'NONBLOCKING RAW-CAPTURE 123 q "FRAMEX" 2.5 flat(duration: 2.5, iq: 1.0 + (2.0)*i)'
+  'NONBLOCKING RAW-CAPTURE 123 q "FRAMEX" 2.5 ro[0]'
 # ---
 # name: TestRawCapture.test_out[NonBlocking]
-  'NONBLOCKING RAW-CAPTURE 123 q "FRAMEX" 2.5 WAVEFORMY'
+  'NONBLOCKING RAW-CAPTURE 123 q "FRAMEX" 2.5 ro[0]'
 # ---
 # name: TestReset.test_out[FormalArgument]
   'RESET a'

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -32,6 +32,7 @@ from pyquil.quilbase import (
     ParameterDesignator,
     Parameter,
     Pragma,
+    Pulse,
     QubitDesignator,
     Reset,
     ResetQubit,
@@ -810,3 +811,43 @@ class TestCapture:
         assert capture.nonblocking == nonblocking
         capture.nonblocking = not nonblocking
         assert capture.nonblocking == (not nonblocking)
+
+
+@pytest.mark.parametrize(
+    ("frame", "waveform", "nonblocking"),
+    [
+        (
+            Frame([Qubit(123), FormalArgument("q")], "FRAMEX"),
+            WaveformReference("WAVEFORMY"),
+            False,
+        ),
+        (
+            Frame([Qubit(123), FormalArgument("q")], "FRAMEX"),
+            WaveformReference("WAVEFORMY"),
+            True,
+        ),
+    ],
+    ids=("Blocking", "NonBlocking"),
+)
+class TestPulse:
+    @pytest.fixture
+    def pulse(self, frame: Frame, waveform: Waveform, nonblocking: bool):
+        return Pulse(frame, waveform, nonblocking)
+
+    def test_out(self, pulse: Pulse, snapshot: SnapshotAssertion):
+        assert pulse.out() == snapshot
+
+    def test_frame(self, pulse: Pulse, frame: Frame):
+        assert pulse.frame == frame
+        pulse.frame = Frame([Qubit(123)], "new-frame")
+        assert pulse.frame == Frame([Qubit(123)], "new-frame")
+
+    def test_waveform(self, pulse: Pulse, waveform: Waveform):
+        assert pulse.waveform == waveform
+        pulse.waveform = WaveformReference("new-waveform")
+        assert pulse.waveform == WaveformReference("new-waveform")
+
+    def test_nonblocking(self, pulse: Pulse, nonblocking: bool):
+        assert pulse.nonblocking == nonblocking
+        pulse.nonblocking = not nonblocking
+        assert pulse.nonblocking == (not nonblocking)

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -16,7 +16,6 @@ from pyquil.quilbase import (
     DefCircuit,
     DefFrame,
     DefGate,
-    DefMeasureCalibration,
     DefWaveform,
     DefPermutationGate,
     DefGateByPaulis,
@@ -40,7 +39,6 @@ from pyquil.quilbase import (
 )
 from pyquil.paulis import PauliSum, PauliTerm
 from pyquil.quilatom import BinaryExp, Mul, Frame, Qubit, Expression, Waveform, WaveformReference
-from pyquil.paulis import PauliSum, PauliTerm
 from pyquil.api._compiler import QPUCompiler
 from pyquil.quiltwaveforms import FlatWaveform
 

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -878,13 +878,13 @@ class TestPulse:
         (
             Frame([Qubit(123), FormalArgument("q")], "FRAMEX"),
             2.5,
-            WaveformReference("WAVEFORMY"),
+            MemoryReference("ro"),
             True,
         ),
         (
             Frame([Qubit(123), FormalArgument("q")], "FRAMEX"),
             2.5,
-            FlatWaveform(duration=2.5, iq=complex(1.0, 2.0)),
+            MemoryReference("ro"),
             True,
         ),
     ],

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -34,6 +34,7 @@ from pyquil.quilbase import (
     Pragma,
     Pulse,
     QubitDesignator,
+    RawCapture,
     Reset,
     ResetQubit,
 )
@@ -851,3 +852,50 @@ class TestPulse:
         assert pulse.nonblocking == nonblocking
         pulse.nonblocking = not nonblocking
         assert pulse.nonblocking == (not nonblocking)
+
+
+@pytest.mark.parametrize(
+    ("frame", "duration", "memory_region", "nonblocking"),
+    [
+        (
+            Frame([Qubit(123), FormalArgument("q")], "FRAMEX"),
+            0.5,
+            MemoryReference("ro"),
+            False,
+        ),
+        (
+            Frame([Qubit(123), FormalArgument("q")], "FRAMEX"),
+            2.5,
+            WaveformReference("WAVEFORMY"),
+            True,
+        ),
+    ],
+    ids=("Blocking", "NonBlocking"),
+)
+class TestRawCapture:
+    @pytest.fixture
+    def raw_capture(self, frame: Frame, duration: float, memory_region: MemoryReference, nonblocking: bool):
+        return RawCapture(frame, duration, memory_region, nonblocking)
+
+    def test_out(self, raw_capture: RawCapture, snapshot: SnapshotAssertion):
+        assert raw_capture.out() == snapshot
+
+    def test_frame(self, raw_capture: RawCapture, frame: Frame):
+        assert raw_capture.frame == frame
+        raw_capture.frame = Frame([Qubit(123)], "new-frame")
+        assert raw_capture.frame == Frame([Qubit(123)], "new-frame")
+
+    def test_duration(self, raw_capture: RawCapture, duration: float):
+        assert raw_capture.duration == duration
+        raw_capture.duration = 3.14
+        assert raw_capture.duration == 3.14
+
+    def test_memory_region(self, raw_capture: RawCapture, memory_region: MemoryReference):
+        assert raw_capture.memory_region == memory_region
+        raw_capture.memory_region = MemoryReference("new-memory-reference")
+        assert raw_capture.memory_region == MemoryReference("new-memory-reference")
+
+    def test_nonblocking(self, raw_capture: RawCapture, nonblocking: bool):
+        assert raw_capture.nonblocking == nonblocking
+        raw_capture.nonblocking = not nonblocking
+        assert raw_capture.nonblocking == (not nonblocking)

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -42,6 +42,7 @@ from pyquil.paulis import PauliSum, PauliTerm
 from pyquil.quilatom import BinaryExp, Mul, Frame, Qubit, Expression, Waveform, WaveformReference
 from pyquil.paulis import PauliSum, PauliTerm
 from pyquil.api._compiler import QPUCompiler
+from pyquil.quiltwaveforms import FlatWaveform
 
 
 @pytest.mark.parametrize(
@@ -782,8 +783,14 @@ class TestDefCircuit:
             MemoryReference("ro"),
             True,
         ),
+        (
+            Frame([Qubit(123), FormalArgument("q")], "FRAMEX"),
+            FlatWaveform(duration=2.5, iq=complex(1.0, 2.0)),
+            MemoryReference("ro"),
+            True,
+        ),
     ],
-    ids=("Blocking", "NonBlocking"),
+    ids=("Blocking", "NonBlocking", "TemplateWaveform"),
 )
 class TestCapture:
     @pytest.fixture
@@ -827,8 +834,13 @@ class TestCapture:
             WaveformReference("WAVEFORMY"),
             True,
         ),
+        (
+            Frame([Qubit(123), FormalArgument("q")], "FRAMEX"),
+            FlatWaveform(duration=2.5, iq=complex(1.0, 2.0)),
+            True,
+        ),
     ],
-    ids=("Blocking", "NonBlocking"),
+    ids=("Blocking", "NonBlocking", "FlatWaveform"),
 )
 class TestPulse:
     @pytest.fixture
@@ -869,8 +881,14 @@ class TestPulse:
             WaveformReference("WAVEFORMY"),
             True,
         ),
+        (
+            Frame([Qubit(123), FormalArgument("q")], "FRAMEX"),
+            2.5,
+            FlatWaveform(duration=2.5, iq=complex(1.0, 2.0)),
+            True,
+        ),
     ],
-    ids=("Blocking", "NonBlocking"),
+    ids=("Blocking", "NonBlocking", "FlatWaveform"),
 )
 class TestRawCapture:
     @pytest.fixture


### PR DESCRIPTION
Backs `Capture`, `RawCapture`, and `Pulse`, with their quil-rs counterparts.

Because these instructions take `WaveformReference` and `TemplateWaveform`, I also addressed the compatibility layer for those. For `TemplateWaveform`, this meant stripping it's `@dataclass` decorator, so it's technically a breaking change, but hopefully still backwards compatible for most use cases. Additionally, `TemplateWaveform` can now be more easily used as a waveform invocation using any set of parameters. 