### PR TITLE
 fix: Unpickling an `AbstractInstruction` will result in an `AbstractInstruction` instead of a `quil` `Instruction`

### DIFF
--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -23,12 +23,13 @@ from typing import (
     Callable,
     ClassVar,
     Optional,
+    TypeVar,
     Union,
 )
 
 import numpy as np
 from deprecated.sphinx import deprecated
-from typing_extensions import Self
+from typing_extensions import Self, Type
 
 from pyquil.quilatom import (
     Expression,
@@ -102,6 +103,22 @@ class AbstractInstruction(metaclass=_InstructionMeta):
 
     def __hash__(self) -> int:
         return hash(str(self))
+
+
+_T = TypeVar("_T", bound=type)
+
+
+def _add_reduce_method(cls: _T) -> _T:
+    def __reduce__(self: Any) -> tuple[Callable[[Any], AbstractInstruction], tuple[Any]]:
+        init_fn, args = super(self, cls).__reduce__()
+        obj = init_fn(*args)
+        return (
+            _convert_to_py_instruction,
+            (obj,),
+        )
+
+    cls.__reduce__ = __reduce__  # type: ignore
+    return cls
 
 
 def _convert_to_rs_instruction(instr: Union[AbstractInstruction, quil_rs.Instruction]) -> quil_rs.Instruction:
@@ -319,6 +336,7 @@ RESERVED_WORDS: Container[str] = [
 ]
 
 
+@_add_reduce_method
 class Gate(quil_rs.Gate, AbstractInstruction):
     """A quantum gate instruction."""
 
@@ -488,6 +506,7 @@ def _strip_modifiers(gate: Gate, limit: Optional[int] = None) -> Gate:
     return stripped
 
 
+@_add_reduce_method
 class Measurement(quil_rs.Measurement, AbstractInstruction):
     """A Quil measurement instruction."""
 
@@ -565,6 +584,7 @@ class Measurement(quil_rs.Measurement, AbstractInstruction):
         return Measurement._from_rs_measurement(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class Reset(quil_rs.Reset, AbstractInstruction):
     """The RESET instruction."""
 
@@ -644,6 +664,7 @@ class ResetQubit(Reset):
         raise ValueError("reset.qubit should not be None")
 
 
+@_add_reduce_method
 class DefGate(quil_rs.GateDefinition, AbstractInstruction):
     """A DEFGATE directive."""
 
@@ -840,6 +861,7 @@ class DefGateByPaulis(DefGate):
         return super().to_quil_or_debug()
 
 
+@_add_reduce_method
 class JumpTarget(quil_rs.Label, AbstractInstruction):
     """Representation of a target that can be jumped to."""
 
@@ -872,6 +894,7 @@ class JumpTarget(quil_rs.Label, AbstractInstruction):
         return JumpTarget._from_rs_label(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class JumpWhen(quil_rs.JumpWhen, AbstractInstruction):
     """The JUMP-WHEN instruction."""
 
@@ -923,6 +946,7 @@ class JumpWhen(quil_rs.JumpWhen, AbstractInstruction):
         return JumpWhen._from_rs_jump_when(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class JumpUnless(quil_rs.JumpUnless, AbstractInstruction):
     """The JUMP-UNLESS instruction."""
 
@@ -1011,6 +1035,7 @@ class Nop(SimpleInstruction):
     instruction = quil_rs.Instruction.new_nop()
 
 
+@_add_reduce_method
 class UnaryClassicalInstruction(quil_rs.UnaryLogic, AbstractInstruction):
     """Base class for unary classical instructions."""
 
@@ -1061,6 +1086,7 @@ class ClassicalNot(UnaryClassicalInstruction):
     op = quil_rs.UnaryOperator.Not
 
 
+@_add_reduce_method
 class LogicalBinaryOp(quil_rs.BinaryLogic, AbstractInstruction):
     """Base class for binary logical classical instructions."""
 
@@ -1142,6 +1168,7 @@ class ClassicalExclusiveOr(LogicalBinaryOp):
     op = quil_rs.BinaryOperator.Xor
 
 
+@_add_reduce_method
 class ArithmeticBinaryOp(quil_rs.Arithmetic, AbstractInstruction):
     """Base class for binary arithmetic classical instructions."""
 
@@ -1216,6 +1243,7 @@ class ClassicalDiv(ArithmeticBinaryOp):
     op = quil_rs.ArithmeticOperator.Divide
 
 
+@_add_reduce_method
 class ClassicalMove(quil_rs.Move, AbstractInstruction):
     """The MOVE instruction."""
 
@@ -1259,6 +1287,7 @@ class ClassicalMove(quil_rs.Move, AbstractInstruction):
         return ClassicalMove._from_rs_move(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class ClassicalExchange(quil_rs.Exchange, AbstractInstruction):
     """The EXCHANGE instruction."""
 
@@ -1306,6 +1335,7 @@ class ClassicalExchange(quil_rs.Exchange, AbstractInstruction):
         return ClassicalExchange._from_rs_exchange(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class ClassicalConvert(quil_rs.Convert, AbstractInstruction):
     """The CONVERT instruction."""
 
@@ -1349,6 +1379,7 @@ class ClassicalConvert(quil_rs.Convert, AbstractInstruction):
         return ClassicalConvert._from_rs_convert(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class ClassicalLoad(quil_rs.Load, AbstractInstruction):
     """The LOAD instruction."""
 
@@ -1420,6 +1451,7 @@ def _to_py_arithmetic_operand(operand: quil_rs.ArithmeticOperand) -> Union[Memor
     return inner
 
 
+@_add_reduce_method
 class ClassicalStore(quil_rs.Store, AbstractInstruction):
     """The STORE instruction."""
 
@@ -1473,6 +1505,7 @@ class ClassicalStore(quil_rs.Store, AbstractInstruction):
         return ClassicalStore._from_rs_store(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class ClassicalComparison(quil_rs.Comparison, AbstractInstruction):
     """Base class for ternary comparison instructions."""
 
@@ -1588,6 +1621,7 @@ class ClassicalGreaterEqual(ClassicalComparison):
     op = quil_rs.ComparisonOperator.GreaterThanOrEqual
 
 
+@_add_reduce_method
 class Jump(quil_rs.Jump, AbstractInstruction):
     """Representation of an unconditional jump instruction (JUMP)."""
 
@@ -1624,6 +1658,7 @@ class Jump(quil_rs.Jump, AbstractInstruction):
         return Jump._from_rs_jump(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class Pragma(quil_rs.Pragma, AbstractInstruction):
     """A PRAGMA instruction.
 
@@ -1712,6 +1747,7 @@ class Pragma(quil_rs.Pragma, AbstractInstruction):
         return Pragma._from_rs_pragma(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class Declare(quil_rs.Declaration, AbstractInstruction):
     """A DECLARE directive.
 
@@ -1838,6 +1874,7 @@ class Declare(quil_rs.Declaration, AbstractInstruction):
         return Declare._from_rs_declaration(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class Include(quil_rs.Include, AbstractInstruction):
     """An INCLUDE directive."""
 
@@ -1859,6 +1896,7 @@ class Include(quil_rs.Include, AbstractInstruction):
         return Include._from_rs_include(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class Pulse(quil_rs.Pulse, AbstractInstruction):
     """A PULSE instruction."""
 
@@ -1926,6 +1964,7 @@ class Pulse(quil_rs.Pulse, AbstractInstruction):
         return Pulse._from_rs_pulse(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class SetFrequency(quil_rs.SetFrequency, AbstractInstruction):
     """A SET-FREQUENCY instruction."""
 
@@ -1983,6 +2022,7 @@ class SetFrequency(quil_rs.SetFrequency, AbstractInstruction):
         return SetFrequency._from_rs_set_frequency(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class ShiftFrequency(quil_rs.ShiftFrequency, AbstractInstruction):
     """The SHIFT-FREQUENCY instruction."""
 
@@ -2040,6 +2080,7 @@ class ShiftFrequency(quil_rs.ShiftFrequency, AbstractInstruction):
         return ShiftFrequency._from_rs_shift_frequency(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class SetPhase(quil_rs.SetPhase, AbstractInstruction):
     """The SET-PHASE instruction."""
 
@@ -2097,6 +2138,7 @@ class SetPhase(quil_rs.SetPhase, AbstractInstruction):
         return SetPhase._from_rs_set_phase(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class ShiftPhase(quil_rs.ShiftPhase, AbstractInstruction):
     """The SHIFT-PHASE instruction."""
 
@@ -2154,6 +2196,7 @@ class ShiftPhase(quil_rs.ShiftPhase, AbstractInstruction):
         return ShiftPhase._from_rs_shift_phase(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class SwapPhases(quil_rs.SwapPhases, AbstractInstruction):
     """The SWAP-PHASES instruction."""
 
@@ -2211,6 +2254,7 @@ class SwapPhases(quil_rs.SwapPhases, AbstractInstruction):
         return SwapPhases._from_rs_swap_phases(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class SetScale(quil_rs.SetScale, AbstractInstruction):
     """The SET-SCALE instruction."""
 
@@ -2268,6 +2312,7 @@ class SetScale(quil_rs.SetScale, AbstractInstruction):
         return SetScale._from_rs_set_scale(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class Capture(quil_rs.Capture, AbstractInstruction):
     """The CAPTURE instruction."""
 
@@ -2352,6 +2397,7 @@ class Capture(quil_rs.Capture, AbstractInstruction):
         return Capture._from_rs_capture(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class RawCapture(quil_rs.RawCapture, AbstractInstruction):
     """The RAW-CAPTURE instruction."""
 
@@ -2440,6 +2486,7 @@ class RawCapture(quil_rs.RawCapture, AbstractInstruction):
         return RawCapture._from_rs_raw_capture(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class Delay(quil_rs.Delay, AbstractInstruction):
     """The DELAY instruction."""
 
@@ -2534,6 +2581,7 @@ class DelayQubits(Delay):
         return Delay._from_rs_delay.__func__(cls, delay)  # type: ignore
 
 
+@_add_reduce_method
 class Fence(quil_rs.Fence, AbstractInstruction):
     """The FENCE instruction."""
 
@@ -2579,6 +2627,7 @@ class FenceAll(Fence):
         return super().__new__(cls, [])
 
 
+@_add_reduce_method
 class DefWaveform(quil_rs.WaveformDefinition, AbstractInstruction):
     """A waveform definition."""
 
@@ -2637,6 +2686,7 @@ class DefWaveform(quil_rs.WaveformDefinition, AbstractInstruction):
         return DefWaveform._from_rs_waveform_definition(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class DefCircuit(quil_rs.CircuitDefinition, AbstractInstruction):
     """A circuit definition."""
 
@@ -2707,6 +2757,7 @@ class DefCircuit(quil_rs.CircuitDefinition, AbstractInstruction):
         return DefCircuit._from_rs_circuit_definition(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class DefCalibration(quil_rs.Calibration, AbstractInstruction):
     """A calibration definition."""
 
@@ -2789,6 +2840,7 @@ class DefCalibration(quil_rs.Calibration, AbstractInstruction):
         return DefCalibration._from_rs_calibration(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstruction):
     """A measure calibration definition."""
 
@@ -2866,6 +2918,7 @@ class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstru
         return DefMeasureCalibration._from_rs_measure_calibration_definition(super().__deepcopy__(memo))
 
 
+@_add_reduce_method
 class DefFrame(quil_rs.FrameDefinition, AbstractInstruction):
     """A frame definition."""
 

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -29,7 +29,7 @@ from typing import (
 
 import numpy as np
 from deprecated.sphinx import deprecated
-from typing_extensions import Self, Type
+from typing_extensions import Self
 
 from pyquil.quilatom import (
     Expression,

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -2843,6 +2843,15 @@ class DefMeasureCalibration(quil_rs.MeasureCalibrationDefinition, AbstractInstru
     def instrs(self, instrs: list[AbstractInstruction]) -> None:
         quil_rs.MeasureCalibrationDefinition.instructions.__set__(self, _convert_to_rs_instructions(instrs))  # type: ignore[attr-defined] # noqa
 
+    @property  # type: ignore[override]
+    def instructions(self) -> list[AbstractInstruction]:
+        """The instructions in the calibration."""
+        return self.instrs
+
+    @instructions.setter
+    def instructions(self, instructions: list[AbstractInstruction]) -> None:
+        self.instrs = instructions
+
     def out(self) -> str:
         """Return the instruction as a valid Quil string."""
         return super().to_quil()

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -110,7 +110,7 @@ _T = TypeVar("_T", bound=type)
 
 def _add_reduce_method(cls: _T) -> _T:
     def __reduce__(self: Any) -> tuple[Callable[[Any], AbstractInstruction], tuple[Any]]:
-        init_fn, args = super(self, cls).__reduce__()
+        init_fn, args = super(cls, self).__reduce__()  # type: ignore
         obj = init_fn(*args)
         return (
             _convert_to_py_instruction,

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -473,8 +473,21 @@ class TestDefMeasureCalibration:
 
     def test_instrs(self, measure_calibration: DefMeasureCalibration, instrs: List[AbstractInstruction]):
         assert measure_calibration.instrs == instrs
-        measure_calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], [])]
-        assert measure_calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], [])]
+        measure_calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], []), Fence([0])]
+        assert isinstance(measure_calibration.instrs[0], Gate)
+        assert not isinstance(measure_calibration.instrs[0], Fence)
+        assert isinstance(measure_calibration.instrs[1], Fence)
+        assert not isinstance(measure_calibration.instrs[1], Gate)
+        assert measure_calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], []), Fence([0])]
+
+    def test_instructions(self, measure_calibration: DefMeasureCalibration, instrs: List[AbstractInstruction]):
+        assert measure_calibration.instructions == instrs
+        measure_calibration.instrs = [Gate("SomeGate", [], [Qubit(0)], []), Fence([0])]
+        assert isinstance(measure_calibration.instrs[0], Gate)
+        assert not isinstance(measure_calibration.instrs[0], Fence)
+        assert isinstance(measure_calibration.instrs[1], Fence)
+        assert not isinstance(measure_calibration.instrs[1], Gate)
+        assert measure_calibration.instrs == [Gate("SomeGate", [], [Qubit(0)], []), Fence([0])]
 
     def test_copy(self, measure_calibration: DefMeasureCalibration):
         assert isinstance(copy.copy(measure_calibration), DefMeasureCalibration)

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -830,7 +830,7 @@ class TestReset:
     def test_pickle(self, reset_qubit: Reset):
         pickled = pickle.dumps(reset_qubit)
         unpickled = pickle.loads(pickled)
-        assert isinstance(unpickled, Reset)
+        assert isinstance(unpickled, (Reset, ResetQubit))
         assert unpickled == reset_qubit
 
 

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -191,6 +191,7 @@ class TestGate:
     def test_pickle(self, gate: Gate):
         pickled = pickle.dumps(gate)
         unpickled = pickle.loads(pickled)
+        assert isinstance(unpickled, Gate)
         assert unpickled == gate
 
 
@@ -270,6 +271,7 @@ class TestDefGate:
     def test_pickle(self, def_gate: DefGate, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(def_gate)
         unpickled = pickle.loads(pickled)
+        assert isinstance(def_gate, DefGate)
         assert unpickled == snapshot
 
 
@@ -444,6 +446,7 @@ class TestDefCalibration:
     def test_pickle(self, calibration: DefCalibration):
         pickled = pickle.dumps(calibration)
         unpickled = pickle.loads(pickled)
+        assert isinstance(calibration, DefCalibration)
         assert unpickled == calibration
 
 
@@ -548,6 +551,7 @@ class TestMeasurement:
     def test_pickle(self, measurement: Measurement):
         pickled = pickle.dumps(measurement)
         unpickled = pickle.loads(pickled)
+        assert isinstance(measurement, Measurement)
         assert unpickled == measurement
 
 
@@ -643,9 +647,9 @@ class TestDefFrame:
         assert def_frame == _convert_to_py_instruction(rs_def_frame)
 
     def test_pickle(self, def_frame: DefFrame):
-        print(def_frame.to_quil())
         pickled = pickle.dumps(def_frame)
         unpickled = pickle.loads(pickled)
+        assert isinstance(def_frame, DefFrame)
         assert unpickled == def_frame
 
 
@@ -721,6 +725,7 @@ class TestDeclare:
     def test_pickle(self, declare: Declare):
         pickled = pickle.dumps(declare)
         unpickled = pickle.loads(pickled)
+        assert isinstance(declare, Declare)
         assert unpickled == declare
 
 
@@ -771,6 +776,7 @@ class TestPragma:
     def test_pickle(self, pragma: Pragma):
         pickled = pickle.dumps(pragma)
         unpickled = pickle.loads(pickled)
+        assert isinstance(pragma, Pragma)
         assert unpickled == pragma
 
 
@@ -823,6 +829,7 @@ class TestReset:
     def test_pickle(self, reset_qubit: Reset):
         pickled = pickle.dumps(reset_qubit)
         unpickled = pickle.loads(pickled)
+        assert isinstance(reset_qubit, Reset)
         assert unpickled == reset_qubit
 
 
@@ -861,6 +868,7 @@ class TestDelayFrames:
     def test_pickle(self, delay_frames: DelayFrames):
         pickled = pickle.dumps(delay_frames)
         unpickled = pickle.loads(pickled)
+        assert isinstance(delay_frames, DelayFrames)
         assert unpickled == delay_frames
 
 
@@ -901,6 +909,7 @@ class TestDelayQubits:
     def test_pickle(self, delay_qubits: DelayQubits):
         pickled = pickle.dumps(delay_qubits)
         unpickled = pickle.loads(pickled)
+        assert isinstance(delay_qubits, DelayQubits)
         assert unpickled == delay_qubits
 
 
@@ -936,6 +945,7 @@ class TestFence:
     def test_pickle(self, fence: Fence):
         pickled = pickle.dumps(fence)
         unpickled = pickle.loads(pickled)
+        assert isinstance(fence, Fence)
         assert unpickled == fence
 
 
@@ -989,9 +999,9 @@ class TestDefWaveform:
         assert def_waveform == _convert_to_py_instruction(rs_def_waveform)
 
     def test_pickle(self, def_waveform: DefWaveform, snapshot: SnapshotAssertion):
-        print(def_waveform.to_quil())
         pickled = pickle.dumps(def_waveform)
         unpickled = pickle.loads(pickled)
+        assert isinstance(def_waveform, DefWaveform)
         assert unpickled == snapshot
 
 
@@ -1054,9 +1064,9 @@ class TestDefCircuit:
         assert def_circuit == _convert_to_py_instruction(rs_def_circuit)
 
     def test_pickle(self, def_circuit: DefCircuit):
-        print(def_circuit.to_quil())
         pickled = pickle.dumps(def_circuit)
         unpickled = pickle.loads(pickled)
+        assert isinstance(def_circuit, DefCircuit)
         assert unpickled == def_circuit
 
 
@@ -1123,6 +1133,7 @@ class TestCapture:
     def test_pickle(self, capture: Capture, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(capture)
         unpickled = pickle.loads(pickled)
+        assert isinstance(capture, Capture)
         assert unpickled == snapshot
 
 
@@ -1218,6 +1229,7 @@ class TestPulse:
     def test_pickle(self, pulse: Pulse, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(pulse)
         unpickled = pickle.loads(pickled)
+        assert isinstance(pulse, Pulse)
         assert unpickled == snapshot
 
 
@@ -1284,6 +1296,7 @@ class TestRawCapture:
     def test_pickle(self, raw_capture: RawCapture):
         pickled = pickle.dumps(raw_capture)
         unpickled = pickle.loads(pickled)
+        assert isinstance(raw_capture, RawCapture)
         assert unpickled == raw_capture
 
 
@@ -1390,6 +1403,7 @@ class TestSwapPhases:
     def test_pickle(self, swap_phases: SwapPhases):
         pickled = pickle.dumps(swap_phases)
         unpickled = pickle.loads(pickled)
+        assert isinstance(swap_phases, SwapPhases)
         assert unpickled == swap_phases
 
 
@@ -1430,6 +1444,7 @@ class TestClassicalMove:
     def test_pickle(self, move: ClassicalMove):
         pickled = pickle.dumps(move)
         unpickled = pickle.loads(pickled)
+        assert isinstance(move, ClassicalMove)
         assert unpickled == move
 
 
@@ -1466,6 +1481,7 @@ class TestClassicalExchange:
     def test_pickle(self, exchange: ClassicalExchange):
         pickled = pickle.dumps(exchange)
         unpickled = pickle.loads(pickled)
+        assert isinstance(exchange, ClassicalExchange)
         assert unpickled == exchange
 
 
@@ -1502,6 +1518,7 @@ class TestClassicalConvert:
     def test_pickle(self, convert: ClassicalConvert):
         pickled = pickle.dumps(convert)
         unpickled = pickle.loads(pickled)
+        assert isinstance(convert, ClassicalConvert)
         assert unpickled == convert
 
 
@@ -1543,6 +1560,7 @@ class TestClassicalLoad:
     def test_pickle(self, load: ClassicalLoad):
         pickled = pickle.dumps(load)
         unpickled = pickle.loads(pickled)
+        assert isinstance(load, ClassicalLoad)
         assert unpickled == load
 
 
@@ -1588,6 +1606,7 @@ class TestClassicalStore:
     def test_pickle(self, store: ClassicalStore):
         pickled = pickle.dumps(store)
         unpickled = pickle.loads(pickled)
+        assert isinstance(store, ClassicalStore)
         assert unpickled == store
 
 
@@ -1645,6 +1664,7 @@ class TestClassicalComparison:
     def test_pickle(self, comparison: ClassicalComparison):
         pickled = pickle.dumps(comparison)
         unpickled = pickle.loads(pickled)
+        assert isinstance(comparison, ClassicalComparison)
         assert unpickled == comparison
 
 
@@ -1727,7 +1747,7 @@ class TestArithmeticBinaryOp:
     def valid_in_program(self, arithmetic):
         try:
             p = Program(arithmetic)
-            p[0] == arithmetic
+            p[0] = arithmetic
         except Exception:
             pytest.fail("ArithmeticBinaryOp not valid in Program")
 

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -910,7 +910,7 @@ class TestDelayQubits:
     def test_pickle(self, delay_qubits: DelayQubits):
         pickled = pickle.dumps(delay_qubits)
         unpickled = pickle.loads(pickled)
-        assert isinstance(unickled, DelayQubits)
+        assert isinstance(unpickled, DelayQubits)
         assert unpickled == delay_qubits
 
 

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -271,7 +271,7 @@ class TestDefGate:
     def test_pickle(self, def_gate: DefGate, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(def_gate)
         unpickled = pickle.loads(pickled)
-        assert isinstance(def_gate, DefGate)
+        assert isinstance(unpickled, DefGate)
         assert unpickled == snapshot
 
 
@@ -446,7 +446,7 @@ class TestDefCalibration:
     def test_pickle(self, calibration: DefCalibration):
         pickled = pickle.dumps(calibration)
         unpickled = pickle.loads(pickled)
-        assert isinstance(calibration, DefCalibration)
+        assert isinstance(unpickled, DefCalibration)
         assert unpickled == calibration
 
 
@@ -503,6 +503,7 @@ class TestDefMeasureCalibration:
     def test_pickle(self, measure_calibration: DefMeasureCalibration):
         pickled = pickle.dumps(measure_calibration)
         unpickled = pickle.loads(pickled)
+        assert isinstance(unpickled, DefMeasureCalibration)
         assert unpickled == measure_calibration
 
 
@@ -551,7 +552,7 @@ class TestMeasurement:
     def test_pickle(self, measurement: Measurement):
         pickled = pickle.dumps(measurement)
         unpickled = pickle.loads(pickled)
-        assert isinstance(measurement, Measurement)
+        assert isinstance(unpickled, Measurement)
         assert unpickled == measurement
 
 
@@ -649,7 +650,7 @@ class TestDefFrame:
     def test_pickle(self, def_frame: DefFrame):
         pickled = pickle.dumps(def_frame)
         unpickled = pickle.loads(pickled)
-        assert isinstance(def_frame, DefFrame)
+        assert isinstance(unpickled, DefFrame)
         assert unpickled == def_frame
 
 
@@ -725,7 +726,7 @@ class TestDeclare:
     def test_pickle(self, declare: Declare):
         pickled = pickle.dumps(declare)
         unpickled = pickle.loads(pickled)
-        assert isinstance(declare, Declare)
+        assert isinstance(unpickled, Declare)
         assert unpickled == declare
 
 
@@ -776,7 +777,7 @@ class TestPragma:
     def test_pickle(self, pragma: Pragma):
         pickled = pickle.dumps(pragma)
         unpickled = pickle.loads(pickled)
-        assert isinstance(pragma, Pragma)
+        assert isinstance(unpickled, Pragma)
         assert unpickled == pragma
 
 
@@ -829,7 +830,7 @@ class TestReset:
     def test_pickle(self, reset_qubit: Reset):
         pickled = pickle.dumps(reset_qubit)
         unpickled = pickle.loads(pickled)
-        assert isinstance(reset_qubit, Reset)
+        assert isinstance(unpickled, Reset)
         assert unpickled == reset_qubit
 
 
@@ -868,7 +869,7 @@ class TestDelayFrames:
     def test_pickle(self, delay_frames: DelayFrames):
         pickled = pickle.dumps(delay_frames)
         unpickled = pickle.loads(pickled)
-        assert isinstance(delay_frames, DelayFrames)
+        assert isinstance(unpickled, DelayFrames)
         assert unpickled == delay_frames
 
 
@@ -909,7 +910,7 @@ class TestDelayQubits:
     def test_pickle(self, delay_qubits: DelayQubits):
         pickled = pickle.dumps(delay_qubits)
         unpickled = pickle.loads(pickled)
-        assert isinstance(delay_qubits, DelayQubits)
+        assert isinstance(unickled, DelayQubits)
         assert unpickled == delay_qubits
 
 
@@ -945,7 +946,7 @@ class TestFence:
     def test_pickle(self, fence: Fence):
         pickled = pickle.dumps(fence)
         unpickled = pickle.loads(pickled)
-        assert isinstance(fence, Fence)
+        assert isinstance(unpickled, Fence)
         assert unpickled == fence
 
 
@@ -1001,7 +1002,7 @@ class TestDefWaveform:
     def test_pickle(self, def_waveform: DefWaveform, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(def_waveform)
         unpickled = pickle.loads(pickled)
-        assert isinstance(def_waveform, DefWaveform)
+        assert isinstance(unpickled, DefWaveform)
         assert unpickled == snapshot
 
 
@@ -1066,7 +1067,7 @@ class TestDefCircuit:
     def test_pickle(self, def_circuit: DefCircuit):
         pickled = pickle.dumps(def_circuit)
         unpickled = pickle.loads(pickled)
-        assert isinstance(def_circuit, DefCircuit)
+        assert isinstance(unpickled, DefCircuit)
         assert unpickled == def_circuit
 
 
@@ -1133,7 +1134,7 @@ class TestCapture:
     def test_pickle(self, capture: Capture, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(capture)
         unpickled = pickle.loads(pickled)
-        assert isinstance(capture, Capture)
+        assert isinstance(unpickled, Capture)
         assert unpickled == snapshot
 
 
@@ -1229,7 +1230,7 @@ class TestPulse:
     def test_pickle(self, pulse: Pulse, snapshot: SnapshotAssertion):
         pickled = pickle.dumps(pulse)
         unpickled = pickle.loads(pickled)
-        assert isinstance(pulse, Pulse)
+        assert isinstance(unpickled, Pulse)
         assert unpickled == snapshot
 
 
@@ -1296,7 +1297,7 @@ class TestRawCapture:
     def test_pickle(self, raw_capture: RawCapture):
         pickled = pickle.dumps(raw_capture)
         unpickled = pickle.loads(pickled)
-        assert isinstance(raw_capture, RawCapture)
+        assert isinstance(unpickled, RawCapture)
         assert unpickled == raw_capture
 
 
@@ -1403,7 +1404,7 @@ class TestSwapPhases:
     def test_pickle(self, swap_phases: SwapPhases):
         pickled = pickle.dumps(swap_phases)
         unpickled = pickle.loads(pickled)
-        assert isinstance(swap_phases, SwapPhases)
+        assert isinstance(unpickled, SwapPhases)
         assert unpickled == swap_phases
 
 
@@ -1444,7 +1445,7 @@ class TestClassicalMove:
     def test_pickle(self, move: ClassicalMove):
         pickled = pickle.dumps(move)
         unpickled = pickle.loads(pickled)
-        assert isinstance(move, ClassicalMove)
+        assert isinstance(unpickled, ClassicalMove)
         assert unpickled == move
 
 
@@ -1481,7 +1482,7 @@ class TestClassicalExchange:
     def test_pickle(self, exchange: ClassicalExchange):
         pickled = pickle.dumps(exchange)
         unpickled = pickle.loads(pickled)
-        assert isinstance(exchange, ClassicalExchange)
+        assert isinstance(unpickled, ClassicalExchange)
         assert unpickled == exchange
 
 
@@ -1518,7 +1519,7 @@ class TestClassicalConvert:
     def test_pickle(self, convert: ClassicalConvert):
         pickled = pickle.dumps(convert)
         unpickled = pickle.loads(pickled)
-        assert isinstance(convert, ClassicalConvert)
+        assert isinstance(unpickled, ClassicalConvert)
         assert unpickled == convert
 
 
@@ -1560,7 +1561,7 @@ class TestClassicalLoad:
     def test_pickle(self, load: ClassicalLoad):
         pickled = pickle.dumps(load)
         unpickled = pickle.loads(pickled)
-        assert isinstance(load, ClassicalLoad)
+        assert isinstance(unpickled, ClassicalLoad)
         assert unpickled == load
 
 
@@ -1606,7 +1607,7 @@ class TestClassicalStore:
     def test_pickle(self, store: ClassicalStore):
         pickled = pickle.dumps(store)
         unpickled = pickle.loads(pickled)
-        assert isinstance(store, ClassicalStore)
+        assert isinstance(unpickled, ClassicalStore)
         assert unpickled == store
 
 
@@ -1664,7 +1665,7 @@ class TestClassicalComparison:
     def test_pickle(self, comparison: ClassicalComparison):
         pickled = pickle.dumps(comparison)
         unpickled = pickle.loads(pickled)
-        assert isinstance(comparison, ClassicalComparison)
+        assert isinstance(unpickled, ClassicalComparison)
         assert unpickled == comparison
 
 


### PR DESCRIPTION
## Description

Closes #1800

## Checklist

- [X] The PR targets the `master` branch
- [X] The above description motivates these changes.
- [X] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [X] All changes to code are covered via unit tests.
- [X] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [X] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [X] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
