### PR TITLE
feat: Add CHANNEL-DELAY attribute to DefFrame

### DIFF
--- a/pyquil/_parser/grammar.lark
+++ b/pyquil/_parser/grammar.lark
@@ -67,6 +67,7 @@ frame_spec : _NEWLINE_TAB frame_attr ":" ( expression | string )
             | "HARDWARE-OBJECT"
             | "CENTER-FREQUENCY"
             | "ENABLE-RAW-CAPTURE"
+            | "CHANNEL-DELAY"
 
 def_waveform : "DEFWAVEFORM" waveform_name params ":" matrix
 

--- a/pyquil/_parser/parser.py
+++ b/pyquil/_parser/parser.py
@@ -138,6 +138,7 @@ class QuilTransformer(Transformer):  # type: ignore
             "SAMPLE-RATE": "sample_rate",
             "CENTER-FREQUENCY": "center_frequency",
             "ENABLE-RAW-CAPTURE": "enable_raw_capture",
+            "CHANNEL-DELAY": "channel_delay",
         }
         options = {}
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1367,6 +1367,9 @@ class DefFrame(AbstractInstruction):
     enable_raw_capture: Optional[str] = None
     """ A flag signalling that raw capture is enabled for this frame. """
 
+    channel_delay: Optional[float] = None
+    """ The amount to delay this frame, to account for hardware signal offsets [seconds]. """
+
     def out(self) -> str:
         r = f"DEFFRAME {self.frame.out()}"
         options = [
@@ -1376,6 +1379,7 @@ class DefFrame(AbstractInstruction):
             (self.hardware_object, "HARDWARE-OBJECT"),
             (self.sample_rate, "SAMPLE-RATE"),
             (self.enable_raw_capture, "ENABLE-RAW-CAPTURE"),
+            (self.channel_delay, "CHANNEL-DELAY"),
         ]
         if any(value for (value, name) in options):
             r += ":"

--- a/test/unit/test_parser.py
+++ b/test/unit/test_parser.py
@@ -602,17 +602,25 @@ def test_parsing_defframe():
         'DEFFRAME 0 "rf":\n'
         '    SAMPLE-RATE: 2.0\n'
         '    INITIAL-FREQUENCY: 10\n'
-        '    ENABLE-RAW-CAPTURE: "true"',
+        '    ENABLE-RAW-CAPTURE: "true"\n'
+        '    CHANNEL-DELAY: 20e-9',
         DefFrame(
             Frame([Qubit(0)], "rf"),
             sample_rate=2.0,
             initial_frequency=10,
             enable_raw_capture="true",
+            channel_delay=20e-9,
         ),
     )
     assert DefFrame(
-        Frame([Qubit(0)], "rf"), enable_raw_capture="true"
-    ).out() == 'DEFFRAME 0 "rf":\n    ENABLE-RAW-CAPTURE: "true"\n'
+        Frame([Qubit(0)], "rf"),
+        enable_raw_capture="true",
+        channel_delay=12e-9,
+    ).out() == (
+        'DEFFRAME 0 "rf":\n'
+        '    ENABLE-RAW-CAPTURE: "true"\n'
+        '    CHANNEL-DELAY: 1.2e-08\n'
+    )
 
     with pytest.raises(UnexpectedToken) as excp:
         parse('DEFFRAME 0 "rf":\n' "    UNSUPPORTED: 2.0\n")


### PR DESCRIPTION
## Description

Add CHANNEL-DELAY attribute to DefFrame objects.

Closes #1565

## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
