### PR TITLE
fix: Expression arithmetic does not error when a numpy type is on the left hand side.

### DIFF
--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -578,9 +578,9 @@ class Expression(object):
                 return np.asarray(self._evaluate(), dtype=dtype)
             raise ValueError
         except ValueError:
-            # Note: The `None` here is a placeholder for the expression in the numpy array.
-            # The expression instance will still be accessible in the array.
-            return np.array(None, dtype=object)
+            array = np.asarray(None, dtype=object)
+            array.flat[0] = self
+            return array
 
 
 ParameterSubstitutionsMapDesignator = Mapping[Union["Parameter", "MemoryReference"], ExpressionValueDesignator]

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -578,6 +578,8 @@ class Expression(object):
                 return np.asarray(self._evaluate(), dtype=dtype)
             raise ValueError
         except ValueError:
+            # np.asarray(self, ...) would cause an infinite recursion error, so we build the array with a
+            # placeholder value, then replace it with self after.
             array = np.asarray(None, dtype=object)
             array.flat[0] = self
             return array

--- a/test/unit/test_quilatom.py
+++ b/test/unit/test_quilatom.py
@@ -1,8 +1,10 @@
 from typing import Sequence, Union
+
 import pytest
 from syrupy.assertion import SnapshotAssertion
+import numpy as np
 
-from pyquil.quilatom import FormalArgument, Frame, Qubit, Label, LabelPlaceholder, QubitPlaceholder
+from pyquil.quilatom import Add, FormalArgument, Frame, Qubit, Label, LabelPlaceholder, QubitPlaceholder, Parameter
 
 
 @pytest.mark.parametrize(
@@ -69,3 +71,9 @@ def test_qubit_placeholder():
         register[0].out()
 
     assert register[0] != register[1]
+
+
+def test_arithmetic_with_numpy():
+    x = Parameter("x")
+    expression = np.float_(1.0) + x
+    assert expression == Add(np.float_(1.0), x)


### PR DESCRIPTION
closes #1768