### PR TITLE
fix: Gate instructions specified as tuples no longer error when using a list of parameters.

### DIFF
--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -253,8 +253,6 @@ class Program:
             Program { ... }
             >>> p.inst(H(i) for i in range(4)) # A generator of instructions
             Program { ... }
-            >>> p.inst(("H", 1)) # A tuple representing an instruction
-            Program { ... }
             >>> p.inst("H 0") # A string representing an instruction
             Program { ... }
             >>> q = Program()
@@ -275,6 +273,13 @@ class Program:
             elif isinstance(instruction, types.GeneratorType):
                 self.inst(*instruction)
             elif isinstance(instruction, tuple):
+                warnings.warn(
+                    "Adding instructions to a program by specifying them as tuples is deprecated. Consider building "
+                    "the instruction you need using classes from the `pyquil.gates` or `pyquil.quilbase` modules and "
+                    "passing those to Program.inst() instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
                 if len(instruction) == 0:
                     raise ValueError("tuple should have at least one element")
                 elif len(instruction) == 1:

--- a/pyquil/quil.py
+++ b/pyquil/quil.py
@@ -277,8 +277,24 @@ class Program:
             elif isinstance(instruction, tuple):
                 if len(instruction) == 0:
                     raise ValueError("tuple should have at least one element")
+                elif len(instruction) == 1:
+                    self.inst(instruction[0])
                 else:
-                    self.inst(" ".join(map(str, instruction)))
+                    op = instruction[0]
+                    if op == "MEASURE":
+                        if len(instruction) == 2:
+                            self.measure(instruction[1], None)
+                        else:
+                            self.measure(instruction[1], instruction[2])
+                    else:
+                        params: List[ParameterDesignator] = []
+                        possible_params = instruction[1]
+                        rest: Sequence[Any] = instruction[2:]
+                        if isinstance(possible_params, list):
+                            params = possible_params
+                        else:
+                            rest = [possible_params] + list(rest)
+                        self.gate(op, params, rest)
             elif isinstance(instruction, str):
                 self.inst(RSProgram.parse(instruction.strip()))
             elif isinstance(instruction, Program):

--- a/test/unit/__snapshots__/test_quil.ambr
+++ b/test/unit/__snapshots__/test_quil.ambr
@@ -190,6 +190,18 @@
   
   '''
 # ---
+# name: test_inst_tuple_measure
+  '''
+  MEASURE 0 ro[1]
+  
+  '''
+# ---
+# name: test_inst_tuple_multiple_params
+  '''
+  RX(1.5707963267948966) 0
+  
+  '''
+# ---
 # name: test_kraus
   '''
   X 0

--- a/test/unit/test_quil.py
+++ b/test/unit/test_quil.py
@@ -200,6 +200,20 @@ def test_inst_tuple(snapshot):
     assert p.out() == snapshot
 
 
+def test_inst_tuple_measure(snapshot):
+    p = Program()
+    p.inst(("MEASURE", 0, ("ro", 1)))
+    assert len(p) == 1
+    assert p.out() == snapshot
+
+
+def test_inst_tuple_multiple_params(snapshot):
+    p = Program()
+    p.inst(("RX", [pi / 2], 0))
+    assert len(p) == 1
+    assert p.out() == snapshot
+
+
 def test_inst_rs_gate(snapshot):
     p = Program()
     q = quil_rs.Qubit.from_fixed(0)


### PR DESCRIPTION
## Description

Closes #1700

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
