### PR TITLE
fix: DefFrame no longer attempts to serialize HARDWARE-OBJECT as json.

### DIFF
--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -151,9 +151,15 @@ class QPUCompiler(AbstractCompiler):
         """
         Get the Quil-T calibration program associated with the underlying QPU.
 
-        This will return a cached copy of the calibration program if present.
+        This will return a cached reference of the calibration program if present.
         Otherwise (or if forcing a refresh), it will fetch and store the
         calibration program from the QCS API.
+
+        Note that the returned program is a reference, meaning if you modify
+        it directly, you will be updating the cached version, and future calls
+        to this function will return your modified reference. If you want to
+        update the program without impacting the cached version, you should
+        make a copy of the returned program using `Program.copy()`
 
         A calibration program contains a number of DEFCAL, DEFWAVEFORM, and
         DEFFRAME instructions. In sum, those instructions describe how a Quil-T

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -17,7 +17,6 @@
 Contains the core pyQuil objects that correspond to Quil instructions.
 """
 import abc
-import json
 
 from typing import (
     Any,
@@ -2693,14 +2692,6 @@ class DefFrame(quil_rs.FrameDefinition, AbstractInstruction):
         enable_raw_capture: Optional[str] = None,
         channel_delay: Optional[float] = None,
     ) -> Self:
-        # The quil spec doesn't outline anything for JSON support
-        # but it can be used for the hardware_object field.
-        # This generates a properly escaped json string
-        # then peels off the outer quotation marks, since they
-        # are already added to string values on output.
-        if hardware_object is not None:
-            hardware_object = json.dumps(hardware_object)
-            hardware_object = hardware_object[1:-1]
         attributes = {
             key: DefFrame._to_attribute_value(value)
             for key, value in zip(

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -532,6 +532,11 @@ class TestDefFrame:
         def_frame.hardware_object = "bfg"
         assert def_frame.hardware_object == "bfg"
 
+    def test_hardware_object(self, def_frame: DefFrame, hardware_object: Optional[str]):
+        assert def_frame.hardware_object == hardware_object
+        def_frame.hardware_object = '{"string": "str", "int": 1, "float": 3.14}'
+        assert def_frame.hardware_object == '{"string": "str", "int": 1, "float": 3.14}'
+
     def test_sample_rate(self, def_frame: DefFrame, sample_rate: Optional[float]):
         assert def_frame.sample_rate == sample_rate
         def_frame.sample_rate = 96.0


### PR DESCRIPTION
## Description

Closes #1711, but still needs a repro case + test.

I also updated the docstring on `get_calibration_program` to warn about potentially surprising behavior with returning a cached reference.

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
