### PR TITLE
fix: ResetQubit instructions will not be returned as Reset after being inserted into a Program

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -624,7 +624,10 @@ class ResetQubit(Reset):
 
     @classmethod
     def _from_rs_reset(cls, reset: quil_rs.Reset) -> "ResetQubit":
-        return super().__new__(cls, reset.qubit)
+        if reset.qubit is not None:
+            return ResetQubit.__new__(cls, _convert_to_py_qubit(reset.qubit))
+        else:
+            return ValueError("ResetQubit cannot be created from a quil.Reset without a qubit.")
 
 
 class DefGate(quil_rs.GateDefinition, AbstractInstruction):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -623,7 +623,7 @@ class ResetQubit(Reset):
         return super().__new__(cls, qubit)
 
     @classmethod
-    def _from_rs_reset(cls, reset: quil_rs.Reset) -> "Reset":
+    def _from_rs_reset(cls, reset: quil_rs.Reset) -> "ResetQubit":
         return super().__new__(cls, reset.qubit)
 
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -2414,7 +2414,7 @@ class DelayFrames(Delay):
 
     @classmethod
     def _from_rs_delay(cls, delay: quil_rs.Delay) -> "DelayFrames":
-        return Delay._from_rs_delay.__func__(cls, delay)
+        return Delay._from_rs_delay.__func__(cls, delay)  # type: ignore
 
 
 class DelayQubits(Delay):
@@ -2423,7 +2423,7 @@ class DelayQubits(Delay):
 
     @classmethod
     def _from_rs_delay(cls, delay: quil_rs.Delay) -> "DelayQubits":
-        return Delay._from_rs_delay.__func__(cls, delay)
+        return Delay._from_rs_delay.__func__(cls, delay)  # type: ignore
 
 
 class Fence(quil_rs.Fence, AbstractInstruction):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -218,7 +218,13 @@ def _convert_to_py_instruction(instr: Any) -> AbstractInstruction:
     if isinstance(instr, quil_rs.Declaration):
         return Declare._from_rs_declaration(instr)
     if isinstance(instr, quil_rs.Delay):
-        return Delay._from_rs_delay(instr)
+        print("len(instr.qubits):", len(instr.qubits))
+        print("len(instr.frame_names):", len(instr.frame_names))
+        if len(instr.qubits) > 0 and len(instr.frame_names) > 0:
+            return Delay._from_rs_delay(instr)
+        if len(instr.qubits) > 0:
+            return DelayQubits._from_rs_delay(instr)
+        return DelayFrames._from_rs_delay(instr)
     if isinstance(instr, quil_rs.Fence):
         if len(instr.qubits) == 0:
             return FenceAll()
@@ -2406,10 +2412,18 @@ class DelayFrames(Delay):
     def __new__(cls, frames: List[Frame], duration: float) -> Self:
         return super().__new__(cls, frames, [], duration)
 
+    @classmethod
+    def _from_rs_delay(cls, delay: quil_rs.Delay) -> "DelayFrames":
+        return Delay._from_rs_delay.__func__(cls, delay)
+
 
 class DelayQubits(Delay):
     def __new__(cls, qubits: Sequence[Union[Qubit, FormalArgument]], duration: float) -> Self:
         return super().__new__(cls, [], qubits, duration)
+
+    @classmethod
+    def _from_rs_delay(cls, delay: quil_rs.Delay) -> "DelayQubits":
+        return Delay._from_rs_delay.__func__(cls, delay)
 
 
 class Fence(quil_rs.Fence, AbstractInstruction):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -558,7 +558,7 @@ class Reset(quil_rs.Reset, AbstractInstruction):
     The RESET instruction.
     """
 
-    def __new__(cls, qubit: Optional[Union[Qubit, QubitPlaceholder, FormalArgument]] = None) -> Self:
+    def __new__(cls, qubit: Optional[Union[Qubit, QubitPlaceholder, FormalArgument, int]] = None) -> Self:
         rs_qubit: Optional[quil_rs.Qubit] = None
         if qubit is not None:
             rs_qubit = _convert_to_rs_qubit(qubit)
@@ -617,7 +617,7 @@ class ResetQubit(Reset):
     This is the pyQuil object for a Quil targeted reset instruction.
     """
 
-    def __new__(cls, qubit: Union[Qubit, QubitPlaceholder, FormalArgument]) -> Self:
+    def __new__(cls, qubit: Union[Qubit, QubitPlaceholder, FormalArgument, int]) -> Self:
         if qubit is None:
             raise TypeError("qubit should not be None")
         return super().__new__(cls, qubit)
@@ -625,9 +625,9 @@ class ResetQubit(Reset):
     @classmethod
     def _from_rs_reset(cls, reset: quil_rs.Reset) -> "ResetQubit":
         if reset.qubit is not None:
-            return ResetQubit.__new__(cls, _convert_to_py_qubit(reset.qubit))
-        else:
-            return ValueError("ResetQubit cannot be created from a quil.Reset without a qubit.")
+            qubit = _convert_to_py_qubit(reset.qubit)
+            return ResetQubit.__new__(cls, qubit)
+        raise ValueError("reset.qubit should not be None")
 
 
 class DefGate(quil_rs.GateDefinition, AbstractInstruction):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -238,7 +238,10 @@ def _convert_to_py_instruction(instr: Any) -> AbstractInstruction:
     if isinstance(instr, quil_rs.RawCapture):
         return RawCapture._from_rs_raw_capture(instr)
     if isinstance(instr, quil_rs.Reset):
-        return Reset._from_rs_reset(instr)
+        if instr.qubit is None:
+            return Reset._from_rs_reset(instr)
+        else:
+            return ResetQubit._from_rs_reset(instr)
     if isinstance(instr, quil_rs.CircuitDefinition):
         return DefCircuit._from_rs_circuit_definition(instr)
     if isinstance(instr, quil_rs.GateDefinition):
@@ -618,6 +621,10 @@ class ResetQubit(Reset):
         if qubit is None:
             raise TypeError("qubit should not be None")
         return super().__new__(cls, qubit)
+
+    @classmethod
+    def _from_rs_reset(cls, reset: quil_rs.Reset) -> "Reset":
+        return super().__new__(cls, reset.qubit)
 
 
 class DefGate(quil_rs.GateDefinition, AbstractInstruction):

--- a/test/unit/test_program.py
+++ b/test/unit/test_program.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from pyquil import Program
 from pyquil.quil import AbstractInstruction, Declare, Measurement, MemoryReference
+from pyquil.quilbase import Reset, ResetQubit
 from pyquil.experiment._program import (
     measure_qubits,
     parameterized_single_qubit_measurement_basis,
@@ -139,3 +140,17 @@ SWAP-PHASES 2 3 "xy" 3 4 "xy";
     )
     full_program = non_quil_t_program + quil_t_program
     assert full_program.remove_quil_t_instructions() == non_quil_t_program
+
+
+def test_compatibility_layer():
+    """
+    Test that the compatibility layer that transforms pyQuil instructions to quil instructions works as intended.
+    """
+    # Note: `quil` re-orders some instructions in a program (e.g. by shuffling DECLAREs to the top). This isn't a
+    # problem for the current set of instructions we're testing, but it's something to keep in mind if we add more.
+    instructions = [ResetQubit(0), Reset()]
+    program = Program(instructions)
+    for (original, transformed) in zip(instructions, program):
+        assert isinstance(transformed, AbstractInstruction)
+        assert isinstance(transformed, type(original))
+        assert transformed == original

--- a/test/unit/test_program.py
+++ b/test/unit/test_program.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from pyquil import Program
 from pyquil.quil import AbstractInstruction, Declare, Measurement, MemoryReference
-from pyquil.quilbase import Reset, ResetQubit
+from pyquil.quilbase import Reset, ResetQubit, Delay, DelayFrames, DelayQubits, Frame
 from pyquil.experiment._program import (
     measure_qubits,
     parameterized_single_qubit_measurement_basis,
@@ -148,9 +148,17 @@ def test_compatibility_layer():
     """
     # Note: `quil` re-orders some instructions in a program (e.g. by shuffling DECLAREs to the top). This isn't a
     # problem for the current set of instructions we're testing, but it's something to keep in mind if we add more.
-    instructions = [ResetQubit(0), Reset()]
+    instructions = [
+        ResetQubit(0),
+        Reset(),
+        Delay([Frame([0], "frame")], [0], 0.01),
+        DelayFrames([Frame([], "frame")], 0.01),
+        DelayQubits([0, 1], 0.01),
+    ]
     program = Program(instructions)
     for (original, transformed) in zip(instructions, program):
         assert isinstance(transformed, AbstractInstruction)
+        print("type(transformed):", type(transformed))
+        print("type(original):", type(original))
         assert isinstance(transformed, type(original))
         assert transformed == original


### PR DESCRIPTION
## Description

closes #1726

Thanks to @mac01021 for the report!

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
