### PR TITLE
fix: CompilerISA.dict() now uses the correct default field names: qubits and edges

### DIFF
--- a/pyquil/external/rpcq.py
+++ b/pyquil/external/rpcq.py
@@ -220,18 +220,18 @@ class CompilerISA:
     qubits: Dict[str, Qubit] = field(default_factory=dict)
     edges: Dict[str, Edge] = field(default_factory=dict)
 
-    def _dict(self) -> Dict[str, JsonValue]:
+    def _dict(self, by_alias=False) -> Dict[str, JsonValue]:
         return {
-            "1Q": {k: q._dict() for k, q in self.qubits.items()},
-            "2Q": {k: e._dict() for k, e in self.edges.items()},
+            "1Q" if by_alias else "qubits": {k: q._dict() for k, q in self.qubits.items()},
+            "2Q" if by_alias else "edges": {k: e._dict() for k, e in self.edges.items()},
         }
 
     @deprecated(
         version="4.6.2",
         reason="No longer requires serialization of RPCQ objects and is dropping Pydantic as a dependency.",  # noqa: E501
     )
-    def dict(self):
-        return self._dict()
+    def dict(self, by_alias=False):
+        return self._dict(by_alias=by_alias)
 
     @classmethod
     def _parse_obj(cls, dictionary: Dict):
@@ -288,7 +288,7 @@ def get_edge(quantum_processor: CompilerISA, qubit1: int, qubit2: int) -> Option
 
 
 def compiler_isa_to_target_quantum_processor(compiler_isa: CompilerISA) -> TargetQuantumProcessor:
-    return TargetQuantumProcessor(isa=compiler_isa._dict(), specs={})
+    return TargetQuantumProcessor(isa=compiler_isa.dict(by_alias=True), specs={})
 
 
 class Supported1QGate:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,7 +8,7 @@ build:
     post_create_environment:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
-      - pip install poetry 'sphinx-rtd-theme==1.3.0'
+      - pip install 'poetry==1.6.1'
       # Tell poetry to not use a virtual environment
       - poetry config virtualenvs.create false
     post_install:

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,13 +8,13 @@ build:
     post_create_environment:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
-      - pip install poetry
+      - pip install poetry 'sphinx-rtd-theme==1.3.0'
       # Tell poetry to not use a virtual environment
       - poetry config virtualenvs.create false
     post_install:
       # Install dependencies with 'docs' dependency group
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install --with docs --with latex
+      - poetry install --extras docs --extras latex
 
 sphinx:
   configuration: docs/source/conf.py

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -14,7 +14,7 @@ build:
     post_install:
       # Install dependencies with 'docs' dependency group
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install --extras docs --extras latex
+      - poetry install --with docs --with latex
 
 sphinx:
   configuration: docs/source/conf.py

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -19,7 +19,7 @@ def test_isa_from_graph_order():
     # representation will have it as (16,15)
     fc = nx.from_edgelist([(16, 17), (15, 16)])
     isa = graph_to_compiler_isa(fc)
-    isad = isa.dict()
+    isad = isa.dict(by_alias=True)
     for k in isad["2Q"]:
         q1, q2 = k.split("-")
         assert q1 < q2


### PR DESCRIPTION
## Description

closes #1745

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
