### PR TITLE
fix: Compatibility layer will prefer to return `DelayFrames`, then `DelayQubits`, then `Delay`.

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -218,13 +218,11 @@ def _convert_to_py_instruction(instr: Any) -> AbstractInstruction:
     if isinstance(instr, quil_rs.Declaration):
         return Declare._from_rs_declaration(instr)
     if isinstance(instr, quil_rs.Delay):
-        print("len(instr.qubits):", len(instr.qubits))
-        print("len(instr.frame_names):", len(instr.frame_names))
-        if len(instr.qubits) > 0 and len(instr.frame_names) > 0:
-            return Delay._from_rs_delay(instr)
+        if len(instr.frame_names) > 0:
+            return DelayFrames._from_rs_delay(instr)
         if len(instr.qubits) > 0:
             return DelayQubits._from_rs_delay(instr)
-        return DelayFrames._from_rs_delay(instr)
+        return Delay._from_rs_delay(instr)
     if isinstance(instr, quil_rs.Fence):
         if len(instr.qubits) == 0:
             return FenceAll()


### PR DESCRIPTION
## Description

Insert your PR description here. Thanks for [contributing][contributing] to pyQuil! 🙂

## Checklist

- [ ] The PR targets the `master` branch
- [ ] The above description motivates these changes.
- [ ] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [ ] All changes to code are covered via unit tests.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
