### PR TITLE
docs: Replace deprecated usage of readout_data with get_register_map

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ p += MEASURE(0, ro[0])
 p += MEASURE(1, ro[1])
 p.wrap_in_numshots_loop(10)
 
-qvm.run(p).readout_data['ro'].tolist()
+qvm.run(p).get_register_map()['ro'].tolist()
 ```
 
 The output of the above program should look something like the following,

--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -69,7 +69,7 @@ Below is an example that demonstrates how to use pyQuil in a multithreading scen
 
 
     def run(program: Program):
-        return qc.run(qc.compile(program)).readout_data.get("ro")
+        return qc.run(qc.compile(program)).get_register_map().get("ro")
 
 
     programs = [
@@ -396,7 +396,7 @@ We can run this program a few times to see what we get in the readout register `
     qc = get_qc("2q-qvm")
     branching_prog.wrap_in_numshots_loop(10)
     result = qc.run(branching_prog)
-    print(result.readout_data['test_register'])
+    print(result.get_register_map()['test_register'])
 
 .. testoutput:: control-flow
     :hide:

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -133,7 +133,7 @@ an entangled state between qubits 0 and 1 (that's what the "CNOT" gate does). Fi
 
     # run the program on a QVM
     qc = get_qc('9q-square-qvm')
-    result = qc.run(qc.compile(p)).readout_data.get("ro")
+    result = qc.run(qc.compile(p)).get_register_map().get("ro")
     print(result[0])
     print(result[1])
 
@@ -182,7 +182,7 @@ the terminal windows where your servers are running, you should see output print
 
         with local_forest_runtime():
             qvm = get_qc('9q-square-qvm')
-            bitstrings = qvm.run(qvm.compile(prog)).readout_data.get("ro")
+            bitstrings = qvm.run(qvm.compile(prog)).get_register_map().get("ro")
 
 In the following sections, we'll cover gates, program construction & execution, and go into detail about our Quantum
 Virtual Machine, our QPUs, noise models and more. Let's start with the :ref:`basics`.

--- a/docs/source/introducing_v4.rst
+++ b/docs/source/introducing_v4.rst
@@ -106,7 +106,7 @@ you should use the ``get_raw_readout_data`` method to access the raw data and bu
    result = qc.run(exe)
 
    try:
-        matrix = result.readout_data
+        matrix = result.get_register_map()
     except RegisterMatrixConversionError:
         matrix = process_raw_data(result.get_raw_readout_data())
 

--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -376,7 +376,7 @@ state decays to the :math:`\ket{0}` state.
         p.define_noisy_gate("I", [0], append_damping_to_gate(np.eye(2), damping_per_I))
         p.wrap_in_numshots_loop(trials)
         qc.qam.random_seed = int(num_I)
-        res = qc.run(p).readout_data.get("ro")
+        res = qc.run(p).get_register_map().get("ro")
         results_damping.append([np.mean(res), np.std(res) / np.sqrt(trials)])
 
     results_damping = np.array(results_damping)
@@ -537,7 +537,7 @@ good starting point.**
         p.define_noisy_gate("CZ", [0, 1], corrupted_CZ)
         p.wrap_in_numshots_loop(trials)
         qc.qam.random_seed = jj
-        res = qc.run(p).readout_data.get("ro")
+        res = qc.run(p).get_register_map().get("ro")
         results.append(res)
 
     results = np.array(results)
@@ -706,7 +706,7 @@ gate noise, respectively.
                 MEASURE(0, ("ro", 0)),
                 MEASURE(1, ("ro", 1)),
             ])
-            bitstrings = qc.run(noisy).readout_data.get("ro")
+            bitstrings = qc.run(noisy).get_register_map().get("ro")
 
             # Expectation of Z0 and Z1
             z0, z1 = 1 - 2*np.mean(bitstrings, axis=0)
@@ -1002,7 +1002,7 @@ Example 1: Rabi sequence with noisy readout
             p.define_noisy_readout(0, p00=p00, p11=p00)
             ro = p.declare("ro", "BIT", 1)
             p.measure(0, ro[0])
-            res = qc.run(p).readout_data.get("ro")
+            res = qc.run(p).get_register_map().get("ro")
             results_rabi[jj, kk] = np.sum(res)
 
 .. parsed-literal::
@@ -1149,7 +1149,7 @@ Pauli-Z moments that indicate the qubit correlations are corrupted (and correcte
     )
     ghz_prog.wrap_in_numshots_loop(10000)
     print(ghz_prog)
-    results = qc.run(ghz_prog).readout_data.get("ro")
+    results = qc.run(ghz_prog).get_register_map().get("ro")
 
 .. testoutput:: readout-noise
 
@@ -1167,7 +1167,7 @@ Pauli-Z moments that indicate the qubit correlations are corrupted (and correcte
     noisy_ghz = header + ghz_prog
     noisy_ghz.wrap_in_numshots_loop(10000)
     print(noisy_ghz)
-    noisy_results = qc.run(noisy_ghz).readout_data.get("ro")
+    noisy_results = qc.run(noisy_ghz).get_register_map().get("ro")
 
 .. testoutput:: readout-noise
 
@@ -1374,9 +1374,9 @@ we should always measure ``1``.
 
     qc = get_qc("1q-qvm")
     print("Without Noise:")
-    print(qc.run(p).readout_data.get("ro"))
+    print(qc.run(p).get_register_map().get("ro"))
     print("With Noise:")
-    print(noisy_qc.run(p).readout_data.get("ro"))
+    print(noisy_qc.run(p).get_register_map().get("ro"))
 
 .. testoutput:: global-error
     :hide:

--- a/docs/source/programs_and_gates.rst
+++ b/docs/source/programs_and_gates.rst
@@ -84,7 +84,7 @@ program on the Quantum Virtual Machine (QVM). We just have to add a few lines to
     qc = get_qc('1q-qvm')  # You can make any 'nq-qvm' this way for any reasonable 'n'
     executable = qc.compile(p)
     result = qc.run(executable)
-    bitstrings = result.readout_data.get('ro')
+    bitstrings = result.get_register_map().get('ro')
     print(bitstrings)
 
 Congratulations! You just ran your program on the QVM. The returned value should be:
@@ -310,7 +310,7 @@ filled in for, say, 200 values between :math:`0` and :math:`2\pi`. We demonstrat
         memory_map = {"theta": [theta]}
 
         # Get the results of the run with the value we want to execute with
-        bitstrings = qc.run(executable, memory_map=memory_map).readout_data.get("ro")
+        bitstrings = qc.run(executable, memory_map=memory_map).get_register_map().get("ro")
 
         # Store our results
         parametric_measurements.append(bitstrings)


### PR DESCRIPTION
## Description

closes #1690
## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
