### PR TITLE
Allow installation of pyquil and packaging-24.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3548,4 +3548,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<4.0"
-content-hash = "3f046628428b88b676fba5b571a08d52f45ded390f5d0e418f89c00e976ac380"
+content-hash = "83231fe24bb89e0be8d2876614b1a824b8f2cc02508230fa54cbcdcc24b307ed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ rpcq = "^3.11.0"
 networkx = ">=2.5"
 qcs-sdk-python = ">=0.20.1"
 quil = ">=0.15.3"
-packaging = "^23.1"
+packaging = ">=23.1"
 deprecated = "^1.2.14"
 types-deprecated = "^1.2.9.3"
 


### PR DESCRIPTION
## Description

Problem: setuptools-77 requires packaging>=24.2.  Installation of pyquil
downgrades packaging to packaging-23 which breaks pre-installed setuptools.

Solution: Let packaging-24 and pyquil coexist in a Python environment.

Example:

```shell
$ pip install "setuptools>=77"
$ python -c "import setuptools" 
# OK

$ pip install pyquil
# packaging got downgraded to 23.2

$ python -c "import setuptools"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/t312/lib/python3.12/site-packages/setuptools/__init__.py", line 27, in <module>
    from .dist import Distribution
  File "/tmp/t312/lib/python3.12/site-packages/setuptools/dist.py", line 15, in <module>
    from packaging.licenses import canonicalize_license_expression
ModuleNotFoundError: No module named 'packaging.licenses'
```

## Checklist

- [x] The PR targets the `master` branch
- [x] The above description motivates these changes.
- [x] The change is atomic and can be described by a single commit (your PR will be squashed on merge).
- [x] All changes to code are covered via unit tests.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].

[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
