### PR TITLE
1611 Regression fix for `Program.copy_everything_except_instructions()`

### DIFF
--- a/pyquil/api/_rewrite_arithmetic.py
+++ b/pyquil/api/_rewrite_arithmetic.py
@@ -138,8 +138,7 @@ def rewrite_arithmetic(prog: Program) -> RewriteArithmeticResponse:
                 # so we divide by 8...
                 expr = str(Div(inst.scale, 8))
                 updated.inst(SetScale(inst.frame, expr_mref(expr)))
-        # Program.copy_everything_except_instructions persists DECLARE statements
-        elif not isinstance(inst, Declare):
+        else:
             updated.inst(inst)
 
     if mref_idx > 0:

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -200,8 +200,9 @@ class Program:
 
         :return: a new Program
         """
-        new_prog = self.copy_everything_except_instructions()
+        new_prog = self.copy_everything_except_instructions()  # and declarations, which is a view
         new_prog._instructions = self._instructions.copy()
+        new_prog._declarations = self._declarations.copy()
         return new_prog
 
     @property

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -183,7 +183,6 @@ class Program:
         """
         new_prog = Program()
         new_prog._calibrations = self.calibrations.copy()
-        new_prog._declarations = self._declarations.copy()
         new_prog._waveforms = self.waveforms.copy()
         new_prog._defined_gates = self._defined_gates.copy()
         new_prog._frames = self.frames.copy()

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -183,8 +183,6 @@ class Program:
         """
         new_prog = Program()
         new_prog._calibrations = self.calibrations.copy()
-        for declaration in self.declarations.values():
-            new_prog.inst(declaration)
         new_prog._declarations = self._declarations.copy()
         new_prog._waveforms = self.waveforms.copy()
         new_prog._defined_gates = self._defined_gates.copy()

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -834,7 +834,7 @@ def test_qc_expectation_on_qvm(client_configuration: QCSClient, dummy_compiler: 
 
 def test_undeclared_memory_region(client_configuration: QCSClient, dummy_compiler: DummyCompiler):
     """
-    Fix for https://github.com/rigetti/pyquil/issues/1596
+    Test for https://github.com/rigetti/pyquil/issues/1596
     """
     program = Program(
         """
@@ -847,6 +847,8 @@ MEASURE 1 ro[1]
 """
     )
     program = program.copy_everything_except_instructions()
+    assert len(program.instructions) == 0  # the purpose of copy_everything_except_instructions()
+    assert len(program.declarations) == 0  # this is a view on the instructions member; must be consistent
     qc = QuantumComputer(name="testy!", qam=QVM(client_configuration=client_configuration), compiler=dummy_compiler)
     executable = qc.compiler.native_quil_to_executable(program)
     qc.run(executable)


### PR DESCRIPTION
## Description

Closes #1611 

Refer to the analysis in #1611 for a description of the issue and suggested solution.

The short version is that `Program.declarations` is intended as a view of `Program.instructions`, and should not have been copied in v3. This fix should be back-ported to v3. This MR reverts the earlier changes to resolve the inconsistency the other way; it made the test added in RC23 fail, but then the new approach (don't copy `_declarations`!) also fixed the issue and does not regress in terms of the expectation that `instructions` be empty after `copy_everything_except_instructions()`.

## Checklist

- [ ] The PR targets the `master` branch. {NO- this targets `v4`)
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
