### PR TITLE
Fix ryy gate definition

### DIFF
--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -984,10 +984,10 @@ def exponentiate_pauli_sum(
         assert isinstance(coeff, Number)
         qubit_paulis = {qubit: pauli for qubit, pauli in term.operations_as_set()}
         paulis = [qubit_paulis[q] if q in qubit_paulis else "I" for q in qubits]
-        matrix = float(np.real(coeff)) * reduce(np.kron, [pauli_matrices[p] for p in paulis]) # type: ignore
+        matrix = float(np.real(coeff)) * reduce(np.kron, [pauli_matrices[p] for p in paulis])  # type: ignore
         matrices.append(matrix)
     generated_unitary = expm(-1j * np.pi * sum(matrices))
-    phase = np.exp(-1j*np.angle(generated_unitary[0, 0])) # type: ignore
+    phase = np.exp(-1j * np.angle(generated_unitary[0, 0]))  # type: ignore
     return np.asarray(phase * generated_unitary, dtype=np.complex_)
 
 

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -295,7 +295,7 @@ class PauliTerm(object):
                 new_term = new_term._multiply_factor(op, index)
 
             return term_with_coeff(new_term, new_term.coefficient * new_coeff)
-        return term_with_coeff(self, self.coefficient * complex(term))
+        return term_with_coeff(self, self.coefficient * term)
 
     def __rmul__(self, other: ExpressionDesignator) -> "PauliTerm":
         """Multiplies this PauliTerm with another object, probably a number.
@@ -935,7 +935,7 @@ def exponentiate_commuting_pauli_sum(
 def exponentiate_pauli_sum(
     pauli_sum: PauliSum,
 ) -> np.ndarray:
-    """
+    r"""
     Exponentiates a sequence of PauliTerms, which may or may not commute. The Pauliterms must
     have fixed (non-parametric) coefficients. The coefficients are interpreted in cycles
     rather than radians or degrees.
@@ -972,11 +972,15 @@ def exponentiate_pauli_sum(
         "I": np.array([[1.0, 0.0], [0.0, 1.0]]),
     }
 
-    qubits = sorted(pauli_sum.get_qubits())
+    qubits = pauli_sum.get_qubits()
+    for q in qubits:
+        assert isinstance(q, int)
+    qubits.sort()
 
     matrices = []
     for term in pauli_sum.terms:
         coeff = term.coefficient
+        assert isinstance(coeff, (int, float, complex))
         qubit_paulis = {qubit: pauli for qubit, pauli in term.operations_as_set()}
         paulis = [qubit_paulis[q] if q in qubit_paulis else "I" for q in qubits]
         matrix = float(np.real(coeff)) * reduce(np.kron, [pauli_matrices[p] for p in paulis])

--- a/pyquil/paulis.py
+++ b/pyquil/paulis.py
@@ -36,6 +36,8 @@ from typing import (
     Union,
     cast,
 )
+from functools import reduce
+from scipy.linalg import expm
 
 from pyquil.quilatom import (
     QubitPlaceholder,
@@ -293,7 +295,7 @@ class PauliTerm(object):
                 new_term = new_term._multiply_factor(op, index)
 
             return term_with_coeff(new_term, new_term.coefficient * new_coeff)
-        return term_with_coeff(self, self.coefficient * term)
+        return term_with_coeff(self, self.coefficient * complex(term))
 
     def __rmul__(self, other: ExpressionDesignator) -> "PauliTerm":
         """Multiplies this PauliTerm with another object, probably a number.
@@ -840,7 +842,6 @@ def commuting_sets(pauli_terms: PauliSum) -> List[List[PauliTerm]]:
         isAssigned_bool = False
         for p in range(m_s):  # check if it commutes with each group
             if isAssigned_bool is False:
-
                 if check_commutation(groups[p], pauli_terms.terms[j]):
                     isAssigned_bool = True
                     groups[p].append(pauli_terms.terms[j])
@@ -929,6 +930,59 @@ def exponentiate_commuting_pauli_sum(
         return Program([f(param) for f in fns])
 
     return combined_exp_wrap
+
+
+def exponentiate_pauli_sum(
+    pauli_sum: PauliSum,
+) -> np.ndarray:
+    """
+    Exponentiates a sequence of PauliTerms, which may or may not commute. The Pauliterms must
+    have fixed (non-parametric) coefficients. The coefficients are interpreted in cycles
+    rather than radians or degrees.
+
+    e^{-i\pi\sum_i \theta_i P_i}
+
+    Thus, 1.0 corresponds to one full rotation.
+
+    To produce a CZ gate:
+
+    >>> phi = pi
+    >>> coeff = phi/(-4*pi) # -0.25
+    >>> hamiltonian = PauliTerm("Z", 0) * PauliTerm("Z", 1) - 1*PauliTerm("Z", 0) - 1*PauliTerm("Z", 1)
+    >>> exponentiate_pauli_sum(coeff*hamiltonian)
+
+    To produce the Quil XY(theta) gate, you can use:
+
+    >>> coeff = theta/(-4*pi)
+    >>> hamiltonian = PauliTerm("X", 0) * PauliTerm("X", 1) + PauliTerm("Y", 0) * PauliTerm("Y", 1)
+    >>> exponentiate_pauli_sum(coeff*hamiltonian)
+
+    A global phase is applied to the unitary such that the [0,0] element is always real.
+
+    :param pauli_sum: PauliSum to exponentiate.
+    :returns: The matrix exponetial of the PauliSum
+    """
+    if isinstance(pauli_sum, PauliTerm):
+        pauli_sum = PauliSum([pauli_sum])
+
+    pauli_matrices = {
+        "X": np.array([[0.0, 1.0], [1.0, 0.0]]),
+        "Y": np.array([[0.0, 0.0 - 1.0j], [0.0 + 1.0j, 0.0]]),
+        "Z": np.array([[1.0, 0.0], [0.0, -1.0]]),
+        "I": np.array([[1.0, 0.0], [0.0, 1.0]]),
+    }
+
+    qubits = sorted(pauli_sum.get_qubits())
+
+    matrices = []
+    for term in pauli_sum.terms:
+        coeff = term.coefficient
+        qubit_paulis = {qubit: pauli for qubit, pauli in term.operations_as_set()}
+        paulis = [qubit_paulis[q] if q in qubit_paulis else "I" for q in qubits]
+        matrix = float(np.real(coeff)) * reduce(np.kron, [pauli_matrices[p] for p in paulis])
+        matrices.append(matrix)
+    generated_unitary = expm(-1j * np.pi * sum(matrices))
+    return np.exp(-1j * np.angle(generated_unitary[0, 0])) * generated_unitary
 
 
 def _exponentiate_general_case(pauli_term: PauliTerm, param: float) -> Program:

--- a/pyquil/simulation/matrices.py
+++ b/pyquil/simulation/matrices.py
@@ -94,6 +94,16 @@ Currently includes:
     PHASEDFSIM(:math:`\theta, \zeta, \chi, \gamma, \phi`) - XX+YY interaction with conditonal phase on \|11\>
     :math:`\begin{pmatrix} 1&0&0&0 \\ 0&\ e^{-i(\gamma+\zeta)}\cos(\frac{\theta}{2})&ie^{-i(\gamma-\chi)}\sin(\frac{\theta}{2})&0 \\ 0&ie^{-i(\gamma+\chi)}\sin(\frac{\theta}{2})&e^{-i(\gamma-\zeta)}\cos(\frac{\theta}{2})&0 \\  0&0&0&e^{ i\phi - 2i\gamma} \end{pmatrix}`
 
+    RXX(:math:`\phi`) - XX-interaction
+    :math:`\begin{pmatrix} \cos(\phi/2)&0&0&-i\sin(\phi/2) \\ 0&\cos(\phi/2)&-i\sin(\phi/2)&0 \\ 0&-i\sin(\phi/2)&\cos(\phi/2)&0 \\  -i\sin(\phi/2)&0&0&cos(\phi/2) \end{pmatrix}`
+
+    RYY(:math:`\phi`) - YY-interaction
+    :math:`\begin{pmatrix} \cos(\phi/2)&0&0&i\sin(\phi/2) \\ 0&\cos(\phi/2)&-i\sin(\phi/2)&0 \\ 0&-i\sin(\phi/2)&\cos(\phi/2)&0 \\  i\sin(\phi/2)&0&0&cos(\phi/2) \end{pmatrix}`
+
+    RZZ(:math:`\phi`) - ZZ-interaction
+    :math:`\begin{pmatrix} 1&0&0&0 \\ 0&\cos(\phi/2)&-i\sin(\phi/2)&0 \\ 0&-i\sin(\phi/2)&\cos(\phi/2)&0 \\  0&0&0&1 \end{pmatrix}`
+
+
 Specialized gates / internal utility gates:
     BARENCO(:math:`\alpha, \phi, \theta`) - Barenco gate
     :math:`\begin{pmatrix} 1&0&0&0 \\ 0&1&0&0 \\ 0&0&e^{i\phi} \cos\theta & -i e^{i(\alpha-\phi)} \sin\theta \\ 0&0&-i e^{i(\alpha+\phi)} \sin\theta & e^{i\alpha} \cos\theta \end{pmatrix}`
@@ -278,10 +288,10 @@ def RXX(phi: float) -> np.ndarray:
 def RYY(phi: float) -> np.ndarray:
     return np.array(
         [
-            [np.cos(phi / 2), 0, 0, -1j * np.sin(phi / 2)],
-            [0, np.cos(phi / 2), +1j * np.sin(phi / 2), 0],
-            [0, +1j * np.sin(phi / 2), np.cos(phi / 2), 0],
-            [-1j * np.sin(phi / 2), 0, 0, np.cos(phi / 2)],
+            [np.cos(phi / 2), 0, 0, +1j * np.sin(phi / 2)],
+            [0, np.cos(phi / 2), -1j * np.sin(phi / 2), 0],
+            [0, -1j * np.sin(phi / 2), np.cos(phi / 2), 0],
+            [+1j * np.sin(phi / 2), 0, 0, np.cos(phi / 2)],
         ]
     )
 

--- a/pyquil/simulation/tools.py
+++ b/pyquil/simulation/tools.py
@@ -446,8 +446,9 @@ def scale_out_phase(unitary1: np.ndarray, unitary2: np.ndarray) -> np.ndarray:
 
     return rescale_value * unitary1
 
-def unitary_equal(A: np.ndarray, B: np.ndarray) -> np.bool_:
+
+def unitary_equal(A: np.ndarray, B: np.ndarray) -> bool:
     """Check if two matrices are unitarily equal."""
     assert A.shape == B.shape
     dim = A.shape[0]
-    return np.isclose(np.abs(np.trace(A.T.conjugate() @ B) / dim), 1.0)
+    return np.allclose(np.abs(np.trace(A.T.conjugate() @ B) / dim), 1.0)

--- a/pyquil/simulation/tools.py
+++ b/pyquil/simulation/tools.py
@@ -445,3 +445,9 @@ def scale_out_phase(unitary1: np.ndarray, unitary2: np.ndarray) -> np.ndarray:
             rescale_value = unitary2[j, 0] / unitary1[j, 0]
 
     return rescale_value * unitary1
+
+def unitary_equal(A: np.ndarray, B: np.ndarray) -> np.bool_:
+    """Check if two matrices are unitarily equal."""
+    assert A.shape == B.shape
+    dim = A.shape[0]
+    return np.isclose(np.abs(np.trace(A.T.conjugate() @ B) / dim), 1.0)


### PR DESCRIPTION
## Description

- Fixes the RYY gate definition #1602 [auto-close]
- Addes a new function in pyquil.paulis called `exponentiate_pauli_sum`. This function performs exponentiation of non-commuting PauliSums, but only for PauliSum with numeric values. The return is a unitary.
- Tests that `exponentiate_pauli_sum` produces the quil gates.


## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
