### PR TITLE
Add deprecated property to DefFrame for CHANNEL-DELAY attribute

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -2858,6 +2858,22 @@ class DefFrame(quil_rs.FrameDefinition, AbstractInstruction):
     def center_frequency(self, center_frequency: float) -> None:
         self.set_attribute("CENTER-FREQUENCY", center_frequency)
 
+    @property
+    @deprecated(
+        version="4.0",
+        reason="Quil now supports generic key/value pairs in DEFFRAMEs. Use get_attribute('CHANNEL-DELAY') instead.",
+    )
+    def channel_delay(self) -> Frame:
+        return self.get_attribute("CHANNEL-DELAY")  # type: ignore
+
+    @channel_delay.setter
+    @deprecated(
+        version="4.0",
+        reason="Quil now supports generic key/value pairs in DEFFRAMEs. Use set_attribute('CHANNEL-DELAY') instead.",
+    )
+    def channel_delay(self, channel_delay: float) -> None:
+        self.set_attribute("CHANNEL-DELAY", channel_delay)
+
     def __copy__(self) -> Self:
         return self
 

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -196,6 +196,7 @@
 # name: TestDefFrame.test_out[With-Optionals].1
   set({
     '\tCENTER-FREQUENCY: 440',
+    '\tCHANNEL-DELAY: 0',
     '\tDIRECTION: "direction"',
     '\tHARDWARE-OBJECT: "hardware_object"',
     '\tINITIAL-FREQUENCY: 1.39',
@@ -215,6 +216,7 @@
 # name: TestDefFrame.test_str[With-Optionals].1
   set({
     '\tCENTER-FREQUENCY: 440',
+    '\tCHANNEL-DELAY: 0',
     '\tDIRECTION: "direction"',
     '\tHARDWARE-OBJECT: "hardware_object"',
     '\tINITIAL-FREQUENCY: 1.39',

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -493,10 +493,15 @@ class TestDefFrame:
         center_frequency: Optional[float],
         channel_delay: Optional[float],
     ) -> DefFrame:
-        optional_args = {k: v
-                         for k, v in locals().items()
-                         if k not in ["self", "frame"] and v is not None}
-        return DefFrame(frame, **optional_args)
+        args = dict(
+            direction=direction,
+            initial_frequency=initial_frequency,
+            hardware_object=hardware_object,
+            sample_rate=sample_rate,
+            center_frequency=center_frequency,
+            channel_delay=channel_delay,
+        )
+        return DefFrame(frame, **{k: v for k, v in args.items() if v is not None})
 
     def test_out(self, def_frame: DefFrame, snapshot: SnapshotAssertion):
         # The ordering of attributes isn't stable and can be printed in different orders across calls.

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -495,17 +495,7 @@ class TestDefFrame:
     ) -> DefFrame:
         optional_args = {k: v
                          for k, v in locals().items()
-                         if k not in["self", "frame"] and v is not None}
-        # optional_args = [
-        #     arg
-        #     for arg in [direction,
-        #                 initial_frequency,
-        #                 hardware_object,
-        #                 sample_rate,
-        #                 center_frequency,
-        #                 channel_delay]:
-        #     if arg is not None
-        # ]
+                         if k not in ["self", "frame"] and v is not None}
         return DefFrame(frame, **optional_args)
 
     def test_out(self, def_frame: DefFrame, snapshot: SnapshotAssertion):
@@ -518,7 +508,6 @@ class TestDefFrame:
 
     def test_str(self, def_frame: DefFrame, snapshot: SnapshotAssertion):
         quil_lines = str(def_frame).splitlines()
-        print(quil_lines)
         assert quil_lines[0] == snapshot
         assert set(quil_lines[1:]) == snapshot
 


### PR DESCRIPTION
## Description

v4 has added deprecated attribute properties for all the standard defframe attributes, except for CHANNEL-DELAY.  I have a bunch of call sites in my v3 codebase that use this attribute and engineers like to benefit from autocompletion in their IDE when accessing channel delays.  So here is a PR that adds the missing property.


## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
