### PR TITLE
V4 fix: `copy_everything_but_instructions` now correctly copies `DECLARE` statements

### DIFF
--- a/pyquil/api/_rewrite_arithmetic.py
+++ b/pyquil/api/_rewrite_arithmetic.py
@@ -138,7 +138,7 @@ def rewrite_arithmetic(prog: Program) -> RewriteArithmeticResponse:
                 # so we divide by 8...
                 expr = str(Div(inst.scale, 8))
                 updated.inst(SetScale(inst.frame, expr_mref(expr)))
-        else:
+        elif not isinstance(inst, Declare):
             updated.inst(inst)
 
     if mref_idx > 0:

--- a/pyquil/api/_rewrite_arithmetic.py
+++ b/pyquil/api/_rewrite_arithmetic.py
@@ -138,6 +138,7 @@ def rewrite_arithmetic(prog: Program) -> RewriteArithmeticResponse:
                 # so we divide by 8...
                 expr = str(Div(inst.scale, 8))
                 updated.inst(SetScale(inst.frame, expr_mref(expr)))
+        # Program.copy_everything_except_instructions persists DECLARE statements
         elif not isinstance(inst, Declare):
             updated.inst(inst)
 

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -183,7 +183,7 @@ class Program:
         """
         new_prog = Program()
         new_prog._calibrations = self.calibrations.copy()
-        for _, declaration in self.declarations.items():
+        for declaration in self.declarations.values():
             new_prog.inst(declaration)
         new_prog._declarations = self._declarations.copy()
         new_prog._waveforms = self.waveforms.copy()

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -183,6 +183,8 @@ class Program:
         """
         new_prog = Program()
         new_prog._calibrations = self.calibrations.copy()
+        for _, declaration in self.declarations.items():
+            new_prog.inst(declaration)
         new_prog._declarations = self._declarations.copy()
         new_prog._waveforms = self.waveforms.copy()
         new_prog._defined_gates = self._defined_gates.copy()

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -832,6 +832,26 @@ def test_qc_expectation_on_qvm(client_configuration: QCSClient, dummy_compiler: 
     assert results[2][0].total_counts == 20000
 
 
+def test_undeclared_memory_region(client_configuration: QCSClient, dummy_compiler: DummyCompiler):
+    """
+    Fix for https://github.com/rigetti/pyquil/issues/1596
+    """
+    program = Program(
+        """
+DECLARE beta REAL[1]
+RZ(0.5) 0
+CPHASE(pi) 0 1
+DECLARE ro BIT[2]
+MEASURE 0 ro[0]
+MEASURE 1 ro[1]
+"""
+    )
+    program = program.copy_everything_except_instructions()
+    qc = QuantumComputer(name="testy!", qam=QVM(client_configuration=client_configuration), compiler=dummy_compiler)
+    executable = qc.compiler.native_quil_to_executable(program)
+    qc.run(executable)
+
+
 @pytest.mark.skip  # qcs_sdk client profiles do not support group accounts
 @respx.mock
 def test_get_qc_with_group_account(client_configuration: QCSClient, qcs_aspen8_isa: InstructionSetArchitecture):


### PR DESCRIPTION
## Description

Closes #1596 by copying `DECLARE` instructions along with the declarations mapping in `Program.copy_everything_except_instructions()`