### PR TITLE
Fix the 'getting started' link

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ using `Rigetti's Quantum Cloud Services (QCS) <https://docs.rigetti.com/qcs/>`_.
 
 To learn more about Quil, the Quil SDK, and QCS, see `Rigetti's documentation <https://docs.rigetti.com>`_.
 
-If you’re new to pyQuil, head to the `getting started <getting_started>`_ guide to get setup and run your first program!
+If you’re new to pyQuil, head to the `getting started <getting_started.html>`_ guide to get setup and run your first program!
 
 .. note::
 


### PR DESCRIPTION
## Description

Insert your PR description here. Thanks for [contributing][contributing] to pyQuil! 🙂

## Checklist

- [ ] The PR targets the `master` branch
- [ ] The above description motivates these changes.
- [ ] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [ ] All changes to code are covered via unit tests.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
