### PR TITLE
V4 - fix: Getting a QuantumComputer based on a generic QVM will no longer hang if quilc isn't running

### DIFF
--- a/pyquil/api/_abstract_compiler.py
+++ b/pyquil/api/_abstract_compiler.py
@@ -89,8 +89,6 @@ class AbstractCompiler(ABC):
             request_timeout=timeout,
         )
 
-        self._connect()
-
     def get_version_info(self) -> Dict[str, Any]:
         """
         Return version information for this compiler and its dependencies.
@@ -103,6 +101,7 @@ class AbstractCompiler(ABC):
         """
         Convert a Quil program into native Quil, which is supported for execution on a QPU.
         """
+        self._connect()
 
         # convert the pyquil ``TargetDevice`` to the qcs_sdk ``TargetDevice``
         compiler_isa = self.quantum_processor.to_compiler_isa()


### PR DESCRIPTION
The `_connect` call got moved up into the initializer, leading to the hang when calling `get_qc` without quilc running. Moved it back into `quil_to_native_quil` where it used to be.