### PR TITLE
fix: Instruction types no longer return a superclass instance when using `copy.deepcopy`

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -430,6 +430,12 @@ class Gate(quil_rs.Gate, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Gate":
+        return Gate._from_rs_gate(super().__deepcopy__(memo))
+
 
 def _strip_modifiers(gate: Gate, limit: Optional[int] = None) -> Gate:
     """
@@ -536,6 +542,12 @@ class Measurement(quil_rs.Measurement, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Measurement":
+        return Measurement._from_rs_measurement(super().__deepcopy__(memo))
+
 
 class Reset(quil_rs.Reset, AbstractInstruction):
     """
@@ -586,6 +598,14 @@ class Reset(quil_rs.Reset, AbstractInstruction):
 
     def __str__(self) -> str:
         return super().to_quil_or_debug()
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Reset":
+        copy = Reset._from_rs_reset(super().__deepcopy__(memo))
+        copy.__class__ = self.__class__
+        return copy
 
 
 class ResetQubit(Reset):
@@ -699,6 +719,12 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "DefGate":
+        return DefGate._from_rs_gate_definition(super().__deepcopy__(memo))
+
 
 class DefPermutationGate(DefGate):
     def __new__(cls, name: str, permutation: Union[List[int], np.ndarray]) -> Self:
@@ -808,6 +834,12 @@ class JumpTarget(quil_rs.Label, AbstractInstruction):
     def out(self) -> str:
         return super().to_quil()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "JumpTarget":
+        return JumpTarget._from_rs_label(super().__deepcopy__(memo))
+
 
 class JumpWhen(quil_rs.JumpWhen, AbstractInstruction):
     """
@@ -844,6 +876,12 @@ class JumpWhen(quil_rs.JumpWhen, AbstractInstruction):
 
     def __str__(self) -> str:
         return super().to_quil_or_debug()
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "JumpWhen":
+        return JumpWhen._from_rs_jump_when(super().__deepcopy__(memo))
 
 
 class JumpUnless(quil_rs.JumpUnless, AbstractInstruction):
@@ -882,6 +920,12 @@ class JumpUnless(quil_rs.JumpUnless, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "JumpUnless":
+        return JumpUnless._from_rs_jump_unless(super().__deepcopy__(memo))
+
 
 class SimpleInstruction(AbstractInstruction):
     """
@@ -895,6 +939,12 @@ class SimpleInstruction(AbstractInstruction):
 
     def __str__(self) -> str:
         return self.out()
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "SimpleInstruction":
+        return self
 
 
 class Halt(SimpleInstruction):
@@ -931,6 +981,10 @@ class UnaryClassicalInstruction(quil_rs.UnaryLogic, AbstractInstruction):
     def __new__(cls, target: MemoryReference) -> "UnaryClassicalInstruction":
         return super().__new__(cls, cls.op, target._to_rs_memory_reference())
 
+    @classmethod
+    def _from_rs_unary_logic(cls, unary_logic: quil_rs.UnaryLogic) -> Self:
+        return super().__new__(cls, unary_logic.operator, unary_logic.operand)
+
     @property
     def target(self) -> MemoryReference:
         return MemoryReference._from_rs_memory_reference(super().operand)
@@ -944,6 +998,14 @@ class UnaryClassicalInstruction(quil_rs.UnaryLogic, AbstractInstruction):
 
     def __str__(self) -> str:
         return super().to_quil_or_debug()
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "UnaryClassicalInstruction":
+        copy = UnaryClassicalInstruction._from_rs_unary_logic(super().__deepcopy__(memo))
+        copy.__class__ = self.__class__
+        return copy
 
 
 class ClassicalNeg(UnaryClassicalInstruction):
@@ -972,6 +1034,10 @@ class LogicalBinaryOp(quil_rs.BinaryLogic, AbstractInstruction):
     def __new__(cls, left: MemoryReference, right: Union[MemoryReference, int]) -> Self:
         operands = cls._to_rs_binary_operands(left, right)
         return super().__new__(cls, cls.op, operands)
+
+    @classmethod
+    def _from_rs_binary_logic(cls, binary_logic: quil_rs.BinaryLogic) -> "LogicalBinaryOp":
+        return super().__new__(cls, binary_logic.operator, binary_logic.operands)
 
     @staticmethod
     def _to_rs_binary_operand(operand: Union[MemoryReference, int]) -> quil_rs.BinaryOperand:
@@ -1017,6 +1083,14 @@ class LogicalBinaryOp(quil_rs.BinaryLogic, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "LogicalBinaryOp":
+        copy = LogicalBinaryOp._from_rs_binary_logic(super().__deepcopy__(memo))
+        copy.__class__ = self.__class__
+        return copy
+
 
 class ClassicalAnd(LogicalBinaryOp):
     """
@@ -1054,6 +1128,10 @@ class ArithmeticBinaryOp(quil_rs.Arithmetic, AbstractInstruction):
         right_operand = _to_rs_arithmetic_operand(right)
         return super().__new__(cls, cls.op, left_operand, right_operand)
 
+    @classmethod
+    def _from_rs_arithmetic(cls, arithmetic: quil_rs.Arithmetic) -> "ArithmeticBinaryOp":
+        return super().__new__(cls, arithmetic.operator, arithmetic.destination, arithmetic.source)
+
     @property
     def left(self) -> MemoryReference:
         return MemoryReference._from_rs_memory_reference(super().destination.to_memory_reference())
@@ -1077,6 +1155,14 @@ class ArithmeticBinaryOp(quil_rs.Arithmetic, AbstractInstruction):
 
     def __str__(self) -> str:
         return super().to_quil_or_debug()
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "ArithmeticBinaryOp":
+        copy = ArithmeticBinaryOp._from_rs_arithmetic(super().__deepcopy__(memo))
+        copy.__class__ = self.__class__
+        return copy
 
 
 class ClassicalAdd(ArithmeticBinaryOp):
@@ -1145,6 +1231,12 @@ class ClassicalMove(quil_rs.Move, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "ClassicalMove":
+        return ClassicalMove._from_rs_move(super().__deepcopy__(memo))
+
 
 class ClassicalExchange(quil_rs.Exchange, AbstractInstruction):
     """
@@ -1157,6 +1249,10 @@ class ClassicalExchange(quil_rs.Exchange, AbstractInstruction):
         right: MemoryReference,
     ) -> "ClassicalExchange":
         return super().__new__(cls, left._to_rs_memory_reference(), right._to_rs_memory_reference())
+
+    @classmethod
+    def _from_rs_exchange(cls, exchange: quil_rs.Exchange) -> Self:
+        return super().__new__(cls, exchange.left, exchange.right)
 
     @property  # type: ignore[override]
     def left(self) -> MemoryReference:
@@ -1180,6 +1276,12 @@ class ClassicalExchange(quil_rs.Exchange, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "ClassicalExchange":
+        return ClassicalExchange._from_rs_exchange(super().__deepcopy__(memo))
+
 
 class ClassicalConvert(quil_rs.Convert, AbstractInstruction):
     """
@@ -1188,6 +1290,10 @@ class ClassicalConvert(quil_rs.Convert, AbstractInstruction):
 
     def __new__(cls, left: MemoryReference, right: MemoryReference) -> "ClassicalConvert":
         return super().__new__(cls, left._to_rs_memory_reference(), right._to_rs_memory_reference())
+
+    @classmethod
+    def _from_rs_convert(cls, convert: quil_rs.Convert) -> Self:
+        return super().__new__(cls, convert.destination, convert.source)
 
     @property
     def left(self) -> MemoryReference:
@@ -1211,6 +1317,12 @@ class ClassicalConvert(quil_rs.Convert, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "ClassicalConvert":
+        return ClassicalConvert._from_rs_convert(super().__deepcopy__(memo))
+
 
 class ClassicalLoad(quil_rs.Load, AbstractInstruction):
     """
@@ -1219,6 +1331,10 @@ class ClassicalLoad(quil_rs.Load, AbstractInstruction):
 
     def __new__(cls, target: MemoryReference, left: str, right: MemoryReference) -> "ClassicalLoad":
         return super().__new__(cls, target._to_rs_memory_reference(), left, right._to_rs_memory_reference())
+
+    @classmethod
+    def _from_rs_load(cls, load: quil_rs.Load) -> Self:
+        return super().__new__(cls, load.destination, load.source, load.offset)
 
     @property
     def target(self) -> MemoryReference:
@@ -1250,6 +1366,12 @@ class ClassicalLoad(quil_rs.Load, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "ClassicalLoad":
+        return ClassicalLoad._from_rs_load(super().__deepcopy__(memo))
+
 
 def _to_rs_arithmetic_operand(operand: Union[MemoryReference, int, float]) -> quil_rs.ArithmeticOperand:
     if isinstance(operand, MemoryReference):
@@ -1278,6 +1400,10 @@ class ClassicalStore(quil_rs.Store, AbstractInstruction):
     def __new__(cls, target: str, left: MemoryReference, right: Union[MemoryReference, int, float]) -> "ClassicalStore":
         rs_right = _to_rs_arithmetic_operand(right)
         return super().__new__(cls, target, left._to_rs_memory_reference(), rs_right)
+
+    @classmethod
+    def _from_rs_store(cls, store: quil_rs.Store) -> Self:
+        return super().__new__(cls, store.destination, store.offset, store.source)
 
     @property
     def target(self) -> str:
@@ -1309,6 +1435,12 @@ class ClassicalStore(quil_rs.Store, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "ClassicalStore":
+        return ClassicalStore._from_rs_store(super().__deepcopy__(memo))
+
 
 class ClassicalComparison(quil_rs.Comparison, AbstractInstruction):
     """
@@ -1325,6 +1457,10 @@ class ClassicalComparison(quil_rs.Comparison, AbstractInstruction):
     ) -> "ClassicalComparison":
         operands = (target._to_rs_memory_reference(), left._to_rs_memory_reference(), cls._to_comparison_operand(right))
         return super().__new__(cls, cls.op, operands)
+
+    @classmethod
+    def _from_rs_comparison(cls, comparison: quil_rs.Comparison) -> Self:
+        return super().__new__(cls, comparison.operator, comparison.operands)
 
     @staticmethod
     def _to_comparison_operand(operand: Union[MemoryReference, int, float]) -> quil_rs.ComparisonOperand:
@@ -1380,6 +1516,14 @@ class ClassicalComparison(quil_rs.Comparison, AbstractInstruction):
 
     def __str__(self) -> str:
         return super().to_quil_or_debug()
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "ClassicalComparison":
+        copy = ClassicalComparison._from_rs_comparison(super().__deepcopy__(memo))
+        copy.__class__ = self.__class__
+        return copy
 
 
 class ClassicalEqual(ClassicalComparison):
@@ -1449,6 +1593,12 @@ class Jump(quil_rs.Jump, AbstractInstruction):
 
     def __str__(self) -> str:
         return super().to_quil_or_debug()
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Jump":
+        return Jump._from_rs_jump(super().__deepcopy__(memo))
 
 
 class Pragma(quil_rs.Pragma, AbstractInstruction):
@@ -1527,6 +1677,12 @@ class Pragma(quil_rs.Pragma, AbstractInstruction):
     @freeform_string.setter
     def freeform_string(self, freeform_string: str) -> None:
         quil_rs.Pragma.data.__set__(self, freeform_string)  # type: ignore[attr-defined]
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Pragma":
+        return Pragma._from_rs_pragma(super().__deepcopy__(memo))
 
 
 class Declare(quil_rs.Declaration, AbstractInstruction):
@@ -1643,13 +1799,29 @@ class Declare(quil_rs.Declaration, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Declare":
+        return Declare._from_rs_declaration(super().__deepcopy__(memo))
+
 
 class Include(quil_rs.Include, AbstractInstruction):
     def out(self) -> str:
         return super().to_quil()
 
+    @classmethod
+    def _from_rs_include(cls, include: quil_rs.Include) -> "Include":
+        return super().__new__(cls, include.filename)
+
     def __str__(self) -> str:
         return super().to_quil_or_debug()
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Include":
+        return Include._from_rs_include(super().__deepcopy__(memo))
 
 
 class Pulse(quil_rs.Pulse, AbstractInstruction):
@@ -1703,6 +1875,12 @@ class Pulse(quil_rs.Pulse, AbstractInstruction):
     def nonblocking(self, nonblocking: bool) -> None:
         quil_rs.Pulse.blocking.__set__(self, not nonblocking)  # type: ignore[attr-defined]
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Pulse":
+        return Pulse._from_rs_pulse(super().__deepcopy__(memo))
+
 
 class SetFrequency(quil_rs.SetFrequency, AbstractInstruction):
     def __new__(cls, frame: Frame, freq: ParameterDesignator) -> Self:
@@ -1745,6 +1923,12 @@ class SetFrequency(quil_rs.SetFrequency, AbstractInstruction):
 
     def get_qubit_indices(self) -> Set[int]:
         return {qubit.to_fixed() for qubit in super().frame.qubits}
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "SetFrequency":
+        return SetFrequency._from_rs_set_frequency(super().__deepcopy__(memo))
 
 
 class ShiftFrequency(quil_rs.ShiftFrequency, AbstractInstruction):
@@ -1789,6 +1973,12 @@ class ShiftFrequency(quil_rs.ShiftFrequency, AbstractInstruction):
     def get_qubit_indices(self) -> Set[int]:
         return {qubit.to_fixed() for qubit in super().frame.qubits}
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "ShiftFrequency":
+        return ShiftFrequency._from_rs_shift_frequency(super().__deepcopy__(memo))
+
 
 class SetPhase(quil_rs.SetPhase, AbstractInstruction):
     def __new__(cls, frame: Frame, phase: ParameterDesignator) -> Self:
@@ -1831,6 +2021,12 @@ class SetPhase(quil_rs.SetPhase, AbstractInstruction):
 
     def get_qubit_indices(self) -> Set[int]:
         return {qubit.to_fixed() for qubit in super().frame.qubits}
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "SetPhase":
+        return SetPhase._from_rs_set_phase(super().__deepcopy__(memo))
 
 
 class ShiftPhase(quil_rs.ShiftPhase, AbstractInstruction):
@@ -1875,6 +2071,12 @@ class ShiftPhase(quil_rs.ShiftPhase, AbstractInstruction):
     def get_qubit_indices(self) -> Set[int]:
         return {qubit.to_fixed() for qubit in super().frame.qubits}
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "ShiftPhase":
+        return ShiftPhase._from_rs_shift_phase(super().__deepcopy__(memo))
+
 
 class SwapPhases(quil_rs.SwapPhases, AbstractInstruction):
     def __new__(cls, frameA: Frame, frameB: Frame) -> Self:
@@ -1918,6 +2120,12 @@ class SwapPhases(quil_rs.SwapPhases, AbstractInstruction):
     def get_qubit_indices(self) -> Set[int]:
         return {qubit.to_fixed() for qubit in super().frame_1.qubits + super().frame_2.qubits}
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "SwapPhases":
+        return SwapPhases._from_rs_swap_phases(super().__deepcopy__(memo))
+
 
 class SetScale(quil_rs.SetScale, AbstractInstruction):
     def __new__(cls, frame: Frame, scale: ParameterDesignator) -> Self:
@@ -1960,6 +2168,12 @@ class SetScale(quil_rs.SetScale, AbstractInstruction):
 
     def get_qubit_indices(self) -> Set[int]:
         return {qubit.to_fixed() for qubit in super().frame.qubits}
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "SetScale":
+        return SetScale._from_rs_set_scale(super().__deepcopy__(memo))
 
 
 class Capture(quil_rs.Capture, AbstractInstruction):
@@ -2028,6 +2242,12 @@ class Capture(quil_rs.Capture, AbstractInstruction):
 
     def get_qubit_indices(self) -> Set[int]:
         return {qubit.to_fixed() for qubit in super().frame.qubits}
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Capture":
+        return Capture._from_rs_capture(super().__deepcopy__(memo))
 
 
 class RawCapture(quil_rs.RawCapture, AbstractInstruction):
@@ -2101,6 +2321,12 @@ class RawCapture(quil_rs.RawCapture, AbstractInstruction):
     def get_qubit_indices(self) -> Set[int]:
         return {qubit.to_fixed() for qubit in super().frame.qubits}
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "RawCapture":
+        return RawCapture._from_rs_raw_capture(super().__deepcopy__(memo))
+
 
 class Delay(quil_rs.Delay, AbstractInstruction):
     def __new__(cls, frames: List[Frame], qubits: Sequence[Union[int, Qubit, FormalArgument]], duration: float) -> Self:
@@ -2156,6 +2382,14 @@ class Delay(quil_rs.Delay, AbstractInstruction):
         expression = quil_rs_expr.Expression.from_number(complex(duration))
         quil_rs.Delay.duration.__set__(self, expression)  # type: ignore[attr-defined]
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Delay":
+        copy = Delay._from_rs_delay(super().__deepcopy__(memo))
+        copy.__class__ = self.__class__
+        return copy
+
 
 class DelayFrames(Delay):
     def __new__(cls, frames: List[Frame], duration: float) -> Self:
@@ -2188,6 +2422,12 @@ class Fence(quil_rs.Fence, AbstractInstruction):
     @qubits.setter
     def qubits(self, qubits: List[Union[Qubit, FormalArgument]]) -> None:
         quil_rs.Fence.qubits.__set__(self, _convert_to_rs_qubits(qubits))  # type: ignore[attr-defined]
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "Fence":
+        return Fence._from_rs_fence(super().__deepcopy__(memo))
 
 
 class FenceAll(Fence):
@@ -2243,6 +2483,12 @@ class DefWaveform(quil_rs.WaveformDefinition, AbstractInstruction):
         waveform = super().definition
         waveform.matrix = _convert_to_rs_expressions(entries)
         quil_rs.WaveformDefinition.definition.__set__(self, waveform)  # type: ignore[attr-defined]
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "DefWaveform":
+        return DefWaveform._from_rs_waveform_definition(super().__deepcopy__(memo))
 
 
 class DefCircuit(quil_rs.CircuitDefinition, AbstractInstruction):
@@ -2300,6 +2546,12 @@ class DefCircuit(quil_rs.CircuitDefinition, AbstractInstruction):
     def instructions(self, instructions: List[AbstractInstruction]) -> None:
         rs_instructions = _convert_to_rs_instructions(instructions)
         quil_rs.CircuitDefinition.instructions.__set__(self, rs_instructions)  # type: ignore[attr-defined]
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "DefCircuit":
+        return DefCircuit._from_rs_circuit_definition(super().__deepcopy__(memo))
 
 
 class DefCalibration(quil_rs.Calibration, AbstractInstruction):
@@ -2361,6 +2613,12 @@ class DefCalibration(quil_rs.Calibration, AbstractInstruction):
     def __str__(self) -> str:
         return super().to_quil_or_debug()
 
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "DefCalibration":
+        return DefCalibration._from_rs_calibration(super().__deepcopy__(memo))
+
 
 class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstruction):
     def __new__(
@@ -2415,6 +2673,12 @@ class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstru
 
     def __str__(self) -> str:
         return super().to_quil_or_debug()
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "DefMeasureCalibration":
+        return DefMeasureCalibration._from_rs_measure_calibration_definition(super().__deepcopy__(memo))
 
 
 class DefFrame(quil_rs.FrameDefinition, AbstractInstruction):
@@ -2548,3 +2812,9 @@ class DefFrame(quil_rs.FrameDefinition, AbstractInstruction):
     def center_frequency(self, center_frequency: float) -> None:
         self._set_attribute("CENTER-FREQUENCY", center_frequency)
         self._set_attribute("CENTER-FREQUENCY", center_frequency)
+
+    def __copy__(self) -> Self:
+        return self
+
+    def __deepcopy__(self, memo: Dict) -> "DefFrame":
+        return DefFrame._from_rs_frame_definition(super().__deepcopy__(memo))

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -1,3 +1,4 @@
+import copy
 from math import pi
 from typing import Any, List, Optional, Iterable, Tuple, Union
 from numbers import Complex, Number
@@ -159,6 +160,10 @@ class TestGate:
         assert not (gate == not_eq_gate)
         assert gate != not_eq_gate
 
+    def test_copy(self, gate: Gate):
+        assert isinstance(copy.copy(gate), Gate)
+        assert isinstance(copy.deepcopy(gate), Gate)
+
     def test_compile(self, program: Program, compiler: QPUCompiler):
         try:
             compiler.quil_to_native_quil(program)
@@ -224,6 +229,10 @@ class TestDefGate:
         assert def_gate.parameters == parameters
         def_gate.parameters = [Parameter("brand_new_param")]
         assert def_gate.parameters == [Parameter("brand_new_param")]
+
+    def test_copy(self, def_gate: DefGate):
+        assert isinstance(copy.copy(def_gate), DefGate)
+        assert isinstance(copy.deepcopy(def_gate), DefGate)
 
 
 @pytest.mark.parametrize(
@@ -386,6 +395,10 @@ class TestDefCalibration:
         calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], [])]
         assert calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], [])]
 
+    def test_copy(self, calibration: DefCalibration):
+        assert isinstance(copy.copy(calibration), DefCalibration)
+        assert isinstance(copy.deepcopy(calibration), DefCalibration)
+
 
 @pytest.mark.parametrize(
     ("qubit", "memory_reference", "instrs"),
@@ -415,6 +428,10 @@ class TestDefMeasureCalibration:
         assert measure_calibration.instrs == instrs
         measure_calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], [])]
         assert measure_calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], [])]
+
+    def test_copy(self, measure_calibration: DefMeasureCalibration):
+        assert isinstance(copy.copy(measure_calibration), DefMeasureCalibration)
+        assert isinstance(copy.deepcopy(measure_calibration), DefMeasureCalibration)
 
 
 @pytest.mark.parametrize(
@@ -450,6 +467,10 @@ class TestMeasurement:
         assert measurement.classical_reg == classical_reg
         measurement.classical_reg = MemoryReference("new_mem_ref")
         assert measurement.classical_reg == MemoryReference("new_mem_ref")
+
+    def test_copy(self, measurement: Measurement):
+        assert isinstance(copy.copy(measurement), Measurement)
+        assert isinstance(copy.deepcopy(measurement), Measurement)
 
 
 @pytest.mark.parametrize(
@@ -521,6 +542,10 @@ class TestDefFrame:
         def_frame.center_frequency = 432.0
         assert def_frame.center_frequency == 432.0
 
+    def test_copy(self, def_frame: DefFrame):
+        assert isinstance(copy.copy(def_frame), DefFrame)
+        assert isinstance(copy.deepcopy(def_frame), DefFrame)
+
 
 @pytest.mark.parametrize(
     ("name", "memory_type", "memory_size", "shared_region", "offsets"),
@@ -583,6 +608,10 @@ class TestDeclare:
             declare.offsets = [(1, "BIT"), (2, "INTEGER")]
             assert declare.offsets == [(1, "BIT"), (2, "INTEGER")]
 
+    def test_copy(self, declare: Declare):
+        assert isinstance(copy.copy(declare), Declare)
+        assert isinstance(copy.deepcopy(declare), Declare)
+
 
 @pytest.mark.parametrize(
     ("command", "args", "freeform_string"),
@@ -619,6 +648,10 @@ class TestPragma:
         assert pragma.freeform_string == freeform_string
         pragma.freeform_string = "new string"
         assert pragma.freeform_string == "new string"
+
+    def test_copy(self, pragma: Pragma):
+        assert isinstance(copy.copy(pragma), Pragma)
+        assert isinstance(copy.deepcopy(pragma), Pragma)
 
 
 @pytest.mark.parametrize(
@@ -659,6 +692,10 @@ class TestReset:
             if isinstance(qubit, Qubit):
                 assert reset_qubit.get_qubit_indices() == {qubit.index}
 
+    def test_copy(self, reset_qubit: Union[Reset, ResetQubit]):
+        assert isinstance(copy.copy(reset_qubit), type(reset_qubit))
+        assert isinstance(copy.deepcopy(reset_qubit), type(reset_qubit))
+
 
 @pytest.mark.parametrize(
     ("frames", "duration"),
@@ -683,6 +720,10 @@ class TestDelayFrames:
         assert delay_frames.duration == duration
         delay_frames.duration = 3.14
         assert delay_frames.duration == 3.14
+
+    def test_copy(self, delay_frames: DelayFrames):
+        assert isinstance(copy.copy(delay_frames), DelayFrames)
+        assert isinstance(copy.deepcopy(delay_frames), DelayFrames)
 
 
 @pytest.mark.parametrize(
@@ -711,6 +752,10 @@ class TestDelayQubits:
         delay_qubits.duration = 3.14
         assert delay_qubits.duration == 3.14
 
+    def test_copy(self, delay_qubits: DelayQubits):
+        assert isinstance(copy.copy(delay_qubits), DelayQubits)
+        assert isinstance(copy.deepcopy(delay_qubits), DelayQubits)
+
 
 @pytest.mark.parametrize(
     ("qubits"),
@@ -732,6 +777,10 @@ class TestFence:
         assert fence.qubits == qubits
         fence.qubits = [Qubit(123)]  # type: ignore
         assert fence.qubits == [Qubit(123)]
+
+    def test_copy(self, fence: Fence):
+        assert isinstance(copy.copy(fence), Fence)
+        assert isinstance(copy.deepcopy(fence), Fence)
 
 
 def test_fence_all():
@@ -775,6 +824,10 @@ class TestDefWaveform:
         assert def_waveform.entries == entries
         def_waveform.entries = [Parameter("z")]  # type: ignore
         assert def_waveform.entries == [Parameter("z")]
+
+    def test_copy(self, def_waveform: DefWaveform):
+        assert isinstance(copy.copy(def_waveform), DefWaveform)
+        assert isinstance(copy.deepcopy(def_waveform), DefWaveform)
 
 
 @pytest.mark.parametrize(
@@ -828,6 +881,10 @@ class TestDefCircuit:
         def_circuit.instructions = [Gate("new_gate", [], [Qubit(0)], [])]
         assert def_circuit.instructions == [Gate("new_gate", [], [Qubit(0)], [])]
 
+    def test_copy(self, def_circuit: DefCircuit):
+        assert isinstance(copy.copy(def_circuit), DefCircuit)
+        assert isinstance(copy.deepcopy(def_circuit), DefCircuit)
+
 
 @pytest.mark.parametrize(
     ("frame", "kernel", "memory_region", "nonblocking"),
@@ -880,6 +937,10 @@ class TestCapture:
         assert capture.nonblocking == nonblocking
         capture.nonblocking = not nonblocking
         assert capture.nonblocking == (not nonblocking)
+
+    def test_copy(self, capture: Capture):
+        assert isinstance(copy.copy(capture), Capture)
+        assert isinstance(copy.deepcopy(capture), Capture)
 
 
 @pytest.mark.parametrize(
@@ -963,6 +1024,10 @@ class TestPulse:
         pulse.nonblocking = not nonblocking
         assert pulse.nonblocking == (not nonblocking)
 
+    def test_copy(self, pulse: Pulse):
+        assert isinstance(copy.copy(pulse), Pulse)
+        assert isinstance(copy.deepcopy(pulse), Pulse)
+
 
 @pytest.mark.parametrize(
     ("frame", "duration", "memory_region", "nonblocking"),
@@ -1015,6 +1080,10 @@ class TestRawCapture:
         assert raw_capture.nonblocking == nonblocking
         raw_capture.nonblocking = not nonblocking
         assert raw_capture.nonblocking == (not nonblocking)
+
+    def test_copy(self, raw_capture: RawCapture):
+        assert isinstance(copy.copy(raw_capture), RawCapture)
+        assert isinstance(copy.deepcopy(raw_capture), RawCapture)
 
 
 @pytest.mark.parametrize(
@@ -1073,6 +1142,11 @@ class TestFrameMutations:
             setattr(instr, expression_name, 3.14)
             assert getattr(instr, expression_name) == 3.14
 
+    def test_copy(self, frame_mutation_instructions):
+        for instr in frame_mutation_instructions:
+            assert isinstance(copy.copy(instr), type(instr))
+            assert isinstance(copy.deepcopy(instr), type(instr))
+
 
 @pytest.mark.parametrize(
     ("frame_a", "frame_b"),
@@ -1098,6 +1172,10 @@ class TestSwapPhases:
         expected_qubits = set(frame_a.qubits + frame_b.qubits)
         assert swap_phase.get_qubits() == set([q.index for q in expected_qubits if isinstance(q, Qubit)])
         assert swap_phase.get_qubits(False) == expected_qubits
+
+    def test_copy(self, swap_phase: SwapPhases):
+        assert isinstance(copy.copy(swap_phase), SwapPhases)
+        assert isinstance(copy.deepcopy(swap_phase), SwapPhases)
 
 
 @pytest.mark.parametrize(
@@ -1126,6 +1204,10 @@ class TestClassicalMove:
         move.right = MemoryReference("new-memory-reference")
         assert move.right == MemoryReference("new-memory-reference")
 
+    def test_copy(self, move: ClassicalMove):
+        assert isinstance(copy.copy(move), ClassicalMove)
+        assert isinstance(copy.deepcopy(move), ClassicalMove)
+
 
 @pytest.mark.parametrize(
     ("left", "right"),
@@ -1149,6 +1231,10 @@ class TestClassicalExchange:
         exchange.right = MemoryReference("new-memory-reference")
         assert exchange.right == MemoryReference("new-memory-reference")
 
+    def test_copy(self, exchange: ClassicalExchange):
+        assert isinstance(copy.copy(exchange), ClassicalExchange)
+        assert isinstance(copy.deepcopy(exchange), ClassicalExchange)
+
 
 @pytest.mark.parametrize(
     ("left", "right"),
@@ -1171,6 +1257,10 @@ class TestClassicalConvert:
         assert convert.right == right
         convert.right = MemoryReference("new-memory-reference")
         assert convert.right == MemoryReference("new-memory-reference")
+
+    def test_copy(self, convert: ClassicalConvert):
+        assert isinstance(copy.copy(convert), ClassicalConvert)
+        assert isinstance(copy.deepcopy(convert), ClassicalConvert)
 
 
 @pytest.mark.parametrize(
@@ -1199,6 +1289,10 @@ class TestClassicalLoad:
         assert load.right == right
         load.right = MemoryReference("new-memory-reference")
         assert load.right == MemoryReference("new-memory-reference")
+
+    def test_copy(self, load: ClassicalLoad):
+        assert isinstance(copy.copy(load), ClassicalLoad)
+        assert isinstance(copy.deepcopy(load), ClassicalLoad)
 
 
 @pytest.mark.parametrize(
@@ -1231,6 +1325,10 @@ class TestClassicalStore:
         assert load.right == right
         load.right = MemoryReference("new-memory-reference")
         assert load.right == MemoryReference("new-memory-reference")
+
+    def test_copy(self, load: ClassicalStore):
+        assert isinstance(copy.copy(load), ClassicalStore)
+        assert isinstance(copy.deepcopy(load), ClassicalStore)
 
 
 @pytest.mark.parametrize(
@@ -1276,6 +1374,10 @@ class TestClassicalComparison:
         comparison.right = MemoryReference("new-memory-reference")
         assert comparison.right == MemoryReference("new-memory-reference")
 
+    def test_copy(self, comparison: ClassicalComparison):
+        assert isinstance(copy.copy(comparison), type(comparison))
+        assert isinstance(copy.deepcopy(comparison), type(comparison))
+
 
 @pytest.mark.parametrize(
     ("op", "target"),
@@ -1299,6 +1401,10 @@ class TestUnaryClassicalInstruction:
         assert unary.target == target
         unary.target = MemoryReference("new-memory-reference")
         assert unary.target == MemoryReference("new-memory-reference")
+
+    def test_copy(self, unary: UnaryClassicalInstruction):
+        assert isinstance(copy.copy(unary), type(unary))
+        assert isinstance(copy.deepcopy(unary), type(unary))
 
 
 @pytest.mark.parametrize(
@@ -1336,6 +1442,10 @@ class TestArithmeticBinaryOp:
         arithmetic.right = 3.14
         assert arithmetic.right == 3.14
 
+    def test_copy(self, arithmetic: ArithmeticBinaryOp):
+        assert isinstance(copy.copy(arithmetic), type(arithmetic))
+        assert isinstance(copy.deepcopy(arithmetic), type(arithmetic))
+
 
 @pytest.mark.parametrize(
     ("op", "left", "right"),
@@ -1366,6 +1476,10 @@ class TestLogicalBinaryOp:
         assert logical.right == right
         logical.right = 3
         assert logical.right == 3
+
+    def test_copy(self, logical: LogicalBinaryOp):
+        assert isinstance(copy.copy(logical), type(logical))
+        assert isinstance(copy.deepcopy(logical), type(logical))
 
 
 def test_include():


### PR DESCRIPTION
## Description

closes #1674 by overriding `__copy__` and `__deepcopy__` on instruction types that subclass an instruction from the `quil` package.

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
