### PR TITLE
fix: Arithmetic instructions will not raise an error when used in Programs

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -209,6 +209,8 @@ def _convert_to_py_instruction(instr: Any) -> AbstractInstruction:
         if instr.is_wait():
             return Wait()
         return _convert_to_py_instruction(instr.inner())
+    if isinstance(instr, quil_rs.Arithmetic):
+        return ArithmeticBinaryOp._from_rs_arithmetic(instr)
     if isinstance(instr, quil_rs.Capture):
         return Capture._from_rs_capture(instr)
     if isinstance(instr, quil_rs.Calibration):

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -1467,6 +1467,13 @@ class TestArithmeticBinaryOp:
         assert isinstance(copy.copy(arithmetic), type(arithmetic))
         assert isinstance(copy.deepcopy(arithmetic), type(arithmetic))
 
+    def valid_in_program(self, arithmetic):
+        try:
+            p = Program(arithmetic)
+            p[0] == arithmetic
+        except Exception:
+            pytest.fail("ArithmeticBinaryOp not valid in Program")
+
 
 @pytest.mark.parametrize(
     ("op", "left", "right"),


### PR DESCRIPTION
## Description

Closes #1722

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
