### PR TITLE
docs: fix decoherence noise example missing wrap_in_numshots_loop

### DIFF
--- a/docs/source/noise.rst
+++ b/docs/source/noise.rst
@@ -702,6 +702,7 @@ gate noise, respectively.
                 MEASURE(0, ("ro", 0)),
                 MEASURE(1, ("ro", 1)),
             ])
+            noisy.wrap_in_numshots_loop(1000)
             bitstrings = qc.run(noisy).get_register_map().get("ro")
 
             # Expectation of Z0 and Z1


### PR DESCRIPTION
Fixes #1402

## Summary
The "Adding Decoherence Noise" documentation example was missing a call to `wrap_in_numshots_loop(1000)` before executing the quantum program, causing the statistical calculations to be performed on only a single measurement instead of 1000.

## Changes
- Added `noisy.wrap_in_numshots_loop(1000)` before `qc.run(noisy)` in the decoherence noise example

## Analysis
Without `wrap_in_numshots_loop()`, programs run with the default `num_shots=1`, producing a bitstrings array of shape `(1, 2)`. The example then computes `np.mean(bitstrings, axis=0)` which averages over a single sample, making the statistics meaningless.

This fix matches the pattern used in all other examples in the same documentation file:
- Example 1 (Amplitude damping): Line 375 uses `wrap_in_numshots_loop(trials)`
- Example 2 (Dephased CZ): Line 536 uses `wrap_in_numshots_loop(trials)`
- Readout noise examples: All use `wrap_in_numshots_loop()`

## Note on T2 Parameter
The T2 parameter was left as `T2=t1/2`, which:
- Matches the documented intent (line 670: "By default, T2 = T1 / 2")
- Satisfies the physics constraint (T2 ≤ 2*T1)
- Is more realistic than `T2=2*t1` (which is the theoretical maximum)

The issue originally reported T2 as missing, but it was already added in a previous commit (likely during PR #1574 "Add doctests"), though the `wrap_in_numshots_loop` was still missing.

## Testing
Verified that:
- Default `num_shots = 1` (confirmed in `pyquil/quil.py:140`)
- All existing tests use `wrap_in_numshots_loop()` before `qc.run()` (see `test/unit/test_quantum_computer.py`)
- All tests assert `bitstrings.shape == (num_shots, num_qubits)`