### PR TITLE
feat: allow client to be passed in to get qulit calibrations

### DIFF
--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -122,7 +122,7 @@ class QPUCompiler(AbstractCompiler):
             num_shots=nq_program.num_shots,
             quantum_processor_id=self.quantum_processor_id,
             translation_options=api_options or self.api_options,
-	    client=self._client_configuration,
+            client=self._client_configuration,
         )
 
         ro_sources = translated_program.ro_sources or {}

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -135,6 +135,7 @@ class QPUCompiler(AbstractCompiler):
     def _fetch_calibration_program(self) -> Program:
         response = get_quilt_calibrations(
             quantum_processor_id=self.quantum_processor_id,
+            client=self.client_configuration,
         )
         return Program(response)
 

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -135,7 +135,7 @@ class QPUCompiler(AbstractCompiler):
     def _fetch_calibration_program(self) -> Program:
         response = get_quilt_calibrations(
             quantum_processor_id=self.quantum_processor_id,
-            client=self.client_configuration,
+            client=self._client_configuration,
         )
         return Program(response)
 

--- a/pyquil/api/_compiler.py
+++ b/pyquil/api/_compiler.py
@@ -122,6 +122,7 @@ class QPUCompiler(AbstractCompiler):
             num_shots=nq_program.num_shots,
             quantum_processor_id=self.quantum_processor_id,
             translation_options=api_options or self.api_options,
+	    client=self._client_configuration,
         )
 
         ro_sources = translated_program.ro_sources or {}


### PR DESCRIPTION
## Description

In the case, of a user making calls from the SDK, there will be a missing client for accessing calibration data. The gRPC requests will fail.

Looking at usage of the qcs-sdk without the client passed in: https://github.com/search?q=repo%3Arigetti%2Fpyquil%20qcs_sdk&type=code

Adding in the client that is passed in to the object (or None as this is optional).

## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
