### PR TITLE
Remove unused dependency importlib-metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ lark = "^0.11.1"
 rpcq = "^3.10.0"
 pydantic = "^1.10.7"
 networkx = ">=2.5"
-importlib-metadata = { version = ">=3.7.3,<5", python = "<3.8" }
 qcs-sdk-python = "0.12.2"
 tenacity = "^8.2.2"
 types-python-dateutil = "^2.8.19"


### PR DESCRIPTION
## Description

Insert your PR description here. Thanks for [contributing][contributing] to pyQuil! 🙂

importlib-metadata was only used for python<3.8 but the minimum python is not 3.8, so it is not needed anymore.

## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [ ] All changes to code are covered via unit tests.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
