### PR TITLE
V4 - Cache Program properties, fix compatibility layer for `FenceAll`, `TemplateWaveform`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ installation, perform diagnostics checks, and return a summary.
 - `percolate_declares` is a no-op and will be removed in future versions. `Program` now “percolates” declares automatically.
 - `merge_programs` continues to work, but will be removed in future versions, use `Program` addition instead.
 - The `format_parameter` function continues to work, but will be removed in future versions.
-- The `WaveformReference` and `TemplateWaveform` classes continue to work, but will be removed in future versions. The new `WaveformInvocation` should be used instead.
+- The `WaveformReference` class continues to work, but will be removed in future versions. The new `WaveformInvocation` should be used instead.
 
 ## 3.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The 4.0 release of pyQuil migrates its core functionality into Rigetti's latest 
 - The `pyquil.quil.get_default_qubit_mapping` function for getting a mapping of `QubitPlaceholders` to resolved indices has been removed. Generating a default mapping is handled automatically by the placeholder resolving methods.
 - The `JumpConditional` base class has been removed, use `JumpWhen` and/or `JumpUnless` directly instead.
 - The `Program` class automatically sorts `DECLARE` instructions to the top of the Program when converting to Quil.
+- `FenceAll` is now a subclass of `Fence`. This can be impactful if you are doing something like `isinstance(instruction, Fence)` since that will now match `Fence` and `FenceAll`. If the difference between the two is important, check for `FenceAll` first. You can also check if the `qubits` property is empty, which implies a `FenceAll` instruction.
 
 ### Features
 

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -101,6 +101,7 @@ InstructionDesignator = Union[
     Generator[Any, Any, Any],
 ]
 
+
 class Program:
     """
     A list of pyQuil instructions that comprise a quantum program.
@@ -1062,7 +1063,10 @@ def instantiate_labels(instructions: Iterable[AbstractInstruction]) -> List[Abst
 
     return result
 
+
 RetType = TypeVar("RetType")
+
+
 def invalidates_cached_properties(func: Callable[..., RetType]) -> Callable[..., RetType]:
     @functools.wraps(func)
     def wrapper(self: "Program", *args: Any, **kwargs: Any) -> RetType:

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -17,7 +17,6 @@
 Module for creating and defining Quil programs.
 """
 import types
-import functools
 from collections import defaultdict
 from copy import deepcopy
 from typing import (
@@ -125,12 +124,12 @@ class Program:
 
         self.native_quil_metadata: Optional[NativeQuilMetadata] = None
 
-    @functools.cached_property
+    @property
     def calibrations(self) -> List[DefCalibration]:
         """A list of Quil-T calibration definitions."""
         return [DefCalibration._from_rs_calibration(cal) for cal in self._program.calibrations.calibrations]
 
-    @functools.cached_property
+    @property
     def measure_calibrations(self) -> List[DefMeasureCalibration]:
         """A list of measure calibrations"""
         return [
@@ -138,7 +137,7 @@ class Program:
             for cal in self._program.calibrations.measure_calibrations
         ]
 
-    @functools.cached_property
+    @property
     def waveforms(self) -> Dict[str, DefWaveform]:
         """A mapping from waveform names to their corresponding definitions."""
         return {
@@ -146,7 +145,7 @@ class Program:
             for name, waveform in self._program.waveforms.items()
         }
 
-    @functools.cached_property
+    @property
     def frames(self) -> Dict[Frame, DefFrame]:
         """A mapping from Quil-T frames to their definitions."""
         return {
@@ -154,7 +153,7 @@ class Program:
             for frame, attributes in self._program.frames.get_all_frames().items()
         }
 
-    @functools.cached_property
+    @property
     def declarations(self) -> Dict[str, Declare]:
         """A mapping from declared region names to their declarations."""
         return {name: Declare._from_rs_declaration(inst) for name, inst in self._program.declarations.items()}
@@ -187,7 +186,7 @@ class Program:
         new_program.num_shots = self.num_shots
         return new_program
 
-    @functools.cached_property
+    @property
     def defined_gates(self) -> List[DefGate]:
         """
         A list of defined gates on the program.

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -105,24 +105,6 @@ InstructionDesignator = Union[
 RetType = TypeVar("RetType")
 
 
-def _invalidates_cached_properties(func: Callable[..., RetType]) -> Callable[..., RetType]:
-    @functools.wraps(func)
-    def wrapper(self: "Program", *args: Any, **kwargs: Any) -> RetType:
-        result = func(self, *args, **kwargs)
-        cls = type(self)
-        cached = {
-            attr
-            for attr in list(self.__dict__.keys())
-            if (descriptor := getattr(cls, attr, None))
-            if isinstance(descriptor, functools.cached_property)
-        }
-        for attr in cached:
-            del self.__dict__[attr]
-        return result
-
-    return wrapper
-
-
 class Program:
     """
     A list of pyQuil instructions that comprise a quantum program.
@@ -225,7 +207,6 @@ class Program:
         new_program.inst(instructions)
         self._program = new_program._program
 
-    @_invalidates_cached_properties
     def inst(self, *instructions: Union[InstructionDesignator, RSProgram]) -> "Program":
         """
         Mutates the Program object by appending new instructions.
@@ -288,7 +269,6 @@ class Program:
 
         return self
 
-    @_invalidates_cached_properties
     def resolve_placeholders(self) -> None:
         """
         Resolve all label and qubit placeholders in the program using a default resolver that will generate
@@ -296,7 +276,6 @@ class Program:
         """
         self._program.resolve_placeholders()
 
-    @_invalidates_cached_properties
     def resolve_placeholders_with_custom_resolvers(
         self,
         *,
@@ -331,14 +310,12 @@ class Program:
             target_resolver=rs_label_resolver, qubit_resolver=rs_qubit_resolver
         )
 
-    @_invalidates_cached_properties
     def resolve_qubit_placeholders(self) -> None:
         """
         Resolve all qubit placeholders in the program.
         """
         self._program.resolve_placeholders_with_custom_resolvers(target_resolver=lambda _: None)
 
-    @_invalidates_cached_properties
     def resolve_qubit_placeholders_with_mapping(self, qubit_mapping: Dict[QubitPlaceholder, int]) -> None:
         """
         Resolve all qubit placeholders in the program using a mapping of ``QubitPlaceholder``\\s to
@@ -355,7 +332,6 @@ class Program:
             qubit_resolver=qubit_resolver, target_resolver=label_resolver
         )
 
-    @_invalidates_cached_properties
     def resolve_label_placeholders(self) -> None:
         """
         Resolve all label placeholders in the program.

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -13,7 +13,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 ##############################################################################
-
 from fractions import Fraction
 import inspect
 from numbers import Number
@@ -1015,9 +1014,11 @@ def _template_waveform_property(
             return parameter
 
         if dtype is int or dtype is float:
+            if isinstance(parameter, dtype):
+                return parameter
             if not isinstance(parameter, complex):
                 raise TypeError(
-                    f"Requested float for parameter {name}, but a non-numeric value of type {type(parameter)} was found"
+                    f"Requested float for parameter {name}, but a non-numeric value of type {type(parameter)} was found "
                     "instead"
                 )
             if parameter.imag != 0.0:
@@ -1037,10 +1038,6 @@ def _template_waveform_property(
     return property(fget, fset, fdel, doc)
 
 
-@deprecated(
-    version="4.0",
-    reason="The TemplateWaveform class will be removed, consider using WaveformInvocation instead.",
-)
 class TemplateWaveform(quil_rs.WaveformInvocation, QuilAtom):
     NAME: ClassVar[str]
 
@@ -1136,7 +1133,7 @@ class TemplateWaveform(quil_rs.WaveformInvocation, QuilAtom):
             ]
             if set(waveform.parameters.keys()).issubset(parameter_names):
                 try:
-                    parameters = {key: value.inner() for key, value in waveform.parameters.items()}
+                    parameters = {key: _convert_to_py_expression(value) for key, value in waveform.parameters.items()}
                     return template(**parameters)  # type: ignore[arg-type]
                 except TypeError:
                     break

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -1018,8 +1018,8 @@ def _template_waveform_property(
                 return parameter
             if not isinstance(parameter, complex):
                 raise TypeError(
-                    f"Requested float for parameter {name}, but a non-numeric value of type {type(parameter)} was found "
-                    "instead"
+                    f"Requested float for parameter {name}, but a non-numeric value of type {type(parameter)} was "
+                    "found instead"
                 )
             if parameter.imag != 0.0:
                 raise ValueError(

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -219,6 +219,8 @@ def _convert_to_py_instruction(instr: Any) -> AbstractInstruction:
     if isinstance(instr, quil_rs.Delay):
         return Delay._from_rs_delay(instr)
     if isinstance(instr, quil_rs.Fence):
+        if len(instr.qubits) == 0:
+            return FenceAll()
         return Fence._from_rs_fence(instr)
     if isinstance(instr, quil_rs.FrameDefinition):
         return DefFrame._from_rs_frame_definition(instr)
@@ -2352,7 +2354,6 @@ class DefCalibration(quil_rs.Calibration, AbstractInstruction):
 
     @parameters.setter
     def parameters(self, parameters: Sequence[ParameterDesignator]) -> None:
-
         quil_rs.Calibration.parameters.__set__(self, _convert_to_rs_expressions(parameters))  # type: ignore[attr-defined] # noqa
 
     @property  # type: ignore[override]

--- a/pyquil/quiltwaveforms.py
+++ b/pyquil/quiltwaveforms.py
@@ -10,6 +10,7 @@ from pyquil.quilatom import (
     _template_waveform_property,
 )
 
+
 class FlatWaveform(TemplateWaveform):
     """
     A flat (constant) waveform.

--- a/pyquil/quiltwaveforms.py
+++ b/pyquil/quiltwaveforms.py
@@ -1,8 +1,6 @@
 from typing import Optional
 from typing_extensions import Self
-from warnings import warn
 
-from deprecated.sphinx import deprecated
 import numpy as np
 from scipy.special import erf
 
@@ -12,17 +10,6 @@ from pyquil.quilatom import (
     _template_waveform_property,
 )
 
-warn(
-    DeprecationWarning("The quiltwaveforms module is deprecated. Use quilatom.WaveformInvocation instead."),
-    category=DeprecationWarning,
-    stacklevel=2,
-)
-
-
-@deprecated(
-    version="4.0",
-    reason="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
-)
 class FlatWaveform(TemplateWaveform):
     """
     A flat (constant) waveform.
@@ -50,10 +37,6 @@ class FlatWaveform(TemplateWaveform):
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
-@deprecated(
-    version="4.0",
-    reason="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
-)
 class GaussianWaveform(TemplateWaveform):
     """A Gaussian pulse."""
 
@@ -89,10 +72,6 @@ class GaussianWaveform(TemplateWaveform):
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
-@deprecated(
-    version="4.0",
-    reason="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
-)
 class DragGaussianWaveform(TemplateWaveform):
     """A DRAG Gaussian pulse."""
 
@@ -145,10 +124,6 @@ class DragGaussianWaveform(TemplateWaveform):
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
-@deprecated(
-    version="4.0",
-    reason="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
-)
 class HrmGaussianWaveform(TemplateWaveform):
     """A Hermite Gaussian waveform.
 
@@ -221,10 +196,6 @@ class HrmGaussianWaveform(TemplateWaveform):
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
-@deprecated(
-    version="4.0",
-    reason="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
-)
 class ErfSquareWaveform(TemplateWaveform):
     """A pulse with a flat top and edges that are error functions (erf)."""
 
@@ -283,10 +254,6 @@ class ErfSquareWaveform(TemplateWaveform):
         return _update_envelope(iqs, rate, scale=self.scale, phase=self.phase, detuning=self.detuning)
 
 
-@deprecated(
-    version="4.0",
-    reason="The TemplateWaveform class and its subclasses will be removed, consider using WaveformInvocation instead.",
-)
 class BoxcarAveragerKernel(TemplateWaveform):
 
     NAME = "boxcar_kernel"

--- a/test/unit/test_quil.py
+++ b/test/unit/test_quil.py
@@ -1137,16 +1137,3 @@ MEASURE 1 ro[1]
     assert len(program.instructions) == 0  # the purpose of copy_everything_except_instructions()
     assert len(program.declarations) == 0  # this is a view on the instructions member; must be consistent
 
-def test_cached_frames():
-    frames = [
-        DefFrame(Frame([Qubit(0)], "frame0"), center_frequency=432.0),
-        DefFrame(Frame([Qubit(1)], "frame1"), sample_rate=44100.0),
-    ]
-
-    p = Program(frames[0])
-    program_frames = p.frames
-    assert program_frames == {frames[0].frame: frames[0]}
-
-    p.inst(frames[1])
-    program_frames = p.frames
-    assert program_frames == {frames[0].frame: frames[0], frames[1].frame: frames[1]}

--- a/test/unit/test_quil.py
+++ b/test/unit/test_quil.py
@@ -1136,3 +1136,17 @@ MEASURE 1 ro[1]
     program = program.copy_everything_except_instructions()
     assert len(program.instructions) == 0  # the purpose of copy_everything_except_instructions()
     assert len(program.declarations) == 0  # this is a view on the instructions member; must be consistent
+
+def test_cached_frames():
+    frames = [
+        DefFrame(Frame([Qubit(0)], "frame0"), center_frequency=432.0),
+        DefFrame(Frame([Qubit(1)], "frame1"), sample_rate=44100.0),
+    ]
+
+    p = Program(frames[0])
+    program_frames = p.frames
+    assert program_frames == {frames[0].frame: frames[0]}
+
+    p.inst(frames[1])
+    program_frames = p.frames
+    assert program_frames == {frames[0].frame: frames[0], frames[1].frame: frames[1]}


### PR DESCRIPTION
## Description

A small bundle of improvements:

1. In `quil`, `Fence` is the only class for `Fence` instructions. When there are no qubits, it should be equivalent to `pyQuil`s `FenceAll`. The difference can be important for users who use something like `isinstance(instr, FenceAll)`. The compatibility layer will now check a `Fence` instructions qubits and return `FenceAll` if it is an empty list.

2. A fix to ensure that all parameters are converted to pyQuil types when building `TemplateWaveform`s in the compatibility layer.

3. Un-deprecate the `TemplateWaveform` classes. These are more important to users that I initially realized, so I've removed the deprecation warning.

4. ~Added a caching layer on `Program` properties after identifying a performance issue in an internal test with repeatedly checking `frames` on the calibration program. In that benchmark, the current V4 RC performed 25% _worse_ compared to v3. This branch peforms 40% _better_ than v3. Because we can't efficiently hash a Program, maintaining a cache requires us to manually invalidate it when something mutates the program. I've added a decorator that does this in a heavy handed way to favor correctness of the program state, rather than marginal performance gains.~ Reverted this in favor of simplicity since the boost was in relatively narrow use cases. 