### PR TITLE
V4 - feat: Implement `__iadd__` on `Program`

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -887,6 +887,10 @@ class Program:
         p.inst(other)
         return p
 
+    def __iadd__(self, other: InstructionDesignator) -> "Program":
+        self.inst(other)
+        return self
+
     def __getitem__(self, index: Union[slice, int]) -> Union[AbstractInstruction, "Program"]:
         """
         Allows indexing into the program to get an action.


### PR DESCRIPTION
## Description

closes #1647 

## Performance comparisons

Methodology: Starting with an empty `Program` append a large amount of instructions (~5000) using inplace addition.

| Version | Runtime |
| --- | --- |
| v3.5.4       | 0.0929s |
| v4.0.0-rc.52 | 4.89s |
| This branch  | **0.0642s** |

## Profiling script

```python
def generate_program(num_qubits: int, layers: int) -> Program:
    program = Program()
    params = program.declare("params", "REAL", num_qubits * layers * 3)
    idx = 0
    for layer in range(layers):
        for q in range(num_qubits):
            program += RZ(params[idx], q)
            idx += 1
            program += RX(np.pi / 2, q)
            program += RZ(params[idx], q)
            idx += 1
            program += RX(np.pi / 2, q)
            program += RZ(params[idx], q)
            idx += 1
    return program

def main():
    program = generate_program(10, 100)

    program.out()


if __name__ == "__main__":
    profiler = cProfile.Profile()
    profiler.enable()
    main()
    profiler.disable()
    profiler.dump_stats("program_generation.prof")
```