### PR TITLE
1613 Program declarations should be empty after copy

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -186,7 +186,6 @@ class Program:
         """
         new_prog = Program()
         new_prog._calibrations = self.calibrations.copy()
-        new_prog._declarations = self._declarations.copy()
         new_prog._waveforms = self.waveforms.copy()
         new_prog._defined_gates = self._defined_gates.copy()
         new_prog._frames = self.frames.copy()

--- a/test/unit/test_quantum_computer.py
+++ b/test/unit/test_quantum_computer.py
@@ -838,28 +838,6 @@ def test_qc_expectation_on_qvm(client_configuration: QCSClientConfiguration, dum
     assert results[2][0].total_counts == 20000
 
 
-def test_undeclared_memory_region(client_configuration: QCSClientConfiguration, dummy_compiler: DummyCompiler):
-    """
-    Test for https://github.com/rigetti/pyquil/issues/1613
-    """
-    program = Program(
-        """
-DECLARE beta REAL[1]
-RZ(0.5) 0
-CPHASE(pi) 0 1
-DECLARE ro BIT[2]
-MEASURE 0 ro[0]
-MEASURE 1 ro[1]
-"""
-    )
-    program = program.copy_everything_except_instructions()
-    assert len(program.instructions) == 0  # the purpose of copy_everything_except_instructions()
-    assert len(program.declarations) == 0  # this is a view on the instructions member; must be consistent
-    qc = QuantumComputer(name="testy!", qam=QVM(client_configuration=client_configuration), compiler=dummy_compiler)
-    executable = qc.compiler.native_quil_to_executable(program)
-    qc.run(executable)
-
-
 @respx.mock
 def test_get_qc_endpoint_id(client_configuration: QCSClientConfiguration, qcs_aspen8_isa: InstructionSetArchitecture):
     """

--- a/test/unit/test_quil.py
+++ b/test/unit/test_quil.py
@@ -1409,3 +1409,20 @@ def test_params_pi_and_precedence():
     prog = Program(f"RX({more_less_trivial_pi}) 0")
     exp = str(prog[0].params[0])
     assert _eval_as_np_pi(more_less_trivial_pi) == _eval_as_np_pi(exp)
+
+
+def test_copy_everything_except_instructions():
+    """Test for https://github.com/rigetti/pyquil/issues/1613"""
+    program = Program(
+        """
+DECLARE beta REAL[1]
+RZ(0.5) 0
+CPHASE(pi) 0 1
+DECLARE ro BIT[2]
+MEASURE 0 ro[0]
+MEASURE 1 ro[1]
+"""
+    )
+    program = program.copy_everything_except_instructions()
+    assert len(program.instructions) == 0  # the purpose of copy_everything_except_instructions()
+    assert len(program.declarations) == 0  # this is a view on the instructions member; must be consistent


### PR DESCRIPTION
## Description

Closes #1613 

Back-ported the single-line fix from the v4 branch, so we no longer copy `declarations` member. Made a new test for `Program.copy_everything_except_instructions()` which was lacking; based this on the v4 test.

## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
