### PR TITLE
V4- fix: Strip calibrations from QVM requests

### DIFF
--- a/pyquil/api/_qvm.py
+++ b/pyquil/api/_qvm.py
@@ -136,7 +136,7 @@ http://pyquil.readthedocs.io/en/latest/noise_models.html#support-for-noisy-gates
             executable = apply_noise_model(executable, self.noise_model)
 
         result = qvm.run(
-            executable.out(),
+            executable.out(calibrations=False),
             trials,
             addresses,
             memory_map or {},

--- a/pyquil/api/_wavefunction_simulator.py
+++ b/pyquil/api/_wavefunction_simulator.py
@@ -91,7 +91,7 @@ class WavefunctionSimulator:
             quil_program = self.augment_program_with_memory_values(quil_program, memory_map)
 
         request = qvm.api.WavefunctionRequest(
-            quil_program.out(),
+            quil_program.out(calibrations=False),
             self.measurement_noise,
             self.gate_noise,
             self.random_seed,


### PR DESCRIPTION
## Description

This restores things to how they were in v3 - calibrations aren't included in programs sent to the QVM.
