### PR TITLE
re-enable knope changelog management

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -1,5 +1,6 @@
 [package]
 versioned_files = ["pyproject.toml"]
+changelog = "CHANGELOG.md"
 
 [[workflows]]
 name = "release"


### PR DESCRIPTION
## Description

Let knope handle automatically updating our CHANGELOG again.

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).