### PR TITLE
fix: The imaginary part of a complex number is no longer moved incorrectly to the outside of a binary expression.

### DIFF
--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -792,7 +792,9 @@ def _expression_to_string(expression: ExpressionDesignator) -> str:
         # If op2 is a float, it will maybe represented as a multiple
         # of pi in right. If that is the case, then we need to take
         # extra care to insert parens. See gh-943.
-        elif isinstance(expression.op2, float) and (("pi" in right and right != "pi")):
+        elif (isinstance(expression.op2, float) and (("pi" in right and right != "pi"))) or isinstance(
+            expression.op2, complex
+        ):
             right = "(" + right + ")"
 
         return left + expression.operator + right

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -792,7 +792,7 @@ def _expression_to_string(expression: ExpressionDesignator) -> str:
         # If op2 is a float, it will maybe represented as a multiple
         # of pi in right. If that is the case, then we need to take
         # extra care to insert parens. Similarly, complex numbers need
-        # to be wrapped in params so the imaginary part is captured.
+        # to be wrapped in parens so the imaginary part is captured.
         # See gh-943,1734.
         elif (isinstance(expression.op2, float) and (("pi" in right and right != "pi"))) or isinstance(
             expression.op2, complex

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -791,7 +791,9 @@ def _expression_to_string(expression: ExpressionDesignator) -> str:
             right = "(" + right + ")"
         # If op2 is a float, it will maybe represented as a multiple
         # of pi in right. If that is the case, then we need to take
-        # extra care to insert parens. See gh-943.
+        # extra care to insert parens. Similarly, complex numbers need
+        # to be wrapped in params so the imaginary part is captured.
+        # See gh-943,1734.
         elif (isinstance(expression.op2, float) and (("pi" in right and right != "pi"))) or isinstance(
             expression.op2, complex
         ):

--- a/test/unit/test_parameters.py
+++ b/test/unit/test_parameters.py
@@ -65,12 +65,15 @@ def test_expression_to_string():
     assert str((x + y) - 2) == "%x + %y - 2"
     assert str(x + (y - 2)) == "%x + %y - 2"
 
-    assert str(x ** y ** 2) == "%x^%y^2"
-    assert str(x ** (y ** 2)) == "%x^%y^2"
-    assert str((x ** y) ** 2) == "(%x^%y)^2"
+    assert str(x**y**2) == "%x^%y^2"
+    assert str(x ** (y**2)) == "%x^%y^2"
+    assert str((x**y) ** 2) == "(%x^%y)^2"
 
     assert str(quil_sin(x)) == "SIN(%x)"
     assert str(3 * quil_sin(x + y)) == "3*SIN(%x + %y)"
+    assert (
+        str(quil_exp(-1j * x / 2) * np.exp(1j * np.pi / 4)) == "EXP(-i*%x/2)*(0.7071067811865476+0.7071067811865475i)"
+    )
 
 
 def test_contained_parameters():
@@ -80,7 +83,7 @@ def test_contained_parameters():
     y = Parameter("y")
     assert _contained_parameters(x + y) == {x, y}
 
-    assert _contained_parameters(x ** y ** quil_sin(x * y * 4)) == {x, y}
+    assert _contained_parameters(x**y ** quil_sin(x * y * 4)) == {x, y}
 
 
 def test_eval():
@@ -93,7 +96,7 @@ def test_eval():
     assert substitute(quil_exp(x), {y: 5}) != np.exp(5)
     assert substitute(quil_exp(x), {x: 5}) == np.exp(5)
 
-    assert np.isclose(substitute(quil_sin(x * x ** 2 / y), {x: 5.0, y: 10.0}), np.sin(12.5))
+    assert np.isclose(substitute(quil_sin(x * x**2 / y), {x: 5.0, y: 10.0}), np.sin(12.5))
     assert np.isclose(substitute(quil_sqrt(x), {x: 5.0, y: 10.0}), np.sqrt(5.0))
     assert np.isclose(substitute(quil_cis(x), {x: 5.0, y: 10.0}), np.exp(1j * 5.0))
     assert np.isclose(substitute(x - y, {x: 5.0, y: 10.0}), -5.0)

--- a/test/unit/test_rewrite_arithmetic.py
+++ b/test/unit/test_rewrite_arithmetic.py
@@ -36,7 +36,7 @@ def test_rewrite_arithmetic_duplicate_exprs():
 
     assert response == RewriteArithmeticResponse(
         original_memory_descriptors={"theta": ParameterSpec(length=1, type="REAL")},
-        recalculation_table={ParameterAref(index=0, name="__P1"): "theta[0]*1.5/(2*pi)"},
+        recalculation_table={ParameterAref(index=0, name="__P1"): "theta[0]*(1.5)/(2*pi)"},
         quil=Program("DECLARE __P1 REAL[1]", "DECLARE theta REAL[1]", "RZ(__P1[0]) 0", "RX(__P1[0]) 0").out(),
     )
 


### PR DESCRIPTION
## Description

Fixes #1734

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
