### PR TITLE
Mcm measurement buffers

### DIFF
--- a/pyquil/api/_qpu.py
+++ b/pyquil/api/_qpu.py
@@ -58,15 +58,7 @@ def _extract_memory_regions(
     ro_sources: Dict[MemoryReference, str],
     buffers: Dict[str, np.ndarray],
 ) -> Dict[str, np.ndarray]:
-    # hack to extract num_shots indirectly from the shape of the returned data
-    (first_key, first), *rest = buffers.items()
-    # the number of shots is the shape divided by how many times the first
-    # appears in ro_sources
-    num_lanes = sum((first_key == val for val in ro_sources.values()))
-    num_shots = first.shape[0] // num_lanes
-    # num_shots = 1000
-
-    def alloc(spec: ParameterSpec) -> np.ndarray:
+    def alloc(spec: ParameterSpec, num_shots: int) -> np.ndarray:
         dtype = {
             "BIT": np.int64,
             "INTEGER": np.int64,
@@ -83,17 +75,24 @@ def _extract_memory_regions(
     # filter out the ro_sources and initialize regions
     sources = {mem_desc: defaultdict(list) for mem_desc in memory_descriptors}
     for mref, key in ro_sources.items():
-        # Translation sometimes introduces ro_sources that the user didn't ask for.
-        # That's fine, we just ignore them.
+        # Translation sometimes introduces ro_sources that the user didn't
+        # ask for. That's fine, we just ignore them.
         if mref.name not in sources:
             continue
         sources[mref.name][key].append(mref)
-        if mref.name not in regions:
-            regions[mref.name] = alloc(memory_descriptors[mref.name])
 
-    for reg_name, buffer_desc in sources.items():
-        region_width = memory_descriptors[reg_name].length
-        for key, mref_list in buffer_desc.items():
+    # hack to extract the number of shots
+    # the number of shots is the length of the buffer
+    # divided by how many sources are in that buffer
+    # it should be the same for all buffers
+    mref_name = next(iter(sources))
+    buf_key = next(iter(sources[mref_name]))
+    num_shots = buffers[buf_key].shape[0] // len(sources[mref_name][buf_key])
+
+    for mref_name, mref_dict in sources.items():
+        regions[mref_name] = alloc(memory_descriptors[mref_name], num_shots)
+        region_width = memory_descriptors[mref_name].length
+        for key, mref_list in mref_dict.items():
             num_lanes = len(mref_list)
             # sort the items in the mref_list by their offset
             sorted_mref = [mref for _, mref in sorted(zip((m.offset for m in mref_list), mref_list))]
@@ -107,10 +106,10 @@ def _extract_memory_regions(
                 end = mref.offset + width
                 if end > region_width:
                     raise ValueError(
-                        f"Attempted to fill {reg_name}[{mref.offset}, {end})"
+                        f"Attempted to fill {mref_name}[{mref.offset}, {end})"
                         f"but the declared region has width {region_width}."
                     )
-                regions[reg_name][:, mref.offset : end] = buf[i::num_lanes, :]
+                regions[mref_name][:, mref.offset : end] = buf[i::num_lanes, :]
 
     return regions
 


### PR DESCRIPTION
## Description

Updating how the memory regions are adapted to support repeated measurements on the same qubit. 
When the same qubit is measured multiple times, the received buffer is of the length `num_shots*n_mmts` where sequential measurements are done in blocks of `n_mmts`. The returned `ro_sources` then contain multiple `MemoryReference` with the same name and key, but different offset.

What I do in this PR is first construct the list of all relevant `sources`. Which filters out the unrequested `ro_sources` as well as lists all `MemoryReference` objects that refer to the same key.
This then lets me deduce the correct `num_shots` (length of the buffer divided by the number of `MemoryReference` referring to that buffer. Also, to get the correct ordering of the entries in the buffer, I needed to sort the `MemoryReference` by their offset (I am less sure if this is the correct thing to do, but it seems to work).

I am unsure about how to test this for the complex buffers, but it might work as is.

Insert your PR description here. Thanks for [contributing][contributing] to pyQuil! 🙂

## Checklist

- [ ] The PR targets the `master` branch
- [ x ] The above description motivates these changes.
- [ x ] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [ ] All changes to code are covered via unit tests.
- [ x ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ x ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
