### PR TITLE
feat: Instruction classes and execution results now support the pickle module

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2329,65 +2329,65 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qcs-sdk-python"
-version = "0.19.1"
+version = "0.19.2"
 description = "Python interface for the QCS Rust SDK"
 optional = false
 python-versions = "*"
 files = [
-    {file = "qcs_sdk_python-0.19.1-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:934f00d9b970788b54bf4b0db5136e85688ff1f5745c44de18b272af3697f230"},
-    {file = "qcs_sdk_python-0.19.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:6c6752a14e7698d6b25dffa86f6a3c7cd6f006b9a21d1e31dde1796dfc713578"},
-    {file = "qcs_sdk_python-0.19.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:722594274b1ffb00d93a23e681db16f0180b806ead93c35556a07cba75272d0e"},
-    {file = "qcs_sdk_python-0.19.1-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ab53c9d908caccac89e23c435ee5d20c8a58c7492e5353181332db38cefc218d"},
-    {file = "qcs_sdk_python-0.19.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1159ffcecdfabae92fb17dd9af6d674dc53c196eebd9ebca71e076811b5e5e2a"},
-    {file = "qcs_sdk_python-0.19.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:764409d166ab3a6bfeb572bdfaa3fd7e64a94b623a2b1737bb04487a1e7e48ee"},
-    {file = "qcs_sdk_python-0.19.1-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d453ebfb6a3f028c08ce02409d9133b9756f46873a4fc65787ff6f71b95a26a8"},
-    {file = "qcs_sdk_python-0.19.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:eb946cfe2fb8aad5e023057c0bf035a3d9945c531cc3402b1c6ea85345896df4"},
-    {file = "qcs_sdk_python-0.19.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ee38542ce9c86616ace58164ffde734070497673286bb1865edb52ed5b86c038"},
-    {file = "qcs_sdk_python-0.19.1-cp38-cp38-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d7e6a171d39a5e679d284522a654e5585f1eacc06969f7f9b7c633c86b7d7275"},
-    {file = "qcs_sdk_python-0.19.1-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:e7c3e79c53c532af95c8c97c61cd59b7b321229b01c940eb7e02a48908367165"},
-    {file = "qcs_sdk_python-0.19.1-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:fcf8548a832fd7b8c9f5141d920c21890477b6495d2e85416745a97e71a34965"},
-    {file = "qcs_sdk_python-0.19.1-cp39-cp39-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8cb4ddf19d68c2ad3932826d674db0a23f1ce716594b9b8965e7dc787bb81838"},
-    {file = "qcs_sdk_python-0.19.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:2efdc54ed2894a55a73e6a5971a62c70e2b62b7b2bd5be5316c384eb3075f41e"},
-    {file = "qcs_sdk_python-0.19.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:4450a461a74ee469e3549f38daaf5b4bc692f2d60e15becaced76a7f3813b3b3"},
-    {file = "qcs_sdk_python-0.19.1.tar.gz", hash = "sha256:0011f13aa3f053e5e2c5eb8f5533481fe83ee5ce9eb98f747952ff5e01be6518"},
+    {file = "qcs_sdk_python-0.19.2-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:9ee89af75d0d0a250683ff229c9c9f8358e499719087284a1febe3bcc0e4ba1b"},
+    {file = "qcs_sdk_python-0.19.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:59649a5b7749dfa4d73bad557d0583f426b523874d3e59a507f5ca95b1b22471"},
+    {file = "qcs_sdk_python-0.19.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c16aa92a9e629c3e564f42d72905f47c74fdeec7beaa1f3e0b0b5b4580737eb9"},
+    {file = "qcs_sdk_python-0.19.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:391112537398d972ba1f99e842245bd5f1b48e4ed3fd4d2bf433553544e23ddd"},
+    {file = "qcs_sdk_python-0.19.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:98d3216b5abc803c182b96908d08c81f127c8c25b0641c7c47c890945dbe67b4"},
+    {file = "qcs_sdk_python-0.19.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0b91527b5b4afe8097a8ba4a7553d1f4cb66881989c7aecbf3c77e7306529845"},
+    {file = "qcs_sdk_python-0.19.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f6c2566263f763f34c8788d45f6ae5c9e66ce1d499e8893fed5cdb7e92f81037"},
+    {file = "qcs_sdk_python-0.19.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ade3dc05dbb40d46188a053e22017a9c3ca19c4966b6683610f5a92edbbf1ee8"},
+    {file = "qcs_sdk_python-0.19.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f4a73a97579ae01af6028a3fe2b4cb8bccde586aa8a8105147854a881c799530"},
+    {file = "qcs_sdk_python-0.19.2-cp38-cp38-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:837069d3556ccacb48489ba25387e120acd085cacb0d02cd83bf7eaccf2f015f"},
+    {file = "qcs_sdk_python-0.19.2-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:8d6694b5c2d9f07d8017cde0952ccd4ba5156e3ccfd2caa1b06890c40f74f5e8"},
+    {file = "qcs_sdk_python-0.19.2-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:544117335e69f609c05eb2e0d49c513ad1483bcb4bae29988720ed9e0d7cafa3"},
+    {file = "qcs_sdk_python-0.19.2-cp39-cp39-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b6e84c5c91f7a4e42b9be725b94479f5ed5358ffbb9a9780e041b3474e825138"},
+    {file = "qcs_sdk_python-0.19.2-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:7fb40e7d2a74ac0d5d09ce556a70a7e00460f3959404a8c84f16aef2afb62b12"},
+    {file = "qcs_sdk_python-0.19.2-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:c557b1beb86cf3c187fbcedef4e13fb7e4d9d745f9f60a6f742f4cdbf40efdc4"},
+    {file = "qcs_sdk_python-0.19.2.tar.gz", hash = "sha256:1afee795886088966ccf47d2f08e92ca9ee67e638d19b5e874beb20a8ed94662"},
 ]
 
 [package.dependencies]
-quil = "0.11.1"
+quil = ">=0.11.2"
 
 [[package]]
 name = "quil"
-version = "0.11.1"
+version = "0.11.2"
 description = "A Python package for building and parsing Quil programs."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "quil-0.11.1-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:397fd676a3946d76b98c673e8a1dd281b4052c22f347a5928f4a9a93eb54a510"},
-    {file = "quil-0.11.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15bf71d0a7dc2499855c788131ad9a8dd31e89c46d01c92cc703a50879194217"},
-    {file = "quil-0.11.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a93289bff611a216efa5513167b16c16fd0673cfd62678cfb95df91cf4120388"},
-    {file = "quil-0.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4378c3d6c3c11ef2cbee19c3fb4f1af14138ed9947cf685adeaa88fa6e66c267"},
-    {file = "quil-0.11.1-cp310-none-win_amd64.whl", hash = "sha256:4eecab258ea9d3411914a7b5c6a9afcb6a1e21fb44885c658eaa65af778ea7a4"},
-    {file = "quil-0.11.1-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a1d3ed58f02dc9476d890a57d5ef380bb2c17fe41dcd3c70c1df1b0ff01462f3"},
-    {file = "quil-0.11.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22655ae044c43a504d8cb7ad4409b95cedfd75b3fd1fad95aca14658a491ea03"},
-    {file = "quil-0.11.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db0dd6e8ee384d139f0bf47e0d28d55a8599517c870088f6ff84651a47ec1198"},
-    {file = "quil-0.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:998f5148222023a4e98f6eb4f2d1d561242b0c7598cd206bcab210aa7b8e8a88"},
-    {file = "quil-0.11.1-cp311-none-win_amd64.whl", hash = "sha256:a9d322f26830fb0806d779f36eb507dd6e50365537f36b6da3519401b6b63047"},
-    {file = "quil-0.11.1-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c4ed45812c4bc818765b8d8dfd303831ba04efd1ec18853da113763ac52914a5"},
-    {file = "quil-0.11.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:05ee5bea0bd57f898a30448c0268e9f1dab5572a70bf347f575062269565193b"},
-    {file = "quil-0.11.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:467a0418bba805c10ff991e5d874feb4bc49a038b1015f398a55564c93967e19"},
-    {file = "quil-0.11.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54687ab9294c11eb0648e852dd34609d52e1719d18362a730ce851e0a366b2d8"},
-    {file = "quil-0.11.1-cp312-none-win_amd64.whl", hash = "sha256:51da4347405292edf351a7a9acb1327ed8dc2f8fb8bb47023c3f891867b74e05"},
-    {file = "quil-0.11.1-cp38-cp38-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:54bad853268718fd1430cb2f3d6f4855370bf419638b19f2060b4b50aaee8c9f"},
-    {file = "quil-0.11.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d3fbd771233b370e471066485820ecbae078f00293b9a5a6d45c08e1474190d"},
-    {file = "quil-0.11.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:49dca9948eb8d3d679a481c7bdb205cb9848f1c72a0ce253dc3984f7475d5afe"},
-    {file = "quil-0.11.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6de60319afd900db87619e27f8054e2891b8a0f25d1fbc0a760c3b52558fb1e3"},
-    {file = "quil-0.11.1-cp38-none-win_amd64.whl", hash = "sha256:7b805b458eed60a26274c70285d3144181d6674bdc7cd74955a2f50362d3d8e4"},
-    {file = "quil-0.11.1-cp39-cp39-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b6d41dac57443a81646677256aedbf4424025504f4b8fd4e92599b4c52e2f68d"},
-    {file = "quil-0.11.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eaced80dc057f1b84f471d629fde09219c539386381aa197b90fa18548be2f0c"},
-    {file = "quil-0.11.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:83c810e10021ae48dca3cf66dc77e0f9703094368a108963ad9469183322c6d2"},
-    {file = "quil-0.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f3579a8ce44fccef1b1735b4e7d3c34bc0588cc47a0cebdd26669884bcfd565"},
-    {file = "quil-0.11.1-cp39-none-win_amd64.whl", hash = "sha256:e53e68eac8c14914934dfd9cd97cdfb4fd4a802204b7af7f924c456cfdd7e865"},
-    {file = "quil-0.11.1.tar.gz", hash = "sha256:2d4ac702fb61c71c2ed325ea74b236a2a46cee81778582f4b3f5014bfb7839ff"},
+    {file = "quil-0.11.2-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c67cfef64b08d9573e68af74a6464ae2c2c79dc6f85f862a8ad5fa459a863bcb"},
+    {file = "quil-0.11.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dac844c5c7647f04aba2f910ae10ea946ece3a2ee76c069381428218cd743f08"},
+    {file = "quil-0.11.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ec0fd13ff33155ce92f0592ea42ae8bfaede81c9ff9bd18ca0ef4bd72942ec2"},
+    {file = "quil-0.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa58dcea32e7d63d86a9d46fbc2e2045543b50f37e1104b4565e7f005e922144"},
+    {file = "quil-0.11.2-cp310-none-win_amd64.whl", hash = "sha256:796b65cac09e2d200cf78b32df90a7940f91c9491eddca9cb143f6779ce13c77"},
+    {file = "quil-0.11.2-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:46b8f69cffa60bf4d12e81f2cee140a8ed83e9ede42e7fa54143e65c3346e77b"},
+    {file = "quil-0.11.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0173237228f294aa9b0bd546a5a5b1f924eba9378757656bbc4a432c4d56a7e7"},
+    {file = "quil-0.11.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5be4c4c5a5f65f9e222d1fbe2eee36e68c445811b6bd70ffd9b9232d285c8a9d"},
+    {file = "quil-0.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27fd14fda79d9b5706686967618983e6439666b06099258fd26bc16a3eaf28d5"},
+    {file = "quil-0.11.2-cp311-none-win_amd64.whl", hash = "sha256:fc2c291a560712122ba3a78682f39b5198e9c2e534851feb7908fabf23405ccb"},
+    {file = "quil-0.11.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8fc1e8c2f45eae60aa568e792f0dd29d8725065ee6ba4ae22d388e9e43a00000"},
+    {file = "quil-0.11.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16af6b0d77eead291fb350cc1a49a933acfe11cf68c4c70710a9e65a1244a1d7"},
+    {file = "quil-0.11.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:19d6f838afd8b2fb342418fb78bc6b9f202ceccc8e74a7c2f29b98690e48ba11"},
+    {file = "quil-0.11.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e272dba4221476eeeae0ad970a5943dfcc496f81315113500b748be53e889b3"},
+    {file = "quil-0.11.2-cp312-none-win_amd64.whl", hash = "sha256:a0c10463fa66f30c3adcca513ea993edd8275691360d0be2cf014929df50c6fd"},
+    {file = "quil-0.11.2-cp38-cp38-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bbdd481e6e8d64f3ec3f8dccb89f3eaaa720af7e5f153bfb4597db71cdec951e"},
+    {file = "quil-0.11.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3b8a7ceba2adf11d464b6230dd2f52f70db8bc1e71e661d767a80e3f20bb703"},
+    {file = "quil-0.11.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af5796d6c7af9d794d7b858ad724be7cec945d9423dfb28f892c8ea3ff7dd171"},
+    {file = "quil-0.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1e97f06da1f195bea57b846f7ffedc741d11e2be279afb055b4a26afab8c59c"},
+    {file = "quil-0.11.2-cp38-none-win_amd64.whl", hash = "sha256:abe348f8a412b7f3ab7aea92d3b0e61bda731610d05665360dff9f81186d9fa0"},
+    {file = "quil-0.11.2-cp39-cp39-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3ecd211c30421ba5a8788fc2fcda4b516134b8a7d91b0b85b32f6718504bd48d"},
+    {file = "quil-0.11.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8a18e8c2d19fa71cd2c4dc3a489243679194ccc72771a5740306156b922a2b1"},
+    {file = "quil-0.11.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45721a856cc25126fe56742f65739898fff75a1cdd5b9a098efd1012b10a810a"},
+    {file = "quil-0.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2395f6fb88a2f616f15e7d4117e42fe8ca0e831eb5065d45f3e716cdfd6a3538"},
+    {file = "quil-0.11.2-cp39-none-win_amd64.whl", hash = "sha256:7fd216304f0c410df684779d6dc2c9195aac3b5f2c2f3fde752006883f07042c"},
+    {file = "quil-0.11.2.tar.gz", hash = "sha256:499d0db8c99b4cd677268801bca4e1d5662273331917e685986d70d1933399e8"},
 ]
 
 [[package]]
@@ -3228,5 +3228,5 @@ latex = ["ipython"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9,<=3.14"
-content-hash = "f3370d469c74591f16b1c59d9584b6e8b78764028a864fa80155c653d55316fb"
+python-versions = "^3.9,<=4.0"
+content-hash = "62f0ea1397c5edbf592d8a10a4f1b8053a4bf6a02738fd419bb464b25282c295"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2329,70 +2329,65 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qcs-sdk-python"
-version = "0.19.0"
+version = "0.19.1"
 description = "Python interface for the QCS Rust SDK"
 optional = false
 python-versions = "*"
 files = [
-    {file = "qcs_sdk_python-0.19.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:905efe920ffba6d2f280a1f540a0ab757f9aacbc0687c2687f0d264c45a83425"},
-    {file = "qcs_sdk_python-0.19.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b59d4a132aa156278b4a9134550c9937c259e720bba5dab969ab390494af66ca"},
-    {file = "qcs_sdk_python-0.19.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:d837f30921a76a5be9e8c218a88505e0491898a47877a694573ff99b587ffae2"},
-    {file = "qcs_sdk_python-0.19.0-cp310-none-win_amd64.whl", hash = "sha256:3cc299f005faf5f7ac33ed875a236083363ab794affe5a07fb28fee0e1978b62"},
-    {file = "qcs_sdk_python-0.19.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:96de5c498a53627226caa3a0517577d437b264df09cf945a5b8447928431ecfa"},
-    {file = "qcs_sdk_python-0.19.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f5b9b3ac65dea75455f229cbd2a11eb099c6cc78a0b8da69a6777274eb3aee2e"},
-    {file = "qcs_sdk_python-0.19.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:3bec84ee190d43d6901bed6bf0e9cb20ed15110d6eb67ae05bb613190cace6ac"},
-    {file = "qcs_sdk_python-0.19.0-cp311-none-win_amd64.whl", hash = "sha256:b35bc064bcc3fb5af33c067c4abbb038a1cbfbb52e5799acb17c032e8be3ef29"},
-    {file = "qcs_sdk_python-0.19.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ebf1c5a644e155cc73485c733d3d43e3efbbba15400c7334c45c1032cee88404"},
-    {file = "qcs_sdk_python-0.19.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:da788dab8189e494aa32e4128783931a6a6d9ed62d3ccbf0c71a066bb96b84ba"},
-    {file = "qcs_sdk_python-0.19.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:810035586ae0087d1148ae7b6d318ca72f79eca06a9293e89370d0aea73fa005"},
-    {file = "qcs_sdk_python-0.19.0-cp312-none-win_amd64.whl", hash = "sha256:02d0972becd3729b26071e3aac29edaf309452ff8fbb8482f237b7e5cfec09bb"},
-    {file = "qcs_sdk_python-0.19.0-cp38-cp38-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b39e141dcacac250deece9e1bdd3d31df33ec2f8800be967f7c512a9021ed806"},
-    {file = "qcs_sdk_python-0.19.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:9f9742dba08c03c8ccbc94aa821a0b5b5a6b7e2a998b45fcb1e5ade94c4cb200"},
-    {file = "qcs_sdk_python-0.19.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:7977c3dcf08f2d9a576267166cf1ead0587d55150f93120bc82da0427bdd6803"},
-    {file = "qcs_sdk_python-0.19.0-cp38-none-win_amd64.whl", hash = "sha256:b47d42855225572e80b390098693e6482439babb064967a8b5d2f1b4ca24f80a"},
-    {file = "qcs_sdk_python-0.19.0-cp39-cp39-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c2f7ba94b2c1b102ab44de42efdd16090bfdbdc685b6feb4e215448d3c45dc8c"},
-    {file = "qcs_sdk_python-0.19.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:db903603300fa54e76ee657035dacf2c63615f550dae5afdeff904813b36007f"},
-    {file = "qcs_sdk_python-0.19.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:b78d2d63a3f98dafcaed8b4f38643277d910ca263b8065cdd06b9f3786f0fc47"},
-    {file = "qcs_sdk_python-0.19.0-cp39-none-win_amd64.whl", hash = "sha256:cef2b013093a200bde0760f4550ee774b0588ec423b5a8aa3e534d38017ff438"},
-    {file = "qcs_sdk_python-0.19.0.tar.gz", hash = "sha256:a8ddc9a906947d9a93060bf9eb82dfa57720236d9fad8b00e307dd3020ea4ae5"},
+    {file = "qcs_sdk_python-0.19.1-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:934f00d9b970788b54bf4b0db5136e85688ff1f5745c44de18b272af3697f230"},
+    {file = "qcs_sdk_python-0.19.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:6c6752a14e7698d6b25dffa86f6a3c7cd6f006b9a21d1e31dde1796dfc713578"},
+    {file = "qcs_sdk_python-0.19.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:722594274b1ffb00d93a23e681db16f0180b806ead93c35556a07cba75272d0e"},
+    {file = "qcs_sdk_python-0.19.1-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ab53c9d908caccac89e23c435ee5d20c8a58c7492e5353181332db38cefc218d"},
+    {file = "qcs_sdk_python-0.19.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:1159ffcecdfabae92fb17dd9af6d674dc53c196eebd9ebca71e076811b5e5e2a"},
+    {file = "qcs_sdk_python-0.19.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:764409d166ab3a6bfeb572bdfaa3fd7e64a94b623a2b1737bb04487a1e7e48ee"},
+    {file = "qcs_sdk_python-0.19.1-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d453ebfb6a3f028c08ce02409d9133b9756f46873a4fc65787ff6f71b95a26a8"},
+    {file = "qcs_sdk_python-0.19.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:eb946cfe2fb8aad5e023057c0bf035a3d9945c531cc3402b1c6ea85345896df4"},
+    {file = "qcs_sdk_python-0.19.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ee38542ce9c86616ace58164ffde734070497673286bb1865edb52ed5b86c038"},
+    {file = "qcs_sdk_python-0.19.1-cp38-cp38-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d7e6a171d39a5e679d284522a654e5585f1eacc06969f7f9b7c633c86b7d7275"},
+    {file = "qcs_sdk_python-0.19.1-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:e7c3e79c53c532af95c8c97c61cd59b7b321229b01c940eb7e02a48908367165"},
+    {file = "qcs_sdk_python-0.19.1-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:fcf8548a832fd7b8c9f5141d920c21890477b6495d2e85416745a97e71a34965"},
+    {file = "qcs_sdk_python-0.19.1-cp39-cp39-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8cb4ddf19d68c2ad3932826d674db0a23f1ce716594b9b8965e7dc787bb81838"},
+    {file = "qcs_sdk_python-0.19.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:2efdc54ed2894a55a73e6a5971a62c70e2b62b7b2bd5be5316c384eb3075f41e"},
+    {file = "qcs_sdk_python-0.19.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:4450a461a74ee469e3549f38daaf5b4bc692f2d60e15becaced76a7f3813b3b3"},
+    {file = "qcs_sdk_python-0.19.1.tar.gz", hash = "sha256:0011f13aa3f053e5e2c5eb8f5533481fe83ee5ce9eb98f747952ff5e01be6518"},
 ]
 
 [package.dependencies]
-quil = "0.10.0"
+quil = "0.11.1"
 
 [[package]]
 name = "quil"
-version = "0.10.0"
+version = "0.11.1"
 description = "A Python package for building and parsing Quil programs."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "quil-0.10.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3343ac253a6d8f65c0f171c381faab1b00cb18122d4adc1d559e757d5bae84ce"},
-    {file = "quil-0.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9a21333d37990fd627b270b48d864a1497171f05b2e8264747270a9912eb06e"},
-    {file = "quil-0.10.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4af1cc2708b1d2fd7c1f3b659f9acea19ef4e4c6d72f8b58bfc6cf11f648119a"},
-    {file = "quil-0.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:accb1ab83f0944f9d8746dbb4bc5841d77c4376f7fc804ff0d3c87a0c7751d3a"},
-    {file = "quil-0.10.0-cp310-none-win_amd64.whl", hash = "sha256:d7f48cf588b8f95e4c02dd819d7d69cc5e131708ee0318be83eaa717d542de57"},
-    {file = "quil-0.10.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:4ed084149d74cf2a68763d8f6accf2f7880c51bc10a8a7c193d8659b94fd777d"},
-    {file = "quil-0.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a98dca165af4f84afff924e3f9429237b206c985d6cdbc6930b991bb5c11f321"},
-    {file = "quil-0.10.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:96765c2f51bec543cf4df3399fb071ac6899ac9225fbcae5d995c319710eab39"},
-    {file = "quil-0.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d21621e73318b197f74cfa62790e3551a94baed79d154d3c67837891b3ed96ff"},
-    {file = "quil-0.10.0-cp311-none-win_amd64.whl", hash = "sha256:a7be6e36b8bda247ed0e8ae5df162738e388e5a6d6e545dfc438a20c2b1ba70a"},
-    {file = "quil-0.10.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:14b51f3ed4a0e106cb49aa6adb5d4cfcd08f92125ea9828b5b366d058a9cacc6"},
-    {file = "quil-0.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e93034a7a040b711dc000d9612b5d951fdb59b5ffc72b078322ed691df11523d"},
-    {file = "quil-0.10.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb0132f4ea198c975e9abb062c8cdb69622028a7ee623273f62f9d46ae250170"},
-    {file = "quil-0.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f3ae6c74983a26cdc3ed587508bb6f0f3442ff3eb45da294ef3047cedaee72e"},
-    {file = "quil-0.10.0-cp312-none-win_amd64.whl", hash = "sha256:dd7b6c1575dbe7fa7e6d192ab0c455cff87c4bf069ce0ac58eea6744c7edfe2e"},
-    {file = "quil-0.10.0-cp38-cp38-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8a54184e83c02e1303c5f6f34de37c69d7296feff575e93f28f8e2689f351ad7"},
-    {file = "quil-0.10.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b744d9b3e39458e39424d9240bebf8dd3e9a61ea7b833a982aede4254a92419b"},
-    {file = "quil-0.10.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f84ee50c0a1382d9dd1d2112fcfe5a13b2f812ebd0177bef2d68aa86d9ed11c"},
-    {file = "quil-0.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50602a8adf10d6df4fcec95244cf633982e18eba59f6fcca19ed3fc6b11141ea"},
-    {file = "quil-0.10.0-cp38-none-win_amd64.whl", hash = "sha256:d056f08dc387c67382cb51c1edbffd9e1050fa301fe2eb9d5cc8470125e0430c"},
-    {file = "quil-0.10.0-cp39-cp39-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d574c96bf5af47aea1f3e9e855fa6652c74ade1cb9fc9f8bb5a74b577f2e5145"},
-    {file = "quil-0.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f94bcde3f2e231f2d8409f23743cd9e20a9abf056632dbb24845c8d0d0fec832"},
-    {file = "quil-0.10.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63534dd0a32d3e8840fb8551797db65e0cb49a33592fca60997b2b039050d063"},
-    {file = "quil-0.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ec667b7dea20f8d3248766d9ae49102f54961c81d345fe9fdb0c39954dfc670"},
-    {file = "quil-0.10.0-cp39-none-win_amd64.whl", hash = "sha256:bbeabf5dfb1bcfbbb04ebd4ff85517ecf1cffc64972b4b64d5c5355bf3e959fd"},
-    {file = "quil-0.10.0.tar.gz", hash = "sha256:381d6551366dd0403ba5bc2c18d851dc53688da938aaec768e93a8f87e4b4cde"},
+    {file = "quil-0.11.1-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:397fd676a3946d76b98c673e8a1dd281b4052c22f347a5928f4a9a93eb54a510"},
+    {file = "quil-0.11.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15bf71d0a7dc2499855c788131ad9a8dd31e89c46d01c92cc703a50879194217"},
+    {file = "quil-0.11.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a93289bff611a216efa5513167b16c16fd0673cfd62678cfb95df91cf4120388"},
+    {file = "quil-0.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4378c3d6c3c11ef2cbee19c3fb4f1af14138ed9947cf685adeaa88fa6e66c267"},
+    {file = "quil-0.11.1-cp310-none-win_amd64.whl", hash = "sha256:4eecab258ea9d3411914a7b5c6a9afcb6a1e21fb44885c658eaa65af778ea7a4"},
+    {file = "quil-0.11.1-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a1d3ed58f02dc9476d890a57d5ef380bb2c17fe41dcd3c70c1df1b0ff01462f3"},
+    {file = "quil-0.11.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22655ae044c43a504d8cb7ad4409b95cedfd75b3fd1fad95aca14658a491ea03"},
+    {file = "quil-0.11.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db0dd6e8ee384d139f0bf47e0d28d55a8599517c870088f6ff84651a47ec1198"},
+    {file = "quil-0.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:998f5148222023a4e98f6eb4f2d1d561242b0c7598cd206bcab210aa7b8e8a88"},
+    {file = "quil-0.11.1-cp311-none-win_amd64.whl", hash = "sha256:a9d322f26830fb0806d779f36eb507dd6e50365537f36b6da3519401b6b63047"},
+    {file = "quil-0.11.1-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c4ed45812c4bc818765b8d8dfd303831ba04efd1ec18853da113763ac52914a5"},
+    {file = "quil-0.11.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:05ee5bea0bd57f898a30448c0268e9f1dab5572a70bf347f575062269565193b"},
+    {file = "quil-0.11.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:467a0418bba805c10ff991e5d874feb4bc49a038b1015f398a55564c93967e19"},
+    {file = "quil-0.11.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54687ab9294c11eb0648e852dd34609d52e1719d18362a730ce851e0a366b2d8"},
+    {file = "quil-0.11.1-cp312-none-win_amd64.whl", hash = "sha256:51da4347405292edf351a7a9acb1327ed8dc2f8fb8bb47023c3f891867b74e05"},
+    {file = "quil-0.11.1-cp38-cp38-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:54bad853268718fd1430cb2f3d6f4855370bf419638b19f2060b4b50aaee8c9f"},
+    {file = "quil-0.11.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d3fbd771233b370e471066485820ecbae078f00293b9a5a6d45c08e1474190d"},
+    {file = "quil-0.11.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:49dca9948eb8d3d679a481c7bdb205cb9848f1c72a0ce253dc3984f7475d5afe"},
+    {file = "quil-0.11.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6de60319afd900db87619e27f8054e2891b8a0f25d1fbc0a760c3b52558fb1e3"},
+    {file = "quil-0.11.1-cp38-none-win_amd64.whl", hash = "sha256:7b805b458eed60a26274c70285d3144181d6674bdc7cd74955a2f50362d3d8e4"},
+    {file = "quil-0.11.1-cp39-cp39-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b6d41dac57443a81646677256aedbf4424025504f4b8fd4e92599b4c52e2f68d"},
+    {file = "quil-0.11.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eaced80dc057f1b84f471d629fde09219c539386381aa197b90fa18548be2f0c"},
+    {file = "quil-0.11.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:83c810e10021ae48dca3cf66dc77e0f9703094368a108963ad9469183322c6d2"},
+    {file = "quil-0.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f3579a8ce44fccef1b1735b4e7d3c34bc0588cc47a0cebdd26669884bcfd565"},
+    {file = "quil-0.11.1-cp39-none-win_amd64.whl", hash = "sha256:e53e68eac8c14914934dfd9cd97cdfb4fd4a802204b7af7f924c456cfdd7e865"},
+    {file = "quil-0.11.1.tar.gz", hash = "sha256:2d4ac702fb61c71c2ed325ea74b236a2a46cee81778582f4b3f5014bfb7839ff"},
 ]
 
 [[package]]
@@ -3234,4 +3229,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<=3.14"
-content-hash = "2bde08dd792850bbe26c8c524116f06c90635ee9da476e1204f26f9b3362d206"
+content-hash = "f3370d469c74591f16b1c59d9584b6e8b78764028a864fa80155c653d55316fb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ docstring-code-line-length = "dynamic"
 "test/**/*.py" = [
     "D",    # docstrings are not enforced in tests
     "S101", # asserts are allowed in tests
+    "S301", # we only deserialize our own data to ensure compatibility with the pickle module
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,13 @@ packages = [{ include = "pyquil" }]
 exclude = ["pyquil/conftest.py"]
 
 [tool.poetry.dependencies]
-python = "^3.9,<=3.14"
+python = "^3.9,<=4.0"
 numpy = "^1.25"
 scipy = "^1.11"
 rpcq = "^3.11.0"
 networkx = ">=2.5"
-qcs-sdk-python = "0.19.1"
+qcs-sdk-python = "0.19.2"
+quil = ">=0.11.2"
 packaging = "^23.1"
 deprecated = "^1.2.14"
 types-deprecated = "^1.2.9.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = [{ include = "pyquil" }]
 exclude = ["pyquil/conftest.py"]
 
 [tool.poetry.dependencies]
-python = "^3.9,<=4.0"
+python = "^3.9,<4.0"
 numpy = "^1.25"
 scipy = "^1.11"
 rpcq = "^3.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ numpy = "^1.25"
 scipy = "^1.11"
 rpcq = "^3.11.0"
 networkx = ">=2.5"
-qcs-sdk-python = "0.19.0"
+qcs-sdk-python = "0.19.1"
 packaging = "^23.1"
 deprecated = "^1.2.14"
 types-deprecated = "^1.2.9.3"
@@ -116,6 +116,12 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 docstring-code-format = true
 docstring-code-line-length = "dynamic"
+
+[tool.ruff.lint.per-file-ignores]
+"test/**/*.py" = [
+    "D",    # docstrings are not enforced in tests
+    "S101", # asserts are allowed in tests
+]
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning:pyquil.*:", "ignore::DeprecationWarning:test.unit.*:"]

--- a/pyquil/api/__init__.py
+++ b/pyquil/api/__init__.py
@@ -30,7 +30,7 @@ from pyquil.api._compiler import (
     QVMCompiler,
 )
 from pyquil.api._qam import QAM, MemoryMap, QAMExecutionResult
-from pyquil.api._qpu import QPU
+from pyquil.api._qpu import QPU, QPUExecuteResponse
 from pyquil.api._quantum_computer import (
     QuantumComputer,
     get_qc,
@@ -59,6 +59,7 @@ __all__ = [
     "MemoryMap",
     "QAMExecutionResult",
     "QPU",
+    "QPUExecuteResponse",
     "QuantumComputer",
     "get_qc",
     "list_quantum_computers",

--- a/pyquil/control_flow_graph.py
+++ b/pyquil/control_flow_graph.py
@@ -5,7 +5,11 @@ from typing import Optional
 from quil import program as quil_rs
 from typing_extensions import Self, override
 
-from pyquil.quilbase import AbstractInstruction, _convert_to_py_instruction, _convert_to_py_instructions
+from pyquil.quilbase import (
+    AbstractInstruction,
+    _convert_to_py_instruction,
+    _convert_to_py_instructions,
+)
 
 
 class BasicBlock(quil_rs.BasicBlock):

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1068,24 +1068,19 @@ class LogicalBinaryOp(quil_rs.BinaryLogic, AbstractInstruction):
 
     def __new__(cls, left: MemoryReference, right: Union[MemoryReference, int]) -> Self:
         """Initialize the operands of the binary logical instruction."""
-        operands = cls._to_rs_binary_operands(left, right)
-        return super().__new__(cls, cls.op, operands)
+        destination = left._to_rs_memory_reference()
+        source = cls._to_rs_binary_operand(right)
+        return super().__new__(cls, cls.op, destination, source)
 
     @classmethod
     def _from_rs_binary_logic(cls, binary_logic: quil_rs.BinaryLogic) -> "LogicalBinaryOp":
-        return super().__new__(cls, binary_logic.operator, binary_logic.operands)
+        return super().__new__(cls, binary_logic.operator, binary_logic.destination, binary_logic.source)
 
     @staticmethod
     def _to_rs_binary_operand(operand: Union[MemoryReference, int]) -> quil_rs.BinaryOperand:
         if isinstance(operand, MemoryReference):
             return quil_rs.BinaryOperand.from_memory_reference(operand._to_rs_memory_reference())
         return quil_rs.BinaryOperand.from_literal_integer(operand)
-
-    @staticmethod
-    def _to_rs_binary_operands(left: MemoryReference, right: Union[MemoryReference, int]) -> quil_rs.BinaryOperands:
-        left_operand = left._to_rs_memory_reference()
-        right_operand = LogicalBinaryOp._to_rs_binary_operand(right)
-        return quil_rs.BinaryOperands(left_operand, right_operand)
 
     @staticmethod
     def _to_py_binary_operand(operand: quil_rs.BinaryOperand) -> Union[MemoryReference, int]:
@@ -1096,24 +1091,22 @@ class LogicalBinaryOp(quil_rs.BinaryLogic, AbstractInstruction):
     @property
     def left(self) -> MemoryReference:
         """The left hand side of the binary expression."""
-        return MemoryReference._from_rs_memory_reference(super().operands.memory_reference)
+        return MemoryReference._from_rs_memory_reference(super().destination)
 
     @left.setter
     def left(self, left: MemoryReference) -> None:
-        operands = super().operands
-        operands.memory_reference = left._to_rs_memory_reference()
-        quil_rs.BinaryLogic.operands.__set__(self, operands)  # type: ignore[attr-defined]
+        destination = left._to_rs_memory_reference()
+        quil_rs.BinaryLogic.destination.__set__(self, destination)  # type: ignore[attr-defined]
 
     @property
     def right(self) -> Union[MemoryReference, int]:
         """The right hand side of the binary expression."""
-        return self._to_py_binary_operand(super().operands.operand)
+        return self._to_py_binary_operand(super().source)
 
     @right.setter
     def right(self, right: Union[MemoryReference, int]) -> None:
-        operands = super().operands
-        operands.operand = self._to_rs_binary_operand(right)
-        quil_rs.BinaryLogic.operands.__set__(self, operands)  # type: ignore[attr-defined]
+        source = self._to_rs_binary_operand(right)
+        quil_rs.BinaryLogic.source.__set__(self, source)  # type: ignore[attr-defined]
 
     def out(self) -> str:
         """Return the instruction as a valid Quil string. Raises an error if the instruction contains placeholders."""

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1485,7 +1485,11 @@ class ClassicalComparison(quil_rs.Comparison, AbstractInstruction):
         right: Union[MemoryReference, int, float],
     ) -> "ClassicalComparison":
         """Initialize a new comparison instruction."""
-        rs_target, rs_left, rs_right = (target._to_rs_memory_reference(), left._to_rs_memory_reference(), cls._to_comparison_operand(right))
+        rs_target, rs_left, rs_right = (
+            target._to_rs_memory_reference(),
+            left._to_rs_memory_reference(),
+            cls._to_comparison_operand(right),
+        )
         return super().__new__(cls, cls.op, rs_target, rs_left, rs_right)
 
     @classmethod
@@ -1536,7 +1540,7 @@ class ClassicalComparison(quil_rs.Comparison, AbstractInstruction):
 
     @right.setter
     def right(self, right: MemoryReference) -> None:
-        quil_rs.Comparison.rhs.__set__(self, quil_rs.ComparisonOperand(right._to_rs_memory_reference())) # type: ignore
+        quil_rs.Comparison.rhs.__set__(self, quil_rs.ComparisonOperand(right._to_rs_memory_reference()))  # type: ignore
 
     def out(self) -> str:
         """Return the instruction as a valid Quil string."""

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -1164,7 +1164,7 @@ class ArithmeticBinaryOp(quil_rs.Arithmetic, AbstractInstruction):
     @left.setter
     def left(self, left: MemoryReference) -> None:
         quil_rs.Arithmetic.destination.__set__(  # type: ignore[attr-defined]
-            self, quil_rs.ArithmeticOperand.from_memory_reference(left._to_rs_memory_reference())
+            self, left._to_rs_memory_reference()
         )
 
     @property
@@ -1536,7 +1536,7 @@ class ClassicalComparison(quil_rs.Comparison, AbstractInstruction):
 
     @right.setter
     def right(self, right: MemoryReference) -> None:
-        quil_rs.Comparison.rhs.__set__(self, right._to_rs_memory_reference())  # type: ignore
+        quil_rs.Comparison.rhs.__set__(self, quil_rs.ComparisonOperand(right._to_rs_memory_reference())) # type: ignore
 
     def out(self) -> str:
         """Return the instruction as a valid Quil string."""

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -11,6 +11,18 @@
 # name: TestArithmeticBinaryOp.test_out[SUB-left1-1]
   'SUB b[1] 1'
 # ---
+# name: TestArithmeticBinaryOp.test_pickle[ADD-left0-right0]
+  Arithmetic { operator: Add, destination: MemoryReference { name: "a", index: 0 }, source: MemoryReference(MemoryReference { name: "b", index: 0 }) }
+# ---
+# name: TestArithmeticBinaryOp.test_pickle[DIV-left3-4.2]
+  Arithmetic { operator: Divide, destination: MemoryReference { name: "c", index: 2 }, source: LiteralReal(4.2) }
+# ---
+# name: TestArithmeticBinaryOp.test_pickle[MUL-left2-1.0]
+  Arithmetic { operator: Multiply, destination: MemoryReference { name: "c", index: 2 }, source: LiteralInteger(1) }
+# ---
+# name: TestArithmeticBinaryOp.test_pickle[SUB-left1-1]
+  Arithmetic { operator: Subtract, destination: MemoryReference { name: "b", index: 1 }, source: LiteralInteger(1) }
+# ---
 # name: TestCapture.test_out[Blocking]
   'CAPTURE 123 q "FRAMEX" WAVEFORMY ro[0]'
 # ---

--- a/test/unit/__snapshots__/test_quilbase.ambr
+++ b/test/unit/__snapshots__/test_quilbase.ambr
@@ -32,6 +32,15 @@
 # name: TestCapture.test_out[TemplateWaveform]
   'NONBLOCKING CAPTURE 123 q "FRAMEX" flat(duration: 2.5, iq: 1+2.0i) ro[0]'
 # ---
+# name: TestCapture.test_pickle[Blocking]
+  Capture { blocking: true, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, memory_reference: MemoryReference { name: "ro", index: 0 }, waveform: WaveformInvocation { name: "WAVEFORMY", parameters: {} } }
+# ---
+# name: TestCapture.test_pickle[NonBlocking]
+  Capture { blocking: false, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, memory_reference: MemoryReference { name: "ro", index: 0 }, waveform: WaveformInvocation { name: "WAVEFORMY", parameters: {} } }
+# ---
+# name: TestCapture.test_pickle[TemplateWaveform]
+  Capture { blocking: false, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, memory_reference: MemoryReference { name: "ro", index: 0 }, waveform: WaveformInvocation { name: "flat", parameters: {"duration": Number(Complex { re: 2.5, im: 0.0 }), "iq": Infix(InfixExpression { left: Number(Complex { re: 1.0, im: 0.0 }), operator: Plus, right: Number(Complex { re: 0.0, im: 2.0 }) })} } }
+# ---
 # name: TestClassicalComparison.test_out[EQ-target0-left0-right0]
   'EQ t[0] y[0] z[0]'
 # ---
@@ -187,12 +196,6 @@
   DEFCIRCUIT NiftyCircuit(%theta) a:
   	DECLARE ro BIT[1]
   	MEASURE a ro[0]
-  	DEFGATE ParameterizedGate(%theta) AS MATRIX:
-  		%theta, 0, 0, 0
-  		0, %theta, 0, 0
-  		0, 0, %theta, 0
-  		0, 0, 0, %theta
-  	
   
   '''
 # ---
@@ -201,6 +204,8 @@
 # ---
 # name: TestDefFrame.test_out[Frame-Only].1
   set({
+    '\tDIRECTION: "direction"',
+    '\tINITIAL-FREQUENCY: 0',
   })
 # ---
 # name: TestDefFrame.test_out[With-Optionals]
@@ -221,6 +226,8 @@
 # ---
 # name: TestDefFrame.test_str[Frame-Only].1
   set({
+    '\tDIRECTION: "direction"',
+    '\tINITIAL-FREQUENCY: 0',
   })
 # ---
 # name: TestDefFrame.test_str[With-Optionals]
@@ -283,6 +290,18 @@
   	0, 0, 0, cos(%X)
   
   '''
+# ---
+# name: TestDefGate.test_pickle[MixedTypes]
+  GateDefinition { name: "MixedTypes", parameters: ["X"], specification: Matrix([[Number(Complex { re: 0.0, im: 0.0 }), FunctionCall(FunctionCallExpression { function: Sine, expression: Variable("X") })], [Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 })]]) }
+# ---
+# name: TestDefGate.test_pickle[No-Params]
+  GateDefinition { name: "NoParamGate", parameters: [], specification: Matrix([[Number(Complex { re: 1.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 })], [Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 1.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 })], [Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 1.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 })], [Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 1.0, im: 0.0 })]]) }
+# ---
+# name: TestDefGate.test_pickle[ParameterlessExpression]
+  GateDefinition { name: "ParameterlessExpressions", parameters: [], specification: Matrix([[Number(Complex { re: 1.0, im: 0.0 }), Number(Complex { re: 1.2246467991473532e-16, im: 0.0 })], [Number(Complex { re: 1.2246467991473532e-16, im: 0.0 }), Prefix(PrefixExpression { operator: Minus, expression: Number(Complex { re: 1.0, im: 0.0 }) })]]) }
+# ---
+# name: TestDefGate.test_pickle[Params]
+  GateDefinition { name: "ParameterizedGate", parameters: ["X"], specification: Matrix([[FunctionCall(FunctionCallExpression { function: Cosine, expression: Variable("X") }), Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 })], [Number(Complex { re: 0.0, im: 0.0 }), FunctionCall(FunctionCallExpression { function: Cosine, expression: Variable("X") }), Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 })], [Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 }), FunctionCall(FunctionCallExpression { function: Cosine, expression: Variable("X") }), Number(Complex { re: 0.0, im: 0.0 })], [Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 }), Number(Complex { re: 0.0, im: 0.0 }), FunctionCall(FunctionCallExpression { function: Cosine, expression: Variable("X") })]]) }
 # ---
 # name: TestDefGate.test_str[MixedTypes]
   '''
@@ -418,12 +437,6 @@
   
   '''
 # ---
-# name: TestDefWaveform.test_out[No-Params-Entries]
-  '''
-  DEFWAVEFORM Wavey:
-  	
-  '''
-# ---
 # name: TestDefWaveform.test_out[With-Param]
   '''
   DEFWAVEFORM Wavey(%x):
@@ -435,6 +448,12 @@
   DEFWAVEFORM Wavey(%x, %y):
   	1+2.0i, %x, 3*%y
   '''
+# ---
+# name: TestDefWaveform.test_pickle[With-Param]
+  WaveformDefinition { name: "Wavey", definition: Waveform { matrix: [Variable("x")], parameters: ["x"] } }
+# ---
+# name: TestDefWaveform.test_pickle[With-Params-Complex]
+  WaveformDefinition { name: "Wavey", definition: Waveform { matrix: [Infix(InfixExpression { left: Number(Complex { re: 1.0, im: 0.0 }), operator: Plus, right: Number(Complex { re: 0.0, im: 2.0 }) }), Variable("x"), Infix(InfixExpression { left: Number(Complex { re: 3.0, im: 0.0 }), operator: Star, right: Variable("y") })], parameters: ["x", "y"] } }
 # ---
 # name: TestDelayFrames.test_out[frames0-5.0]
   'DELAY 0 "frame" 5'
@@ -609,6 +628,30 @@
 # ---
 # name: TestPulse.test_out[NonBlocking]
   'NONBLOCKING PULSE 123 q "FRAMEX" WAVEFORMY'
+# ---
+# name: TestPulse.test_pickle[Blocking]
+  Pulse { blocking: true, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, waveform: WaveformInvocation { name: "WAVEFORMY", parameters: {} } }
+# ---
+# name: TestPulse.test_pickle[BoxcarAveragerKernel]
+  Pulse { blocking: false, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, waveform: WaveformInvocation { name: "boxcar_kernel", parameters: {"duration": Number(Complex { re: 2.5, im: 0.0 }), "scale": Number(Complex { re: 1.0, im: 0.0 })} } }
+# ---
+# name: TestPulse.test_pickle[DragGaussianWaveform]
+  Pulse { blocking: false, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, waveform: WaveformInvocation { name: "drag_gaussian", parameters: {"alpha": Number(Complex { re: 1.0, im: 0.0 }), "anh": Number(Complex { re: 0.1, im: 0.0 }), "duration": Number(Complex { re: 2.5, im: 0.0 }), "fwhm": Number(Complex { re: 1.0, im: 0.0 }), "t0": Number(Complex { re: 1.0, im: 0.0 })} } }
+# ---
+# name: TestPulse.test_pickle[ErfSquareWaveform]
+  Pulse { blocking: false, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, waveform: WaveformInvocation { name: "erf_square", parameters: {"duration": Number(Complex { re: 2.5, im: 0.0 }), "pad_left": Number(Complex { re: 1.0, im: 0.0 }), "pad_right": Number(Complex { re: 0.1, im: 0.0 }), "risetime": Number(Complex { re: 1.0, im: 0.0 }), "scale": Number(Complex { re: 1.0, im: 0.0 })} } }
+# ---
+# name: TestPulse.test_pickle[FlatWaveform]
+  Pulse { blocking: false, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, waveform: WaveformInvocation { name: "flat", parameters: {"duration": Number(Complex { re: 2.5, im: 0.0 }), "iq": Infix(InfixExpression { left: Number(Complex { re: 1.0, im: 0.0 }), operator: Plus, right: Number(Complex { re: 0.0, im: 2.0 }) })} } }
+# ---
+# name: TestPulse.test_pickle[GaussianWaveform]
+  Pulse { blocking: false, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, waveform: WaveformInvocation { name: "gaussian", parameters: {"duration": Number(Complex { re: 2.5, im: 0.0 }), "fwhm": Number(Complex { re: 1.0, im: 0.0 }), "phase": Number(Complex { re: 0.1, im: 0.0 }), "t0": Number(Complex { re: 1.0, im: 0.0 })} } }
+# ---
+# name: TestPulse.test_pickle[HrmGaussianWaveform]
+  Pulse { blocking: false, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, waveform: WaveformInvocation { name: "hrm_gaussian", parameters: {"alpha": Number(Complex { re: 1.0, im: 0.0 }), "anh": Number(Complex { re: 0.1, im: 0.0 }), "duration": Number(Complex { re: 2.5, im: 0.0 }), "fwhm": Number(Complex { re: 1.0, im: 0.0 }), "second_order_hrm_coeff": Number(Complex { re: 0.5, im: 0.0 }), "t0": Number(Complex { re: 1.0, im: 0.0 })} } }
+# ---
+# name: TestPulse.test_pickle[NonBlocking]
+  Pulse { blocking: false, frame: FrameIdentifier { name: "FRAMEX", qubits: [Fixed(123), Variable("q")] }, waveform: WaveformInvocation { name: "WAVEFORMY", parameters: {} } }
 # ---
 # name: TestRawCapture.test_out[Blocking]
   'RAW-CAPTURE 123 q "FRAMEX" 0.5 ro[0]'

--- a/test/unit/test_qpu.py
+++ b/test/unit/test_qpu.py
@@ -1,4 +1,5 @@
 import pickle
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -237,7 +238,7 @@ class TestQPUExecutionOptions:
         ),
     ],
 )
-def test_pickle_execute_responses(input):
+def test_pickle_execute_responses(input: Any):
     pickled_response = pickle.dumps(input)
     unpickled_response = pickle.loads(pickled_response)
     assert unpickled_response == input

--- a/test/unit/test_qpu.py
+++ b/test/unit/test_qpu.py
@@ -225,13 +225,13 @@ def test_pickle_qam_execution_result(mock_encrypted_program):
     result = QAMExecutionResult(
         executable=mock_encrypted_program,
         data=ExecutionData(
-            # result_data=ResultData.from_qvm(
-            #     QVMResultData.from_memory_map({
-            #         "int": RegisterData.from_i8([[1, 2, 3], [4, 5, 6]]),
-            #         "float": RegisterData.from_f64([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
-            #     })
-            # )
-            result_data=ResultData.from_qpu(QPUResultData(mappings=mappings, readout_values=readout_values, memory_values=memory_values))
+            result_data=ResultData.from_qpu(
+                QPUResultData(
+                    mappings=mappings,
+                    readout_values=readout_values,
+                    memory_values=memory_values
+                )
+            )
         )
     )
 

--- a/test/unit/test_qpu.py
+++ b/test/unit/test_qpu.py
@@ -208,43 +208,36 @@ class TestQPUExecutionOptions:
             execution_options=execution_options,
         )
 
-def test_pickle_qam_execution_result(mock_encrypted_program):
-    mappings = {
-        "ro[0]": "q0",
-        "ro[1]": "q1"
-    }
-    readout_values = {
-        "q0": ReadoutValues.from_integer([1, 1]),
-        "q1": ReadoutValues.from_real([1.1, 1.2]),
-        "q2": ReadoutValues.from_complex([complex(3, 4), complex(2.35, 4.21)]),
-    }
-    memory_values = {
-        "int": MemoryValues([2, 3, 4]),
-        "real": MemoryValues([5.0, 6.0, 7.0]),
-    }
-    result = QAMExecutionResult(
-        executable=mock_encrypted_program,
-        data=ExecutionData(
-            result_data=ResultData.from_qpu(
-                QPUResultData(
-                    mappings=mappings,
-                    readout_values=readout_values,
-                    memory_values=memory_values
-                )
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        (
+            QAMExecutionResult(
+                executable=mock_encrypted_program,
+                data=ExecutionData(
+                    result_data=ResultData.from_qpu(
+                        QPUResultData(
+                            mappings={"ro[0]": "q0", "ro[1]": "q1"},
+                            readout_values={
+                                "q0": ReadoutValues.from_integer([1, 1]),
+                                "q1": ReadoutValues.from_real([1.1, 1.2]),
+                                "q2": ReadoutValues.from_complex([complex(3, 4), complex(2.35, 4.21)]),
+                            },
+                            memory_values={"int": MemoryValues([2, 3, 4]), "real": MemoryValues([5.0, 6.0, 7.0])},
+                        )
+                    )
+                ),
             )
-        )
-    )
-
-    pickled_result = pickle.dumps(result)
-    unpickled_result = pickle.loads(pickled_result)
-    assert unpickled_result == result
-
-def test_pickle_qpu_execute_response(mock_encrypted_program):
-    response = QPUExecuteResponse(
-        job_id="some-job-id",
-        _executable=mock_encrypted_program,
-        execution_options=ExecutionOptions.default()
-    )
-    pickled_response = pickle.dumps(response)
+        ),
+        (
+            QPUExecuteResponse(
+                job_id="some-job-id", _executable=mock_encrypted_program, execution_options=ExecutionOptions.default()
+            )
+        ),
+    ],
+)
+def test_pickle_execute_responses(input):
+    pickled_response = pickle.dumps(input)
     unpickled_response = pickle.loads(pickled_response)
-    assert unpickled_response == response
+    assert unpickled_response == input

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -1629,7 +1629,7 @@ class TestClassicalComparison:
 
     def test_pickle(self, comparison: ClassicalComparison):
         pickled = pickle.dumps(comparison)
-        unpickled = pickle.loads(comparison)
+        unpickled = pickle.loads(pickled)
         assert unpickled == comparison
 
 
@@ -1719,10 +1719,10 @@ class TestArithmeticBinaryOp:
         rs_classical_arithmetic = _convert_to_rs_instruction(arithmetic)
         assert arithmetic == _convert_to_py_instruction(rs_classical_arithmetic)
 
-    def test_pickle(self, arithmetic: UnaryClassicalInstruction):
+    def test_pickle(self, arithmetic: UnaryClassicalInstruction, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(arithmetic)
         unpickled = pickle.loads(pickled)
-        assert unpickled == arithmetic
+        assert unpickled == snapshot
 
 
 @pytest.mark.parametrize(

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -267,10 +267,10 @@ class TestDefGate:
         assert isinstance(copy.copy(def_gate), DefGate)
         assert isinstance(copy.deepcopy(def_gate), DefGate)
 
-    def test_pickle(self, def_gate: DefGate):
+    def test_pickle(self, def_gate: DefGate, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(def_gate)
         unpickled = pickle.loads(pickled)
-        assert unpickled == def_gate
+        assert unpickled == snapshot
 
 
 @pytest.mark.parametrize(
@@ -541,7 +541,7 @@ class TestMeasurement:
 @pytest.mark.parametrize(
     ("frame", "direction", "initial_frequency", "hardware_object", "sample_rate", "center_frequency", "channel_delay"),
     [
-        (Frame([Qubit(0)], "frame"), None, None, None, None, None, None),
+        (Frame([Qubit(0)], "frame"), "direction", 0.0, None, None, None, None),
         (Frame([Qubit(1)], "frame"), "direction", 1.39, "hardware_object", 44.1, 440.0, 0.0),
     ],
     ids=("Frame-Only", "With-Optionals"),
@@ -630,6 +630,7 @@ class TestDefFrame:
         assert def_frame == _convert_to_py_instruction(rs_def_frame)
 
     def test_pickle(self, def_frame: DefFrame):
+        print(def_frame.to_quil())
         pickled = pickle.dumps(def_frame)
         unpickled = pickle.loads(pickled)
         assert unpickled == def_frame
@@ -934,7 +935,6 @@ def test_fence_all():
 @pytest.mark.parametrize(
     ("name", "parameters", "entries"),
     [
-        ("Wavey", [], []),
         ("Wavey", [Parameter("x")], [Parameter("x")]),
         (
             "Wavey",
@@ -942,7 +942,7 @@ def test_fence_all():
             [complex(1.0, 2.0), Parameter("x"), Mul(complex(3.0, 0.0), Parameter("y"))],
         ),
     ],
-    ids=("No-Params-Entries", "With-Param", "With-Params-Complex"),
+    ids=("With-Param", "With-Params-Complex"),
 )
 class TestDefWaveform:
     @pytest.fixture
@@ -975,10 +975,11 @@ class TestDefWaveform:
         rs_def_waveform = _convert_to_rs_instruction(def_waveform)
         assert def_waveform == _convert_to_py_instruction(rs_def_waveform)
 
-    def test_pickle(self, def_waveform: DefWaveform):
+    def test_pickle(self, def_waveform: DefWaveform, snapshot: SnapshotAssertion):
+        print(def_waveform.to_quil())
         pickled = pickle.dumps(def_waveform)
-        unpickled = pickle.loads(def_waveform)
-        assert unpickled == def_waveform
+        unpickled = pickle.loads(pickled)
+        assert unpickled == snapshot
 
 
 @pytest.mark.parametrize(
@@ -992,7 +993,6 @@ class TestDefWaveform:
             [
                 Declare("ro", "BIT", 1),
                 Measurement(FormalArgument("a"), MemoryReference("ro")),
-                DefGate("ParameterizedGate", np.diag([Parameter("theta")] * 4), [Parameter("theta")]),
             ],
         ),
     ],
@@ -1041,6 +1041,7 @@ class TestDefCircuit:
         assert def_circuit == _convert_to_py_instruction(rs_def_circuit)
 
     def test_pickle(self, def_circuit: DefCircuit):
+        print(def_circuit.to_quil())
         pickled = pickle.dumps(def_circuit)
         unpickled = pickle.loads(pickled)
         assert unpickled == def_circuit
@@ -1106,10 +1107,10 @@ class TestCapture:
         rs_capture = _convert_to_rs_instruction(capture)
         assert capture == _convert_to_py_instruction(rs_capture)
 
-    def test_pickle(self, capture: Capture):
+    def test_pickle(self, capture: Capture, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(capture)
         unpickled = pickle.loads(pickled)
-        assert unpickled == capture
+        assert unpickled == snapshot
 
 
 @pytest.mark.parametrize(
@@ -1201,10 +1202,10 @@ class TestPulse:
         rs_pulse = _convert_to_rs_instruction(pulse)
         assert pulse == _convert_to_py_instruction(rs_pulse)
 
-    def test_pickle(self, pulse: Pulse):
+    def test_pickle(self, pulse: Pulse, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(pulse)
         unpickled = pickle.loads(pickled)
-        assert unpickled == pulse
+        assert unpickled == snapshot
 
 
 @pytest.mark.parametrize(
@@ -1576,6 +1577,7 @@ class TestClassicalStore:
         unpickled = pickle.loads(pickled)
         assert unpickled == store
 
+
 @pytest.mark.parametrize(
     ("op", "target", "left", "right"),
     [
@@ -1668,6 +1670,7 @@ class TestUnaryClassicalInstruction:
         pickled = pickle.dumps(unary)
         unpickled = pickle.loads(pickled)
         assert unpickled == unary
+
 
 @pytest.mark.parametrize(
     ("op", "left", "right"),
@@ -1767,6 +1770,7 @@ class TestLogicalBinaryOp:
         pickled = pickle.dumps(logical)
         unpickled = pickle.loads(pickled)
         assert unpickled == logical
+
 
 def test_include():
     include = Include("my-cool-file.quil")

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -1,4 +1,5 @@
 import copy
+import pickle
 from collections.abc import Iterable
 from math import pi
 from numbers import Complex, Number
@@ -187,6 +188,11 @@ class TestGate:
         except Exception as e:
             raise AssertionError(f"Failed to compile the program: \n{program}") from e
 
+    def test_pickle(self, gate: Gate):
+        pickled = pickle.dumps(gate)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == gate
+
 
 @pytest.mark.parametrize(
     ("name", "matrix", "parameters"),
@@ -260,6 +266,11 @@ class TestDefGate:
     def test_copy(self, def_gate: DefGate):
         assert isinstance(copy.copy(def_gate), DefGate)
         assert isinstance(copy.deepcopy(def_gate), DefGate)
+
+    def test_pickle(self, def_gate: DefGate):
+        pickled = pickle.dumps(def_gate)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == def_gate
 
 
 @pytest.mark.parametrize(
@@ -430,6 +441,11 @@ class TestDefCalibration:
         rs_calibration = _convert_to_rs_instruction(calibration)
         assert calibration == _convert_to_py_instruction(rs_calibration)
 
+    def test_pickle(self, calibration: DefCalibration):
+        pickled = pickle.dumps(calibration)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == calibration
+
 
 @pytest.mark.parametrize(
     ("qubit", "memory_reference", "instrs"),
@@ -467,6 +483,11 @@ class TestDefMeasureCalibration:
     def test_convert(self, measure_calibration: DefMeasureCalibration):
         rs_measure_calibration = _convert_to_rs_instruction(measure_calibration)
         assert measure_calibration == _convert_to_py_instruction(rs_measure_calibration)
+
+    def test_pickle(self, measure_calibration: DefMeasureCalibration):
+        pickled = pickle.dumps(measure_calibration)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == measure_calibration
 
 
 @pytest.mark.parametrize(
@@ -510,6 +531,11 @@ class TestMeasurement:
     def test_convert(self, measurement: Measurement):
         rs_measurement = _convert_to_rs_instruction(measurement)
         assert measurement == _convert_to_py_instruction(rs_measurement)
+
+    def test_pickle(self, measurement: Measurement):
+        pickled = pickle.dumps(measurement)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == measurement
 
 
 @pytest.mark.parametrize(
@@ -603,6 +629,11 @@ class TestDefFrame:
         rs_def_frame = _convert_to_rs_instruction(def_frame)
         assert def_frame == _convert_to_py_instruction(rs_def_frame)
 
+    def test_pickle(self, def_frame: DefFrame):
+        pickled = pickle.dumps(def_frame)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == def_frame
+
 
 @pytest.mark.parametrize(
     ("name", "memory_type", "memory_size", "shared_region", "offsets"),
@@ -673,6 +704,11 @@ class TestDeclare:
         rs_declare = _convert_to_rs_instruction(declare)
         assert declare == _convert_to_py_instruction(rs_declare)
 
+    def test_pickle(self, declare: Declare):
+        pickled = pickle.dumps(declare)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == declare
+
 
 @pytest.mark.parametrize(
     ("command", "args", "freeform_string"),
@@ -717,6 +753,11 @@ class TestPragma:
     def test_convert(self, pragma: Pragma):
         rs_pragma = _convert_to_rs_instruction(pragma)
         assert pragma == _convert_to_py_instruction(rs_pragma)
+
+    def test_pickle(self, pragma: Pragma):
+        pickled = pickle.dumps(pragma)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == pragma
 
 
 @pytest.mark.parametrize(
@@ -765,6 +806,11 @@ class TestReset:
         rs_reset_qubit = _convert_to_rs_instruction(reset_qubit)
         assert reset_qubit == _convert_to_py_instruction(rs_reset_qubit)
 
+    def test_pickle(self, reset_qubit: Reset):
+        pickled = pickle.dumps(reset_qubit)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == reset_qubit
+
 
 @pytest.mark.parametrize(
     ("frames", "duration"),
@@ -797,6 +843,11 @@ class TestDelayFrames:
     def test_convert(self, delay_frames: DelayFrames):
         rs_delay_frames = _convert_to_rs_instruction(delay_frames)
         assert delay_frames == _convert_to_py_instruction(rs_delay_frames)
+
+    def test_pickle(self, delay_frames: DelayFrames):
+        pickled = pickle.dumps(delay_frames)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == delay_frames
 
 
 @pytest.mark.parametrize(
@@ -833,6 +884,11 @@ class TestDelayQubits:
         rs_delay_qubits = _convert_to_rs_instruction(delay_qubits)
         assert delay_qubits == _convert_to_py_instruction(rs_delay_qubits)
 
+    def test_pickle(self, delay_qubits: DelayQubits):
+        pickled = pickle.dumps(delay_qubits)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == delay_qubits
+
 
 @pytest.mark.parametrize(
     ("qubits"),
@@ -862,6 +918,11 @@ class TestFence:
     def test_convert(self, fence: Fence):
         rs_fence = _convert_to_rs_instruction(fence)
         assert fence == _convert_to_py_instruction(rs_fence)
+
+    def test_pickle(self, fence: Fence):
+        pickled = pickle.dumps(fence)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == fence
 
 
 def test_fence_all():
@@ -913,6 +974,11 @@ class TestDefWaveform:
     def test_convert(self, def_waveform: DefWaveform):
         rs_def_waveform = _convert_to_rs_instruction(def_waveform)
         assert def_waveform == _convert_to_py_instruction(rs_def_waveform)
+
+    def test_pickle(self, def_waveform: DefWaveform):
+        pickled = pickle.dumps(def_waveform)
+        unpickled = pickle.loads(def_waveform)
+        assert unpickled == def_waveform
 
 
 @pytest.mark.parametrize(
@@ -974,6 +1040,11 @@ class TestDefCircuit:
         rs_def_circuit = _convert_to_rs_instruction(def_circuit)
         assert def_circuit == _convert_to_py_instruction(rs_def_circuit)
 
+    def test_pickle(self, def_circuit: DefCircuit):
+        pickled = pickle.dumps(def_circuit)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == def_circuit
+
 
 @pytest.mark.parametrize(
     ("frame", "kernel", "memory_region", "nonblocking"),
@@ -1034,6 +1105,11 @@ class TestCapture:
     def test_convert(self, capture: Capture):
         rs_capture = _convert_to_rs_instruction(capture)
         assert capture == _convert_to_py_instruction(rs_capture)
+
+    def test_pickle(self, capture: Capture):
+        pickled = pickle.dumps(capture)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == capture
 
 
 @pytest.mark.parametrize(
@@ -1125,6 +1201,11 @@ class TestPulse:
         rs_pulse = _convert_to_rs_instruction(pulse)
         assert pulse == _convert_to_py_instruction(rs_pulse)
 
+    def test_pickle(self, pulse: Pulse):
+        pickled = pickle.dumps(pulse)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == pulse
+
 
 @pytest.mark.parametrize(
     ("frame", "duration", "memory_region", "nonblocking"),
@@ -1185,6 +1266,11 @@ class TestRawCapture:
     def test_convert(self, raw_capture: RawCapture):
         rs_raw_capture = _convert_to_rs_instruction(raw_capture)
         assert raw_capture == _convert_to_py_instruction(rs_raw_capture)
+
+    def test_pickle(self, raw_capture: RawCapture):
+        pickled = pickle.dumps(raw_capture)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == raw_capture
 
 
 @pytest.mark.parametrize(
@@ -1260,32 +1346,37 @@ class TestFrameMutations:
 )
 class TestSwapPhases:
     @pytest.fixture
-    def swap_phase(self, frame_a, frame_b):
+    def swap_phases(self, frame_a, frame_b):
         return SwapPhases(frame_a, frame_b)
 
-    def test_out(self, swap_phase: SwapPhases, snapshot: SnapshotAssertion):
-        assert swap_phase.out() == snapshot
+    def test_out(self, swap_phases: SwapPhases, snapshot: SnapshotAssertion):
+        assert swap_phases.out() == snapshot
 
-    def test_frames(self, swap_phase: SwapPhases, frame_a: Frame, frame_b: Frame):
-        assert swap_phase.frameA == frame_a
-        assert swap_phase.frameB == frame_b
-        swap_phase.frameA = Frame([Qubit(123)], "NEW-FRAME")
-        swap_phase.frameB = Frame([Qubit(123)], "NEW-FRAME")
-        assert swap_phase.frameA == Frame([Qubit(123)], "NEW-FRAME")
-        assert swap_phase.frameB == Frame([Qubit(123)], "NEW-FRAME")
+    def test_frames(self, swap_phases: SwapPhases, frame_a: Frame, frame_b: Frame):
+        assert swap_phases.frameA == frame_a
+        assert swap_phases.frameB == frame_b
+        swap_phases.frameA = Frame([Qubit(123)], "NEW-FRAME")
+        swap_phases.frameB = Frame([Qubit(123)], "NEW-FRAME")
+        assert swap_phases.frameA == Frame([Qubit(123)], "NEW-FRAME")
+        assert swap_phases.frameB == Frame([Qubit(123)], "NEW-FRAME")
 
-    def test_get_qubits(self, swap_phase: SwapPhases, frame_a: Frame, frame_b: Frame):
+    def test_get_qubits(self, swap_phases: SwapPhases, frame_a: Frame, frame_b: Frame):
         expected_qubits = set(frame_a.qubits + frame_b.qubits)
-        assert swap_phase.get_qubits() == set([q.index for q in expected_qubits if isinstance(q, Qubit)])
-        assert swap_phase.get_qubits(False) == expected_qubits
+        assert swap_phases.get_qubits() == set([q.index for q in expected_qubits if isinstance(q, Qubit)])
+        assert swap_phases.get_qubits(False) == expected_qubits
 
-    def test_copy(self, swap_phase: SwapPhases):
-        assert isinstance(copy.copy(swap_phase), SwapPhases)
-        assert isinstance(copy.deepcopy(swap_phase), SwapPhases)
+    def test_copy(self, swap_phases: SwapPhases):
+        assert isinstance(copy.copy(swap_phases), SwapPhases)
+        assert isinstance(copy.deepcopy(swap_phases), SwapPhases)
 
-    def test_convert(self, swap_phase: SwapPhases):
-        rs_swap_phase = _convert_to_rs_instruction(swap_phase)
-        assert swap_phase == _convert_to_py_instruction(rs_swap_phase)
+    def test_convert(self, swap_phases: SwapPhases):
+        rs_swap_phase = _convert_to_rs_instruction(swap_phases)
+        assert swap_phases == _convert_to_py_instruction(rs_swap_phase)
+
+    def test_pickle(self, swap_phases: SwapPhases):
+        pickled = pickle.dumps(swap_phases)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == swap_phases
 
 
 @pytest.mark.parametrize(
@@ -1322,6 +1413,11 @@ class TestClassicalMove:
         rs_classical_move = _convert_to_rs_instruction(move)
         assert move == _convert_to_py_instruction(rs_classical_move)
 
+    def test_pickle(self, move: ClassicalMove):
+        pickled = pickle.dumps(move)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == move
+
 
 @pytest.mark.parametrize(
     ("left", "right"),
@@ -1353,6 +1449,11 @@ class TestClassicalExchange:
         rs_classical_exchange = _convert_to_rs_instruction(exchange)
         assert exchange == _convert_to_py_instruction(rs_classical_exchange)
 
+    def test_pickle(self, exchange: ClassicalExchange):
+        pickled = pickle.dumps(exchange)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == exchange
+
 
 @pytest.mark.parametrize(
     ("left", "right"),
@@ -1383,6 +1484,11 @@ class TestClassicalConvert:
     def test_convert(self, convert: ClassicalConvert):
         rs_classical_convert = _convert_to_rs_instruction(convert)
         assert convert == _convert_to_py_instruction(rs_classical_convert)
+
+    def test_pickle(self, convert: ClassicalConvert):
+        pickled = pickle.dumps(convert)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == convert
 
 
 @pytest.mark.parametrize(
@@ -1419,6 +1525,11 @@ class TestClassicalLoad:
     def test_convert(self, load: ClassicalLoad):
         rs_classical_load = _convert_to_rs_instruction(load)
         assert load == _convert_to_py_instruction(rs_classical_load)
+
+    def test_pickle(self, load: ClassicalLoad):
+        pickled = pickle.dumps(load)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == load
 
 
 @pytest.mark.parametrize(
@@ -1460,6 +1571,10 @@ class TestClassicalStore:
         rs_classical_store = _convert_to_rs_instruction(store)
         assert store == _convert_to_py_instruction(rs_classical_store)
 
+    def test_pickle(self, store: ClassicalStore):
+        pickled = pickle.dumps(store)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == store
 
 @pytest.mark.parametrize(
     ("op", "target", "left", "right"),
@@ -1512,6 +1627,11 @@ class TestClassicalComparison:
         rs_classical_comparison = _convert_to_rs_instruction(comparison)
         assert comparison == _convert_to_py_instruction(rs_classical_comparison)
 
+    def test_pickle(self, comparison: ClassicalComparison):
+        pickled = pickle.dumps(comparison)
+        unpickled = pickle.loads(comparison)
+        assert unpickled == comparison
+
 
 @pytest.mark.parametrize(
     ("op", "target"),
@@ -1544,6 +1664,10 @@ class TestUnaryClassicalInstruction:
         rs_classical_unary = _convert_to_rs_instruction(unary)
         assert unary == _convert_to_py_instruction(rs_classical_unary)
 
+    def test_pickle(self, unary: UnaryClassicalInstruction):
+        pickled = pickle.dumps(unary)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == unary
 
 @pytest.mark.parametrize(
     ("op", "left", "right"),
@@ -1595,6 +1719,11 @@ class TestArithmeticBinaryOp:
         rs_classical_arithmetic = _convert_to_rs_instruction(arithmetic)
         assert arithmetic == _convert_to_py_instruction(rs_classical_arithmetic)
 
+    def test_pickle(self, arithmetic: UnaryClassicalInstruction):
+        pickled = pickle.dumps(arithmetic)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == arithmetic
+
 
 @pytest.mark.parametrize(
     ("op", "left", "right"),
@@ -1634,6 +1763,10 @@ class TestLogicalBinaryOp:
         rs_classical_logical = _convert_to_rs_instruction(logical)
         assert logical == _convert_to_py_instruction(rs_classical_logical)
 
+    def test_pickle(self, logical: LogicalBinaryOp):
+        pickled = pickle.dumps(logical)
+        unpickled = pickle.loads(pickled)
+        assert unpickled == logical
 
 def test_include():
     include = Include("my-cool-file.quil")


### PR DESCRIPTION
## Description

This closes #1719 (along w/ an additional request to support `QPUExecuteResponse`), and #1791 (but for all instruction classes).

Waiting on some upstream changes to land, once they do, this PR should pass CI.

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] (New Feature) The [docs][docs] have been updated accordingly.


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
