### PR TITLE
fix: general tooling fixes in support of quil-rs

### DIFF
--- a/pyquil/latex/_ipython.py
+++ b/pyquil/latex/_ipython.py
@@ -58,8 +58,8 @@ def display(circuit: Program, settings: Optional[DiagramSettings] = None, **imag
         with open(os.path.join(tmpdir, "diagram.tex"), "w") as texfile:
             texfile.write(to_latex(circuit, settings))
 
-        result = subprocess.run(
-            [pdflatex_path, "-halt-on-error", "-output-directory", tmpdir, texfile.name],  # noqa: S603 - valid input
+        result = subprocess.run(  # noqa: S603 - valid input
+            [pdflatex_path, "-halt-on-error", "-output-directory", tmpdir, texfile.name],
             stdout=subprocess.PIPE,
         )
         if result.returncode != 0:

--- a/pyquil/latex/_ipython.py
+++ b/pyquil/latex/_ipython.py
@@ -79,4 +79,4 @@ def display(circuit: Program, settings: Optional[DiagramSettings] = None, **imag
                 msg += " Transcript:\n\n" + result.stderr.decode("utf-8")
             raise RuntimeError(msg)
 
-        return Image(filename=png, **image_options)
+        return Image(filename=png, **image_options)  # type: ignore[no-untyped-call]

--- a/pyquil/noise_gates.py
+++ b/pyquil/noise_gates.py
@@ -51,7 +51,7 @@ def _transform_rpcq_qubit_gate_info_to_qvm_noise_supported_gate(qubit_id: int, g
             return None
 
         parameters = [Parameter(param) if isinstance(param, str) else param for param in gate.parameters]
-        return Gate(gate.operator, parameters, [unpack_qubit(qubit_id)])  # type: ignore
+        return Gate(gate.operator, parameters, [unpack_qubit(qubit_id)])
 
     if gate.operator == Supported1QGate.RZ:
         return Gate(Supported1QGate.RZ, [Parameter("theta")], [unpack_qubit(qubit_id)])

--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -589,7 +589,9 @@ class Expression:
         Note that expression simplification can be slow for large recursive expressions.
         """
         try:
-            if dtype != object:
+            # Ruff documentation says that NumPy overrides `==`, so this rule may produce false
+            # positives; we thus ignore it here.
+            if dtype != object:  # noqa: E721
                 return np.asarray(self._evaluate(), dtype=dtype)
             raise ValueError
         except ValueError:


### PR DESCRIPTION
**This PR is probably unnecessary but I'm leaving it up as draft until I confirm that**

## Description

When [working on quil-rs](https://github.com/rigetti/quil-rs/pull/431), I uncovered some errors when quil-rs is checked with Mypy or Ruff; this PR fixes those small issues.

## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [x] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [x] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [x] (New Feature) The [docs][docs] have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
