### PR TITLE
V4 - fix: Program#calibrate now returns the original instruction if there was no match

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -844,7 +844,7 @@ class Program:
             _convert_to_rs_instructions(previously_calibrated_instructions),
         )
 
-        return _convert_to_py_instructions(calibrated_instructions)
+        return [instruction] if not calibrated_instructions else _convert_to_py_instructions(calibrated_instructions)
 
     @deprecated(
         version="4.0",

--- a/test/unit/test_quilt.py
+++ b/test/unit/test_quilt.py
@@ -278,6 +278,12 @@ def test_program_calibrate(program_input, gate, program_output):
     assert Program(calibrated).out() == program_output.out()
 
 
+def test_program_calibrate_no_match():
+    program = Program()
+    instruction = Gate("RX", [np.pi], [Qubit(0)])
+    assert program.calibrate(instruction) == [instruction]
+
+
 @pytest.mark.parametrize(
     "program_text",
     (


### PR DESCRIPTION
closes #1645 
