### PR TITLE
Proposal - feat: The Quil constant pi can now be represented directly with the new Pi class

### DIFF
--- a/test/unit/test_expressions.py
+++ b/test/unit/test_expressions.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from pyquil.gates import RX
+from pyquil.quil import Program
+from pyquil.quilatom import Pi
+
+
+class TestPi:
+    def test_print(self):
+        assert str(Pi()) == "pi"
+        expr = Pi() / 2
+        print(type(expr))
+        assert str(expr) == "pi/2"
+
+    def test_program(self):
+        program = Program(RX(Pi(), 0), RX(Pi() / 2, 1))
+        assert program.out() == "RX(pi) 0\nRX(pi/2) 1\n"
+        assert program[0] == RX(Pi(), 0)
+        assert program[1] == RX(Pi() / 2, 1)
+
+    def test_numpy(self):
+        pi_class_matrix = np.asmatrix([[Pi(), Pi() / 2], [Pi() / 3, Pi() / 4]])
+        pi_float_matrix = np.asmatrix([[np.pi, np.pi / 2], [np.pi / 3, np.pi / 4]])
+        assert np.allclose(pi_class_matrix, pi_float_matrix)


### PR DESCRIPTION
## Description

This is an attempt to mitigate the issues in #1664 where parsing a program containing the string `pi` would result in a program containing the Quil constant `pi` but programatically building a program from PyQuil classes containing a float like `np.pi` would result in expressions containing the literal float `3.14...`. This results in what are effectively equivalent programs not being evaluated as such.

My proposal here is to add a new `Pi` class to the expression module that can be used to represent the Quil constant `pi`. As a descendant of the `Expression` class, it can be used as part of most kinds of Python expressions easily.

One limitation is that Python expressions between `Expression` objects result in an `Expression`. This can be problematic in situations where an atomic type is needed. In order to support that, I've added support for casting an `Expression` to an `int`, `float`, or `complex` value is supported. This leans on `quil` to simplify the expression, and will fail if the expression contains any unbound parameters.

Adding casting makes it easier to use `Expression`s in numpy array's, but note that once used inside of an array, the expression will be cast to an atomic value and you will lose information about the expression (e.g. if it is a "pi" constant).

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] (New Feature) The [docs][docs] have been updated accordingly.

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
