### PR TITLE
fix!: Set `native_quil_metadata` on `Program` after compilation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1942,24 +1942,24 @@ py = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qcs-sdk-python"
-version = "0.6.0rc0"
+version = "0.6.0rc2"
 description = "Python interface for the QCS Rust SDK"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "qcs_sdk_python-0.6.0rc0-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:8cd9397ac82bb712e535b08cdecbfc492f59fdb26d44777047ca21d222c24e2c"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c51d70b2435d3a23b33d2360d9cef96b861b5bc8e493e827ab0cc86fd4222b7"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bccaa885dce026110a9917bb60e7ce18522460c15bb3ec322c2ce6f8b06fb86e"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:1a83ce61ca8dae811d743d37c3d3875bd74d323399bacf10dbefce1c5a53a438"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:193b4361729e9398624a06474fbc4ec71f123e3cc7f20b2dfe57e27b2a122680"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79e136a06fc94cf9dd8d45a2729c435f152fde7109e077b6684bcb468a37b904"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:2be8db731e02d22484537952643706c72dff82186fb0699ac7bbca10eb995ddf"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae5cc73f127b12e4159585b57602e95902fd4cf4c8f8fdc8d4b93b2b76d546ee"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3654639d76708d143ca37b5d9bb37915eefa7fe134d3e22f35f2cc52a0c4d2af"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:deeea9f204c37da177b0e8bb5a271d92c36a9be3b75dfbc9676d952e733e60f6"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d2e474346855d7447b3af0ccaf7c656ee20ffdd2ae2d4f110425f250a3f7090"},
-    {file = "qcs_sdk_python-0.6.0rc0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6014e580cdc33e3fdeb69862a1754cc06b37884b4101d1623385f9f628e03f92"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:8194656123f8d3a4b8f9b67d5bae5db6d9659dd99ea078e1c5839c092631f366"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b6a4e48f75115456bc71f367be5b422662642c2092e949d1e0dd66394278728"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dd7072afd4304b2bbcacebcd4467b490518d61488a32c794c08e12a13984492"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:d9a90f96d1a00bbfbbbd4cb52f083ce38c26a476b6038a83cb8990a48f22ca55"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:957cec626a5e429ff7c7f1779ae4121d564bfad92b03f83f7dba2636be865eae"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ffc6c8c7c99d570ccd879aa91c5aba31688c1675f1edc3725bc1a8060d2b0e7"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:a4460b43dc04c0cf5f08c3c816f7d7fa3b72d4e12956996806a2f04f78c0d19e"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:629a84d0f990a51749acfb2018bf076cd2f685198443bb38fa1dd8502901540e"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:128276c4043a392d02099fd1dee03a2c847f75ef8b68857fd066da1834453d5f"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:4bc50f793cb02edcb5cc471726fb7b487ae45e93a433df38ab4a1b1d64a1105d"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4185e3508460ee94f11100c76b7f08dda1754c64b4d993a5f17f01bd80675ec5"},
+    {file = "qcs_sdk_python-0.6.0rc2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcc748934f4db87807d2483f995f88939b053fa2cbac36b7949082a392afca3d"},
 ]
 
 [[package]]
@@ -2559,4 +2559,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<3.12"
-content-hash = "73a4d7a331a7e00270989022aa3317788d4171aadac765207395f6c18b0c18c8"
+content-hash = "efa81b8dcba4788078b9e52cf492303be3667f2b833bcde0e2bc83b7f1196621"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1942,24 +1942,24 @@ py = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qcs-sdk-python"
-version = "0.5.0rc20"
+version = "0.6.0rc0"
 description = "Python interface for the QCS Rust SDK"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "qcs_sdk_python-0.5.0rc20-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:7a71e27316c887bed8a736b1d223408cf5baff6967ce3db9238613aac112147d"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aedd416159ec57b013429621805b41e02e875f6f51095f7e88a77650c002384a"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3a2e3032deb95aca024535c24f933cb6ad6a9501ad59d95b1af01fd47479ce8"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:4cf6b20c3b1e984449db891ecb2d56b4149c3be9b873feeb3aa14f7bd494d629"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96e5e061a14cf2975273b93c246b8e56187e9cd291dcdef6d27db56b7dfd3bae"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a33b63e49ef1cddfd56f4f89ecad232931516d7630c383143ddf2f2a31096be"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:3da8ec54b8c10a62c4e656533c64d0b7596fa58e4b79afd05ee0dbd86a9390cc"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5319c60213762edf44881407af00f467e99106f6bb678ea4890f0d1a652ef1df"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4edd1da6bb48af5baf98a1b7c4f592c9506498338ce76e3389e3ccc43186982"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:b6fcc8b0d1afda5028c82c01c4b5169633a10f16f2064c2a4679de7bb8fc6b9d"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d709d28c35d5b66a87d4955a0d67bfbd1689ef7d3e9a6546b55a411f4da72c4a"},
-    {file = "qcs_sdk_python-0.5.0rc20-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:433735603803e26a335cef4614392daf18f830c2be7a2db2b488ec00126364b2"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:8cd9397ac82bb712e535b08cdecbfc492f59fdb26d44777047ca21d222c24e2c"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c51d70b2435d3a23b33d2360d9cef96b861b5bc8e493e827ab0cc86fd4222b7"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bccaa885dce026110a9917bb60e7ce18522460c15bb3ec322c2ce6f8b06fb86e"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp311-cp311-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:1a83ce61ca8dae811d743d37c3d3875bd74d323399bacf10dbefce1c5a53a438"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:193b4361729e9398624a06474fbc4ec71f123e3cc7f20b2dfe57e27b2a122680"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79e136a06fc94cf9dd8d45a2729c435f152fde7109e077b6684bcb468a37b904"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:2be8db731e02d22484537952643706c72dff82186fb0699ac7bbca10eb995ddf"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae5cc73f127b12e4159585b57602e95902fd4cf4c8f8fdc8d4b93b2b76d546ee"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3654639d76708d143ca37b5d9bb37915eefa7fe134d3e22f35f2cc52a0c4d2af"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:deeea9f204c37da177b0e8bb5a271d92c36a9be3b75dfbc9676d952e733e60f6"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d2e474346855d7447b3af0ccaf7c656ee20ffdd2ae2d4f110425f250a3f7090"},
+    {file = "qcs_sdk_python-0.6.0rc0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6014e580cdc33e3fdeb69862a1754cc06b37884b4101d1623385f9f628e03f92"},
 ]
 
 [[package]]
@@ -2559,4 +2559,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<3.12"
-content-hash = "e3fa5733532e61aa1d7be9c86bfcf10dccf7a38854b3fb192a5a3c2437002b90"
+content-hash = "73a4d7a331a7e00270989022aa3317788d4171aadac765207395f6c18b0c18c8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ rpcq = "^3.10.0"
 pydantic = "^1.10.7"
 networkx = "^2.5"
 importlib-metadata = { version = ">=3.7.3,<5", python = "<3.8" }
-qcs-sdk-python = "0.6.0rc.0"
+qcs-sdk-python = "0.6.0rc.2"
 retry = "^0.9.2"
 types-python-dateutil = "^2.8.19"
 types-retry = "^0.9.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ rpcq = "^3.10.0"
 pydantic = "^1.10.7"
 networkx = "^2.5"
 importlib-metadata = { version = ">=3.7.3,<5", python = "<3.8" }
-qcs-sdk-python = "0.5.0rc.20"
+qcs-sdk-python = "0.6.0rc.0"
 retry = "^0.9.2"
 types-python-dateutil = "^2.8.19"
 types-retry = "^0.9.9"

--- a/pyquil/api/_abstract_compiler.py
+++ b/pyquil/api/_abstract_compiler.py
@@ -123,18 +123,19 @@ class AbstractCompiler(ABC):
         target_device_json = json.dumps(compiler_isa_to_target_quantum_processor(compiler_isa).asdict())  # type: ignore
         target_device = TargetDevice.from_json(target_device_json)
 
-        native_quil = compile_program(
+        result = compile_program(
             quil=program.out(calibrations=False),
             target=target_device,
             client=self._client_configuration,
             options=CompilerOpts(protoquil=protoquil, timeout=self._compiler_client.timeout),
         )
 
-        native_program = Program(native_quil)
+        native_program = Program(result.program)
         native_program.num_shots = program.num_shots
         native_program._calibrations = program._calibrations
         native_program._waveforms = program._waveforms
         native_program._memory = program._memory.copy()
+        native_program.native_quil_metadata = result.native_quil_metadata
 
         return native_program
 

--- a/pyquil/api/_compiler_client.py
+++ b/pyquil/api/_compiler_client.py
@@ -29,6 +29,7 @@ from qcs_sdk.compiler.quilc import (
     ConjugatePauliByCliffordResponse,
     RandomizedBenchmarkingRequest,
     GenerateRandomizedBenchmarkingSequenceResponse,
+    NativeQuilMetadata,
 )
 from rpcq.messages import TargetDevice as TargetQuantumProcessor
 
@@ -92,7 +93,7 @@ class CompileToNativeQuilResponse:
     native_program: str
     """Native Quil program."""
 
-    metadata: Optional[NativeQuilMetadataResponse]
+    metadata: Optional[NativeQuilMetadata]
     """Metadata for the returned Native Quil."""
 
 
@@ -137,13 +138,13 @@ class CompilerClient:
         target_device_json = json.dumps(request.target_quantum_processor.asdict())  # type: ignore
         target_device = TargetDevice.from_json(target_device_json)
 
-        native_program = compile_program(
+        result = compile_program(
             quil=request.program,
             target=target_device,
             client=self._client_configuration,
             options=CompilerOpts(protoquil=request.protoquil, timeout=self.timeout),
         )
-        return CompileToNativeQuilResponse(native_program=native_program, metadata=None)
+        return CompileToNativeQuilResponse(native_program=result.program, metadata=result.native_quil_metadata)
 
     def conjugate_pauli_by_clifford(self, request: ConjugateByCliffordRequest) -> ConjugatePauliByCliffordResponse:
         """

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -39,6 +39,7 @@ from rpcq.messages import ParameterAref
 
 from qcs_sdk import QCSClient
 from qcs_sdk.qpu import list_quantum_processors
+from qcs_sdk.qpu.client import LoadClientError
 
 from pyquil.api._abstract_compiler import AbstractCompiler, QuantumExecutable
 from pyquil.api._compiler import QPUCompiler, QVMCompiler
@@ -796,7 +797,11 @@ def get_qc(
     .. _QCS API Docs: https://docs.api.qcs.rigetti.com/#tag/endpoints
     """
 
-    client_configuration = client_configuration or QCSClient.load()
+    if client_configuration is None:
+        try:
+            client_configuration = QCSClient.load()
+        except LoadClientError:
+            client_configuration = QCSClient()
 
     # 1. Parse name, check for redundant options, canonicalize names.
     prefix, qvm_type, noisy = _parse_name(name, as_qvm, noisy)

--- a/pyquil/api/_quantum_computer.py
+++ b/pyquil/api/_quantum_computer.py
@@ -14,6 +14,7 @@
 #    limitations under the License.
 ##############################################################################
 import itertools
+import logging
 import re
 import socket
 import subprocess
@@ -801,6 +802,7 @@ def get_qc(
         try:
             client_configuration = QCSClient.load()
         except LoadClientError:
+            logging.getLogger().info("No QCS client configuration found, only generic QVMs will be accessible.")
             client_configuration = QCSClient()
 
     # 1. Parse name, check for redundant options, canonicalize names.

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -36,8 +36,12 @@ from typing import (
     no_type_check,
 )
 
+from copy import deepcopy
+
 import numpy as np
-from rpcq.messages import NativeQuilMetadata, ParameterAref
+from rpcq.messages import ParameterAref
+
+from qcs_sdk.compiler.quilc import NativeQuilMetadata
 
 from pyquil._parser.parser import run_parser
 from pyquil._memory import Memory
@@ -191,8 +195,7 @@ class Program:
         new_prog._defined_gates = self._defined_gates.copy()
         new_prog._frames = self.frames.copy()
         if self.native_quil_metadata is not None:
-            # TODO: remove this type: ignore once rpcq._base.Message gets type hints.
-            new_prog.native_quil_metadata = self.native_quil_metadata.copy()  # type: ignore
+            new_prog.native_quil_metadata = deepcopy(self.native_quil_metadata)
         new_prog.num_shots = self.num_shots
         new_prog._memory = self._memory.copy()
         return new_prog

--- a/test/unit/test_compiler_client.py
+++ b/test/unit/test_compiler_client.py
@@ -14,8 +14,6 @@
 #    limitations under the License.
 ##############################################################################
 
-from test.unit.utils import patch_rpcq_client
-
 try:
     from unittest.mock import AsyncMock
 except ImportError:  # 3.7 requires this backport of AsyncMock
@@ -30,7 +28,6 @@ from pytest_mock import MockerFixture
 from pyquil.api._compiler_client import (
     CompilerClient,
     CompileToNativeQuilRequest,
-    CompileToNativeQuilResponse,
 )
 from pyquil.external.rpcq import CompilerISA, compiler_isa_to_target_quantum_processor
 
@@ -82,7 +79,7 @@ def test_compile_to_native_quil__returns_native_quil(
         protoquil=True,
     )
 
-    assert compiler_client.compile_to_native_quil(request) == CompileToNativeQuilResponse(
-        native_program="DECLARE ro BIT[1]\n",
-        metadata=None,
-    )
+    response = compiler_client.compile_to_native_quil(request)
+
+    assert response.native_program == "DECLARE ro BIT[1]\n"
+    assert response.metadata is not None


### PR DESCRIPTION
In v3, the `native_quil_metadata` field on a `Program` was by set when compiling program to native Quil. `qcs-sdk-python` never returned this metadata, so this functionality has been missing in v4.

The [latest release](https://github.com/rigetti/qcs-sdk-rust/pull/291) of `qcs-sdk-python` returns `native_quil_metadata` from `compile_program`. This PR uses that and sets `native_quil_metadata` on the `Program`, just like in v3. I'm marking this as a breaking change, as the class v3 used has been replaced with the `qcs-sdk-python` counterpart. The fields are the same, but it is no longer a dataclass. 