### PR TITLE
fix: The DefMeasureCalibration `instructions` property returns `pyQuil` `AbstractInstrction`s instead of `quil` `Instruction`s

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -2843,6 +2843,15 @@ class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstru
     def instrs(self, instrs: list[AbstractInstruction]) -> None:
         quil_rs.MeasureCalibrationDefinition.instructions.__set__(self, _convert_to_rs_instructions(instrs))  # type: ignore[attr-defined] # noqa
 
+    @property  # type: ignore[override]
+    def instructions(self) -> list[AbstractInstruction]:
+        """The instructions in the calibration."""
+        return self.instrs
+
+    @instructions.setter
+    def instructions(self, instructions: list[AbstractInstruction]) -> None:
+        self.instrs = instructions
+
     def out(self) -> str:
         """Return the instruction as a valid Quil string."""
         return super().to_quil()

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -473,8 +473,21 @@ class TestDefMeasureCalibration:
 
     def test_instrs(self, measure_calibration: DefMeasureCalibration, instrs: List[AbstractInstruction]):
         assert measure_calibration.instrs == instrs
-        measure_calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], [])]
-        assert measure_calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], [])]
+        measure_calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], []), Fence([0])]
+        assert isinstance(measure_calibration.instrs[0], Gate)
+        assert not isinstance(measure_calibration.instrs[0], Fence)
+        assert isinstance(measure_calibration.instrs[1], Fence)
+        assert not isinstance(measure_calibration.instrs[1], Gate)
+        assert measure_calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], []), Fence([0])]
+
+    def test_instructions(self, measure_calibration: DefMeasureCalibration, instrs: List[AbstractInstruction]):
+        assert measure_calibration.instructions == instrs
+        measure_calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], []), Fence([0])]
+        assert isinstance(measure_calibration.instrs[0], Gate)
+        assert not isinstance(measure_calibration.instrs[0], Fence)
+        assert isinstance(measure_calibration.instrs[1], Fence)
+        assert not isinstance(measure_calibration.instrs[1], Gate)
+        assert measure_calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], []), Fence([0])]
 
     def test_copy(self, measure_calibration: DefMeasureCalibration):
         assert isinstance(copy.copy(measure_calibration), DefMeasureCalibration)


### PR DESCRIPTION
## Description

closes #1798 

pyQuil v3 defined the `instrs` property on `DefMeasureCalibration` as the only way to get the calibrations contained instructions. The `quil` counterpart uses an `instructions` property for this purpose. In pyQuil v4, we inherit from `quil` base types, but for `DefMeasureCalibration`, never overrode the `instructions` property, meaning that when `instructions` was accessed on `DefMeasureCalibration`, `quil` classes were returned. This fix overrides the inherited instruction property and uses the compatibility layer to return pyQuil compatible instructions.

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
