### PR TITLE
V4 - fix: `packaging` is now specified as a dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2715,4 +2715,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<4.0"
-content-hash = "06793de2d406b1a45ed9ce81a180581b6b9edfe7330d804c31c4cf70794f0828"
+content-hash = "9faab14460d48639b5fe38eefe20584355d756baeb4b466e6d0b5c5885ae2903"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2715,4 +2715,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<4.0"
-content-hash = "43e8ddaeb37fb051acf9e00e0a754918cb022aab9a7db84f50662b9a5b0ae1a9"
+content-hash = "06793de2d406b1a45ed9ce81a180581b6b9edfe7330d804c31c4cf70794f0828"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ qcs-sdk-python = "0.9.0"
 tenacity = "^8.2.2"
 types-python-dateutil = "^2.8.19"
 types-retry = "^0.9.9"
+packaging = "23.1"
 
 # latex extra
 ipython = { version = "^7.21.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ qcs-sdk-python = "0.9.0"
 tenacity = "^8.2.2"
 types-python-dateutil = "^2.8.19"
 types-retry = "^0.9.9"
-packaging = "23.1"
+packaging = "^23.1"
 
 # latex extra
 ipython = { version = "^7.21.0", optional = true }


### PR DESCRIPTION
closes #1607 

I based the version specified on the one that existed in `pyproject.lock`