### PR TITLE
fix: The `DefGate.matrix` property will no longer raise an exception when the matrix contains a mix of atomic and object types.

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -627,7 +627,7 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
     def _convert_to_matrix_specification(
         matrix: Union[List[List[Expression]], np.ndarray, np.matrix]
     ) -> quil_rs.GateSpecification:
-        to_rs_matrix = np.vectorize(_convert_to_rs_expression)
+        to_rs_matrix = np.vectorize(_convert_to_rs_expression, otypes=["O"])
         return quil_rs.GateSpecification.from_matrix(to_rs_matrix(np.asarray(matrix)))
 
     @staticmethod
@@ -678,7 +678,7 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
 
     @property
     def matrix(self) -> np.ndarray:
-        to_py_matrix = np.vectorize(_convert_to_py_expression)
+        to_py_matrix = np.vectorize(_convert_to_py_expression, otypes=["O"])
         return to_py_matrix(np.asarray(super().specification.to_matrix()))  # type: ignore[no-any-return]
 
     @matrix.setter

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -221,11 +221,22 @@
     '\tSAMPLE-RATE: 44.1',
   })
 # ---
+# name: TestDefGate.test_get_constructor[MixedTypes]
+  'MixedTypes(%theta) 123'
+# ---
 # name: TestDefGate.test_get_constructor[No-Params]
   'NoParamGate 123'
 # ---
 # name: TestDefGate.test_get_constructor[Params]
   'ParameterizedGate(%theta) 123'
+# ---
+# name: TestDefGate.test_out[MixedTypes]
+  '''
+  DEFGATE MixedTypes(%X) AS MATRIX:
+  	0, sin(%X)
+  	0, 0
+  
+  '''
 # ---
 # name: TestDefGate.test_out[No-Params]
   '''
@@ -244,6 +255,14 @@
   	0, cos(%X), 0, 0
   	0, 0, cos(%X), 0
   	0, 0, 0, cos(%X)
+  
+  '''
+# ---
+# name: TestDefGate.test_str[MixedTypes]
+  '''
+  DEFGATE MixedTypes(%X) AS MATRIX:
+  	0, sin(%X)
+  	0, 0
   
   '''
 # ---

--- a/test/unit/test_numpy.py
+++ b/test/unit/test_numpy.py
@@ -220,7 +220,7 @@ def test_defgate():
     p += U_test(1, 0)
     qam = PyQVM(n_qubits=2, quantum_simulator_type=NumpyWavefunctionSimulator)
     qam.execute(p)
-    wf1 = qam.wf_simulator.wf
+    wf1 = qam.wf_simulator.wf.astype(np.complex128)
     should_be = np.zeros((2, 2), dtype=np.complex128)
     one_over_sqrt2 = 1 / np.sqrt(2)
     should_be[0, 1] = one_over_sqrt2

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from pyquil.quilatom import quil_cos
+from pyquil.quilatom import quil_cos, quil_sin
 from pyquil.gates import X
 from pyquil.quil import Program
 from pyquil.quilbase import (
@@ -171,8 +171,18 @@ class TestGate:
     [
         ("NoParamGate", np.eye(4), []),
         ("ParameterizedGate", np.diag([quil_cos(Parameter("X"))] * 4), [Parameter("X")]),
+        (
+            "MixedTypes",
+            np.array(
+                [
+                    [0, quil_sin(Parameter("X"))],
+                    [0, 0],
+                ]
+            ),
+            [Parameter("X")],
+        ),
     ],
-    ids=("No-Params", "Params"),
+    ids=("No-Params", "Params", "MixedTypes"),
 )
 class TestDefGate:
     @pytest.fixture


### PR DESCRIPTION
## Description

Closes #1681. Thanks to @steve-jeffrey for the report and suggested fix!

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
