### PR TITLE
Fix: broken action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ on:
   workflow_dispatch:
     description: "Manually publish release"
 
-env:
-  # Only used ephemerally for validating image
-  DOCKER_TEST_TAG: "${{ env.DOCKER_IMAGE_NAME }}:test"
-
 jobs:
   build-publish:
     name: Build and Publish
@@ -66,12 +62,12 @@ jobs:
         with:
           context: .
           load: true
-          tags: ${{ env.DOCKER_TEST_TAG }}
+          tags: "${{ env.DOCKER_IMAGE_NAME }}:test"
           build-args: |
             pyquil_version=${{ env.PYQUIL_TAG_VERSION }}
       - name: Test Image
         run: |
-          docker run --rm ${{ env.DOCKER_TEST_TAG }} python -c "from pyquil import get_qc"
+          docker run --rm "${{ env.DOCKER_IMAGE_NAME }}:test" python -c "from pyquil import get_qc"
       # Build and publish the image
       - name: Login to Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
Removes usage of `${{ env.* }}` context inside the `env` section, because it can only be used in workflows, jobs, or steps.

See https://docs.github.com/en/actions/learn-github-actions/contexts#env-context
