### PR TITLE
fix(quilatom): format complex params with nonzero real and unit imaginary part

### DIFF
--- a/pyquil/quilatom.py
+++ b/pyquil/quilatom.py
@@ -419,13 +419,15 @@ def format_parameter(element: ParameterDesignator) -> str:
             out += repr(r)
 
         if i == 1:
-            if not np.isclose(r, 0, atol=1e-14):
-                raise ValueError(f"Invalid complex number: {element}")
-            out = "i"
+            if np.isclose(r, 0, atol=1e-14):
+                out = "i"
+            else:
+                out += "+i"
         elif i == -1:
-            if not np.isclose(r, 0, atol=1e-14):
-                raise ValueError(f"Invalid complex number: {element}")
-            out = "-i"
+            if np.isclose(r, 0, atol=1e-14):
+                out = "-i"
+            else:
+                out += "-i"
         elif i < 0:
             out += repr(i) + "i"
         elif r != 0:

--- a/test/unit/test_parameters.py
+++ b/test/unit/test_parameters.py
@@ -24,6 +24,9 @@ def test_format_parameter():
         (-1j, "-i"),
         (1e-15 + 1j, "i"),
         (1e-15 - 1j, "-i"),
+        (2 + 1j, "2.0+i"),
+        (2 - 1j, "2.0-i"),
+        (-3 + 1j, "-3.0+i"),
     ]
 
     for test_case in test_cases:


### PR DESCRIPTION
## What's broken

`format_parameter` raises `ValueError` on a complex number whose imaginary part is exactly `+1`/`-1` while the real part is nonzero (e.g. `2+1j`). It's reachable through the non-deprecated noise path `_create_kraus_pragmas`, which serializes Kraus-operator entries into a `PRAGMA ADD-KRAUS` string — and Kraus operators commonly have entries like `2+1j`:

```python
import numpy as np
from pyquil.noise import _create_kraus_pragmas
_create_kraus_pragmas("MYGATE", [0], [np.array([[2+1j, 0],[0, 1]])])
# ValueError: Invalid complex number: (2+1j)
```

## Why it happens

The `i == 1` / `i == -1` branches assumed the real part must be ~0 and raised otherwise. The `np.isclose(r, 0)` check is only meant to drop tiny floating residuals; when the real part is genuinely nonzero it should append `+i`/`-i` to the real part, like every other complex value.

## Fix

When the real part is nonzero, append `+i`/`-i` instead of raising. Output round-trips through pyQuil's own parser (`2.0+i`).

## Test

Extended `test_format_parameter` with `2+1j`, `2-1j`, `-3+1j`; the existing `1e-15±1j → ±"i"` cases still pass, and `test_noise.py` (the Kraus path) stays green.
