### PR TITLE
Loosen `networkx` requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ numpy = "^1.21"
 scipy = "^1.6.1"
 lark = "^0.11.1"
 rpcq = "^3.10.0"
-networkx = "^2.5"
+networkx = ">=2.5"
 importlib-metadata = { version = ">=3.7.3,<5", python = "<3.8" }
 qcs-api-client = ">=0.21.0,<0.22.0"
 types-python-dateutil = "^2.8.19"


### PR DESCRIPTION
## Description
Fixes https://github.com/rigetti/pyquil/issues/1553

## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
