### PR TITLE
feat: qudit noise model (2/5) (#1854)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3337,18 +3337,18 @@ httpx = ">=0.21.0"
 
 [[package]]
 name = "rigetti-quax"
-version = "0.7.0"
+version = "0.7.2"
 description = "A high-performance library for quantum information science built on top of JAX"
 optional = false
 python-versions = "<4.0,>=3.11"
 groups = ["main"]
 files = [
-    {file = "rigetti_quax-0.7.0-py3-none-any.whl", hash = "sha256:bc445b03e58a6c1920344e690a4ea687fc470743636f1ccc968f982620a5dfb8"},
-    {file = "rigetti_quax-0.7.0.tar.gz", hash = "sha256:a5597b12f335c89fc29d6e7f92c7ea1a0d70efe9b3507219848cf451ababc5f7"},
+    {file = "rigetti_quax-0.7.2-py3-none-any.whl", hash = "sha256:d93c8151062f7540b3fb1cb88b5cbf0cb11a0e84f4ffc124d4f719e3b1e6c073"},
+    {file = "rigetti_quax-0.7.2.tar.gz", hash = "sha256:c37a05128b12319b6b47fa10d45277ea89eec7a17ed41681d0c641d5113cdb0d"},
 ]
 
 [package.dependencies]
-jax = ">=0.8.2"
+jax = ">=0.10.2"
 
 [package.extras]
 plot = ["plotly (>=5.20)"]
@@ -4182,4 +4182,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.13"
-content-hash = "efc2119133b96df6dde87f1450cfa32f8c12962c262c98af7f43810940e60529"
+content-hash = "5503ff72b2c686de77ff3b8052d08c442d171314d64b643d51775170de61a14e"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2366,15 +2366,14 @@ xml = ["lxml (>=5.3.0)"]
 
 [[package]]
 name = "pandoc"
-version = "2.4b0"
+version = "2.4"
 description = "Pandoc Documents for Python"
 optional = true
 python-versions = "*"
 groups = ["main"]
 markers = "extra == \"docs\""
 files = [
-    {file = "pandoc-2.4b0-py3-none-any.whl", hash = "sha256:c04dafd3d8f1ff733448a48db8329aeb15f5febb10dc33fc28ed8dad7bfd1eab"},
-    {file = "pandoc-2.4b0.tar.gz", hash = "sha256:2dfb17bc05469076c97c1db4c08a8520a3f76b086e26e32d01fe4e408af2ae87"},
+    {file = "pandoc-2.4.tar.gz", hash = "sha256:ecd1f8cbb7f4180c6b5db4a17a7c1a74df519995f5f186ef81ce72a9cbd0dd9a"},
 ]
 
 [package.dependencies]
@@ -4183,4 +4182,4 @@ latex = ["ipython"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.13"
-content-hash = "3ad31f33df8d21556309569d23f9adbbf034ec011d9ad378a891cd4284c7884b"
+content-hash = "efc2119133b96df6dde87f1450cfa32f8c12962c262c98af7f43810940e60529"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1027,66 +1027,133 @@ test-extra = ["curio", "ipython[test]", "jupyter_ai", "matplotlib (!=3.2.0)", "n
 
 [[package]]
 name = "jax"
-version = "0.10.0"
+version = "0.10.2"
 description = "Differentiate, compile, and transform Numpy code."
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
+markers = "python_version == \"3.11\""
 files = [
-    {file = "jax-0.10.0-py3-none-any.whl", hash = "sha256:76c42ba163c8db3dc2e449e225b888c0edfb623ded31efdc96d85e0fda1d26e8"},
-    {file = "jax-0.10.0.tar.gz", hash = "sha256:0119c767de1645f407df72345d28a3837dc904f1d698911c121d8f2b396fdece"},
+    {file = "jax-0.10.2-py3-none-any.whl", hash = "sha256:724d73c4678d8b06f6a6ab4db1b8a2fea8cd4f1e2c2564f99601634ec7b8d1c6"},
+    {file = "jax-0.10.2.tar.gz", hash = "sha256:bf77428a8c2e6904c4f46d5ab12aa5cfc6cad2179f07f7e4c0fc75ac86ef0639"},
 ]
 
 [package.dependencies]
-jaxlib = "0.10.0"
+jaxlib = ">=0.10.1,<=0.10.2"
 ml_dtypes = ">=0.5.0"
 numpy = ">=2.0"
 opt_einsum = "*"
 scipy = ">=1.14"
 
 [package.extras]
-ci = ["jaxlib (==0.9.2)"]
-cuda = ["jax-cuda12-plugin[with-cuda] (==0.10.0)", "jaxlib (==0.10.0)"]
-cuda12 = ["jax-cuda12-plugin[with-cuda] (==0.10.0)", "jaxlib (==0.10.0)"]
-cuda12-local = ["jax-cuda12-plugin (==0.10.0)", "jaxlib (==0.10.0)"]
-cuda13 = ["jax-cuda13-plugin[with-cuda] (==0.10.0)", "jaxlib (==0.10.0)"]
-cuda13-local = ["jax-cuda13-plugin (==0.10.0)", "jaxlib (==0.10.0)"]
+ci = ["jaxlib (==0.10.1)"]
+cuda = ["jax-cuda12-plugin[with-cuda] (==0.10.2)", "jaxlib (==0.10.2)"]
+cuda12 = ["jax-cuda12-plugin[with-cuda] (==0.10.2)", "jaxlib (==0.10.2)"]
+cuda12-local = ["jax-cuda12-plugin (==0.10.2)", "jaxlib (==0.10.2)"]
+cuda13 = ["jax-cuda13-plugin[with-cuda] (==0.10.2)", "jaxlib (==0.10.2)"]
+cuda13-local = ["jax-cuda13-plugin (==0.10.2)", "jaxlib (==0.10.2)"]
 k8s = ["kubernetes"]
-minimum-jaxlib = ["jaxlib (==0.10.0)"]
-rocm7-local = ["jax-rocm7-plugin (==0.10.0.*)", "jaxlib (==0.10.0)"]
-tpu = ["jaxlib (==0.10.0)", "libtpu (==0.0.40.*)", "requests"]
+minimum-jaxlib = ["jaxlib (==0.10.1)"]
+rocm7-local = ["jax-rocm7-plugin (==0.10.2.*)", "jaxlib (==0.10.2)"]
+tpu = ["jaxlib (==0.10.2)", "libtpu (==0.0.42.*)", "requests"]
+xprof = ["xprof"]
+
+[[package]]
+name = "jax"
+version = "0.11.0"
+description = "Differentiate, compile, and transform Numpy code."
+optional = false
+python-versions = ">=3.12"
+groups = ["main"]
+markers = "python_version == \"3.12\""
+files = [
+    {file = "jax-0.11.0-py3-none-any.whl", hash = "sha256:b31ed66c4321d5c9e48b861f51a72ed5f7960c93514296202d2041cbb9ac45bf"},
+    {file = "jax-0.11.0.tar.gz", hash = "sha256:a2feb7cfa48bb35d36b8ecec16a4ec24044dec01935f779b28b017213697b195"},
+]
+
+[package.dependencies]
+jaxlib = "0.11.0"
+ml_dtypes = ">=0.5.0"
+numpy = ">=2.1"
+opt_einsum = "*"
+scipy = ">=1.15"
+
+[package.extras]
+ci = ["jaxlib (==0.10.2)"]
+cuda = ["jax-cuda12-plugin[with-cuda] (==0.11.0)", "jaxlib (==0.11.0)"]
+cuda12 = ["jax-cuda12-plugin[with-cuda] (==0.11.0)", "jaxlib (==0.11.0)"]
+cuda12-local = ["jax-cuda12-plugin (==0.11.0)", "jaxlib (==0.11.0)"]
+cuda13 = ["jax-cuda13-plugin[with-cuda] (==0.11.0)", "jaxlib (==0.11.0)"]
+cuda13-local = ["jax-cuda13-plugin (==0.11.0)", "jaxlib (==0.11.0)"]
+k8s = ["kubernetes"]
+minimum-jaxlib = ["jaxlib (==0.11.0)"]
+oneapi = ["jax-oneapi-plugin[with-oneapi] (==0.11.0)", "jaxlib (==0.11.0)"]
+rocm7-local = ["jax-rocm7-plugin (==0.11.0.*)", "jaxlib (==0.11.0)"]
+tpu = ["jaxlib (==0.11.0)", "libtpu (==0.0.44.*)", "requests"]
 xprof = ["xprof"]
 
 [[package]]
 name = "jaxlib"
-version = "0.10.0"
+version = "0.10.2"
 description = "XLA library for JAX"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
+markers = "python_version == \"3.11\""
 files = [
-    {file = "jaxlib-0.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:277032e9f074c3fd5ffd1e0cb03d4fe66e272de472667cdbc418ad99b21b646a"},
-    {file = "jaxlib-0.10.0-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:3db94ebc859375d955de3504182add7ce1733ce3d30c15e0ef031602cb51a559"},
-    {file = "jaxlib-0.10.0-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:9be229993a41e5b2b84f234ecc19a5de02f35eddb1195cf027bd539e1601e15d"},
-    {file = "jaxlib-0.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:421cdf3a4a5c2ee41471035e586954c8dc599d677ce9b11b063c3926a82a7850"},
-    {file = "jaxlib-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7c1d9b463327c7a2333f210114ecb04f28fefc51ba8233a85a2280cce75bdb42"},
-    {file = "jaxlib-0.10.0-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:aa1d70f1a4e27eb403654e71e2fb28d5786d3e9b77fc1847e8c5389880927ca4"},
-    {file = "jaxlib-0.10.0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:b0bfb865a07df2e6d7418c0b0c292dd294b5500523b1dd5872b180db2aa480d4"},
-    {file = "jaxlib-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:25bf167e0d8b594e0ec50783ff4892c0b7ec37236c88b2b425a7c252823f8680"},
-    {file = "jaxlib-0.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:384635fff55899a295bbc82ee6c6f773a300e787dc472ca92bbe79abfaac8369"},
-    {file = "jaxlib-0.10.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:6d8d78b7070b34e4c5bba5f7e10927e7f4aac9b69be17e9b0a5898553a4338f3"},
-    {file = "jaxlib-0.10.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:d303dc31b65e8b793d5600f81b1583be03dc9b876a4c10b3e259b6609a1cbe3b"},
-    {file = "jaxlib-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:3869be623c2f3391be2ee86f8b412372b102492e67cac0a5f0ab1037bbc3a5cc"},
-    {file = "jaxlib-0.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9050ce2ae7eeca62b1a235065056cad62cac590ddc035486faa4472a47eed9f6"},
-    {file = "jaxlib-0.10.0-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:59e07aab3bdfaad9bdd3cf32e0d3d4f228837b9b231c53f5ae1c0fc284481094"},
-    {file = "jaxlib-0.10.0-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:3088503812cfe49f34a3083d3b7ef5cb3aaf33d89ceb1b3f647fa52713aee59d"},
-    {file = "jaxlib-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98b26672943672742873f65bc03216819fc55325c99f146590d007c0172bff30"},
-    {file = "jaxlib-0.10.0-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:ad47e072430979ec21637aa487d4dc464028b8e9be27268f37de69536c76e341"},
-    {file = "jaxlib-0.10.0-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:2a42cf04c0f88bc03b150a17fa7ddbb2f40e096667ec8a1b840ed87913e6e735"},
-    {file = "jaxlib-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:450b771c01b3662c3497e2dceada3f6fc893112ae637ef85ef1dcc7dc68892a8"},
-    {file = "jaxlib-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f62026c9fb1f05998592082a6dcb62f70b466342bc139f711802a9b184ba9a46"},
-    {file = "jaxlib-0.10.0-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:e66bdc0b57ed5649950799d3f0d67a6bb67f03d06b49ea3fced0bdd6140a9943"},
-    {file = "jaxlib-0.10.0-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:4dccd9065b30954879869641472d5d12fe4d7914175a5cad56293af8429ce7e0"},
+    {file = "jaxlib-0.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5a98873fc867623b81f2bee15d554b8edd6588a183d01fa50d21b1e3db96ff2b"},
+    {file = "jaxlib-0.10.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:d44565dcfd1b4f60f76d911c6512118a8a4fc764bdef92663fecb8bfccd54f23"},
+    {file = "jaxlib-0.10.2-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:1faca3c5d4662cb4a6130a68105d68bb520764817e165d6eebfd6786c0d1f30f"},
+    {file = "jaxlib-0.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:e7a9214e6b0b9e0825d905573d1bbf2253c20e9d7464a63e085b60519975553f"},
+    {file = "jaxlib-0.10.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47bb7c011515ea862be7e8313f40f9c56cbec09dc98a0fcb5016785fcd454c01"},
+    {file = "jaxlib-0.10.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:53b72977ae582c03a9e8e1cdee1efbf8ebc1418270965b0e69eade57acf40331"},
+    {file = "jaxlib-0.10.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:fe88ec443714c4379968b6c109f9fa617c7ad19b802828e4d7bf861cd66da4b7"},
+    {file = "jaxlib-0.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:4b08f5fbc596b83f76308181863996f93d901d1f09cfd4e130a65c1998e1b371"},
+    {file = "jaxlib-0.10.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4df530afa354a22dc1747a5d560640450cbb895d49889338a3f58c76a4c76c8e"},
+    {file = "jaxlib-0.10.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:45b28b0238697ab74bbcf20411aafb6db42acc31836cc2fd711e5cf056bf9556"},
+    {file = "jaxlib-0.10.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:9e4818b4a8756fd3918766ca2aa5342125809f4f08a6fe46026d4386e7c23644"},
+    {file = "jaxlib-0.10.2-cp313-cp313-win_amd64.whl", hash = "sha256:c75d6f1df1c9cff08e110b4a21c79560fdc502f4288972d6b117d25dafd44352"},
+    {file = "jaxlib-0.10.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4c202d8ff7c1f3b5049dbd8f1e30e52759cd4e0a5835f0b3c7ae076a05818e28"},
+    {file = "jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:b7b029bb95d981566750475b9719a9d6b66ed5dd2748851667899b6cfe075299"},
+    {file = "jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:e8b126097d609b0c6e6786e89f6dd6978adc02ebd5f63a1c61293fbac7821305"},
+    {file = "jaxlib-0.10.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:72eba28b12fee02616fa42aa4b881b4ab62d7757c7843c462401d3fb34a27be4"},
+    {file = "jaxlib-0.10.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:f18f56fee90699cfba9b6627045a7a299702cb0e2af82ce180d9a6a7c8048093"},
+    {file = "jaxlib-0.10.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:ca34f363197fb0ac4082582ca755007910369e33f8a8ba3d35ed94b71070107d"},
+    {file = "jaxlib-0.10.2-cp314-cp314-win_amd64.whl", hash = "sha256:99818b0a18adc0b899abf4873795e8d65169441d87ab2e5cbb228e73d0f25808"},
+    {file = "jaxlib-0.10.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fc62997fce8831819551a2a5469a818169b09582b5b648c102d11ac7205bb812"},
+    {file = "jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:a24d6e3cba263978293eae8b41330d5ccf24d6cdd1a6bcd4e82aff34e767620d"},
+    {file = "jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:5a2ac7aed7c4e661f67600bbcdec9e589151c1efec91f4cdb8d484af1a45c895"},
+]
+
+[package.dependencies]
+ml_dtypes = ">=0.5.0"
+numpy = ">=2.0"
+scipy = ">=1.14"
+
+[[package]]
+name = "jaxlib"
+version = "0.11.0"
+description = "XLA library for JAX"
+optional = false
+python-versions = ">=3.12"
+groups = ["main"]
+markers = "python_version == \"3.12\""
+files = [
+    {file = "jaxlib-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5bf0b3bfc2ef4778580047389dacb51ae000e50c6b3b6f98d10788927066c97"},
+    {file = "jaxlib-0.11.0-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:1b767c4d7ad4dfc6358313b63ae6d83c3571d3ce966de04d8aaf29eb44633786"},
+    {file = "jaxlib-0.11.0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:7ea9dc06d94f536deabcf304513143bc89f51173ddfd786d44f8ac303efdf643"},
+    {file = "jaxlib-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:166ca16586a8aeb23f9c5e322845f3789037ed294f0a1539404a50f7c5fb13cf"},
+    {file = "jaxlib-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:88b349aa95e452caa30a6723320e93ec7bd1ab249e9f0bf29000da1b5efae733"},
+    {file = "jaxlib-0.11.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:112a01c584707a7d0e8634fd55dd7efffe812966e60c2d3ac84e8c24e4571336"},
+    {file = "jaxlib-0.11.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:33dd9405cab05ee4f3ecc3a91289323e9bd2f08d25990e5d45ffb8524f519506"},
+    {file = "jaxlib-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:aced7b1ca4e338b5248821a397d2d53008894672be6fee762f391cfdd7272e1e"},
+    {file = "jaxlib-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7e6c0e2374943ba7191fe196e22067b789894c58cf6ddd24c9971ae642de58ee"},
+    {file = "jaxlib-0.11.0-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:483429cc7fa7fd6a20cb50f666c8d2d499efb7e9ba3163811c01f051ad6057c4"},
+    {file = "jaxlib-0.11.0-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:6125da8532610641b7d3ea7926217cdab52dccb294ef6615455e2b6ecb9e2ee6"},
+    {file = "jaxlib-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:19888d25c2bba4240ccffe39ee4e5490a544a0bbcdcc1c171e558d3efed57d84"},
+    {file = "jaxlib-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5c38a393d37b4a70569224dc8273d8ae6ccea837e45410ed53ca03e15d6fad58"},
+    {file = "jaxlib-0.11.0-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:5ed7c54a6ef02eea19c0a02e3f603e4f9ad77248098bb9fc3feffca7f4814b83"},
+    {file = "jaxlib-0.11.0-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:005ae3a663193d3a89eafadc073880c67d6b829e0ad989690275d02b5adc810a"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ Sphinx = { version = "^7.3.7", optional = true }
 sphinx-rtd-theme = { version = "^1.3.0,<=2.0.0", optional = true }
 nbsphinx = { version = "^0.9.3", optional = true }
 myst-parser = { version = "^3.0.1", optional = true }
-pandoc = {version = "2.4b0", optional = true}
+pandoc = {version = "2.4", optional = true}
 matplotlib = {version = "^3.9.0", optional = true}
 matplotlib-inline = {version = "^0.1.7", optional = true}
 seaborn = {version = "^0.13.2", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ quil = ">=0.15.3,<0.18"
 packaging = ">=23.1"
 deprecated = "^1.2.14"
 types-deprecated = "^1.2.9.3"
-rigetti-quax = ">=0.7.0"
+rigetti-quax = "^0.7.2"
 
 # latex extra
 ipython = { version = "^8.16.0", optional = true }

--- a/pyquil/noise/__init__.py
+++ b/pyquil/noise/__init__.py
@@ -1,0 +1,76 @@
+"""pyquil.noise — Noise modeling for quantum simulators.
+
+This package provides:
+
+- **Noise model** (``_legacy_noise``): Kraus-map based noise construction
+  for the QVM, including ``KrausModel``, ``NoiseModel``, and decoherence
+  helpers.
+
+- **Channel classes** (``_channels``): quax-backed ``Channel``,
+  ``MeasurementChannel``, ``ResetChannel``, and ``CycleChannel`` dataclasses
+  for fine-grained noise modeling.  These are private and not re-exported.
+
+- **New noise model** (``_noise_model``): The quax-based ``NoiseModel``
+  container and program-level fidelity estimation utilities.  These are
+  private and not re-exported; they will become the public API in the next
+  major version.
+"""
+
+# ── Noise model (Kraus-map based) ───────────────────────────────────────
+from pyquil.noise._legacy_noise import (
+    ANGLE_TOLERANCE,
+    INFINITY,
+    NO_NOISE,
+    KrausModel,
+    NoiseModel,
+    NoisyGateUndefined,
+    _bitstring_probs_by_qubit,  # noqa: F401
+    _check_kraus_ops,  # noqa: F401
+    _create_kraus_pragmas,  # noqa: F401
+    _decoherence_noise_model,  # noqa: F401
+    _get_program_gates,  # noqa: F401
+    _noise_model_program_header,  # noqa: F401
+    _run,  # noqa: F401
+    add_decoherence_noise,
+    append_kraus_to_gate,
+    apply_noise_model,
+    bitstring_probs_to_z_moments,
+    combine_kraus_maps,
+    correct_bitstring_probs,
+    corrupt_bitstring_probs,
+    damping_after_dephasing,
+    damping_kraus_map,
+    decoherence_noise_with_asymmetric_ro,
+    dephasing_kraus_map,
+    estimate_assignment_probs,
+    estimate_bitstring_probs,
+    get_noisy_gate,
+    pauli_kraus_map,
+    tensor_kraus_maps,
+)
+
+__all__ = [
+    # Noise model
+    "ANGLE_TOLERANCE",
+    "INFINITY",
+    "KrausModel",
+    "NO_NOISE",
+    "NoiseModel",
+    "NoisyGateUndefined",
+    "add_decoherence_noise",
+    "append_kraus_to_gate",
+    "apply_noise_model",
+    "bitstring_probs_to_z_moments",
+    "combine_kraus_maps",
+    "correct_bitstring_probs",
+    "corrupt_bitstring_probs",
+    "damping_after_dephasing",
+    "damping_kraus_map",
+    "decoherence_noise_with_asymmetric_ro",
+    "dephasing_kraus_map",
+    "estimate_assignment_probs",
+    "estimate_bitstring_probs",
+    "get_noisy_gate",
+    "pauli_kraus_map",
+    "tensor_kraus_maps",
+]

--- a/pyquil/noise/__init__.py
+++ b/pyquil/noise/__init__.py
@@ -4,7 +4,9 @@ This package provides:
 
 - **Noise model** (``_legacy_noise``): Kraus-map based noise construction
   for the QVM, including ``KrausModel``, ``NoiseModel``, and decoherence
-  helpers.
+  helpers. This is the public, supported API and is re-exported below; it was
+  previously the module ``pyquil/noise.py``, and every name it exported is still
+  importable from ``pyquil.noise``.
 
 - **Channel classes** (``_channels``): quax-backed ``Channel``,
   ``MeasurementChannel``, ``ResetChannel``, and ``CycleChannel`` dataclasses
@@ -18,19 +20,26 @@ This package provides:
 """
 
 # ── Noise model (Kraus-map based) ───────────────────────────────────────
+# Everything below is re-exported so that moving ``pyquil/noise.py`` into this package is not a
+# breaking change. The underscore-prefixed names were never public API, but they are re-exported
+# too so that any code reaching for them keeps working.
 from pyquil.noise._legacy_noise import (
+    _CHARS,  # noqa: F401
     ANGLE_TOLERANCE,
     INFINITY,
     NO_NOISE,
     KrausModel,
     NoiseModel,
     NoisyGateUndefined,
+    _apply_local_transforms,  # noqa: F401
     _bitstring_probs_by_qubit,  # noqa: F401
     _check_kraus_ops,  # noqa: F401
     _create_kraus_pragmas,  # noqa: F401
     _decoherence_noise_model,  # noqa: F401
     _get_program_gates,  # noqa: F401
+    _KrausModel,  # noqa: F401
     _noise_model_program_header,  # noqa: F401
+    _NoiseModel,  # noqa: F401
     _run,  # noqa: F401
     add_decoherence_noise,
     append_kraus_to_gate,

--- a/pyquil/noise/__init__.py
+++ b/pyquil/noise/__init__.py
@@ -12,8 +12,9 @@ This package provides:
 
 - **New noise model** (``_noise_model``): The quax-based ``NoiseModel``
   container and program-level fidelity estimation utilities.  These are
-  private and not re-exported; they will become the public API in the next
-  major version.
+  still private and not re-exported; they will become the public API in the
+  next major version, at which point the legacy Kraus-based model above is
+  removed.
 """
 
 # ── Noise model (Kraus-map based) ───────────────────────────────────────

--- a/pyquil/noise/_channels.py
+++ b/pyquil/noise/_channels.py
@@ -119,13 +119,6 @@ def _pack_operator(operator: qx.SuperOp | qx.Unitary | qx.Choi | qx.Observable |
     return data
 
 
-def _unpack_operator_dims(
-    data: dict[str, Any], shape: tuple[int, ...], *, superoperator: bool
-) -> tuple[tuple[int, ...], tuple[int, ...]]:
-    """Read the explicit operator dims stored by :func:`_pack_operator`."""
-    return _unpack_dims(data["dims"])
-
-
 def _resolve_params(params: list[ResolvableParam]) -> list[float]:
     """Resolve gate parameters to concrete float values.
 
@@ -253,7 +246,7 @@ class ChannelProtocol(Protocol):
 
     A gate channel attaches a CPTP ``process`` (a ``qx.SuperOp`` that *includes* the ideal
     gate) to a :class:`~pyquil.quilbase.Gate`, with fidelity metrics measured against the
-    ideal ``target_unitary``. Concrete subclasses supply the three attributes below; the
+    ideal ``unitary``. Concrete subclasses supply the three attributes below; the
     ``process`` may be a stored field (:class:`SuperopChannel`) or derived from a generator
     (:class:`Channel`). Every method here depends only on those three attributes,
     so it works identically regardless of how ``process`` is produced.
@@ -268,12 +261,7 @@ class ChannelProtocol(Protocol):
     if TYPE_CHECKING:
         inst: Gate
         process: qx.SuperOp
-        target_unitary: qx.Unitary
-
-    @cached_property
-    def unitary(self) -> qx.Unitary:
-        """The noiseless unitary of the gate."""
-        return self.target_unitary
+        unitary: qx.Unitary
 
     @cached_property
     def qubits(self) -> list[int]:
@@ -289,12 +277,21 @@ class ChannelProtocol(Protocol):
     # Cached representation conversions
     # ──────────────────────────────────────────────
 
-    @cached_property
-    def noise_process(self) -> qx.SuperOp:
-        r"""The noise-only channel with the ideal gate unitary factored out.
+    def as_post_gate_noise(self) -> qx.SuperOp:
+        r"""The noise as a superoperator applied *after* the ideal gate.
 
-        If the full channel is :math:`\mathcal{E} = \Lambda \circ \mathcal{U}`, this
-        returns :math:`\Lambda`.
+        A noisy gate channel can be viewed either as noise applied after the ideal gate
+        (*post-gate*) or before it (*pre-gate*):
+
+        - **post-gate**: :math:`\mathcal{E} = \Lambda_{\text{post}} \circ \mathcal{U}`, so
+          :math:`\Lambda_{\text{post}} = \mathcal{E} \circ \mathcal{U}^\dagger` — this method.
+        - **pre-gate**: :math:`\mathcal{E} = \mathcal{U} \circ \Lambda_{\text{pre}}`, so
+          :math:`\Lambda_{\text{pre}} = \mathcal{U}^\dagger \circ \mathcal{E}`.
+
+        The two coincide only when the noise commutes with the gate; in general they are
+        related by conjugation, :math:`\Lambda_{\text{post}} = \mathcal{U} \circ
+        \Lambda_{\text{pre}} \circ \mathcal{U}^\dagger`, and share the same fidelity metrics.
+        This channel adopts the post-gate convention throughout.
         """
         return qx.to_superop(self.process @ self.unitary.h)
 
@@ -326,7 +323,7 @@ class ChannelProtocol(Protocol):
     @cached_property
     def stochastic_infidelity(self) -> float:
         """Stochastic (incoherent) component of the process infidelity."""
-        return float(qx.stochastic_infidelity(self.noise_process))
+        return float(qx.stochastic_infidelity(self.as_post_gate_noise()))
 
     @cached_property
     def stochastic_fidelity(self) -> float:
@@ -346,7 +343,7 @@ class ChannelProtocol(Protocol):
     @cached_property
     def unitarity(self) -> float:
         """Unitarity of the channel."""
-        return float(qx.unitarity(self.noise_process))
+        return float(qx.unitarity(self.as_post_gate_noise()))
 
     # ──────────────────────────────────────────────
     # SuperopChannel analysis methods
@@ -354,7 +351,7 @@ class ChannelProtocol(Protocol):
 
     def _as_channel(self, process: qx.SuperOp) -> SuperopChannel:
         """Wrap a derived superoperator as a plain :class:`SuperopChannel` for this gate."""
-        return SuperopChannel(inst=self.inst, process=process, target_unitary=self.target_unitary)
+        return SuperopChannel(inst=self.inst, process=process, unitary=self.unitary)
 
     def pauli_twirl(self) -> SuperopChannel:
         """Return a Pauli-twirled version of this channel.
@@ -377,7 +374,7 @@ class ChannelProtocol(Protocol):
         Uses eigendecomposition + SVD polar decomposition to find the closest
         unitary to the noise channel.
         """
-        choi_matrix = qx.to_choi(self.noise_process).matrix
+        choi_matrix = qx.to_choi(self.as_post_gate_noise()).matrix
         d = 2**self.num_qubits
 
         # Dominant eigenvector of the Choi matrix
@@ -410,7 +407,7 @@ class ChannelProtocol(Protocol):
         """
         u_error = self._unitary_error_component
         # Get the noise-only superoperator and compose with U_err†
-        noise_superop = self.noise_process.matrix
+        noise_superop = self.as_post_gate_noise().matrix
         u_err_inv_superop = jnp.kron(u_error.conj(), u_error.conj().T)
         stochastic_noise_superop = noise_superop @ u_err_inv_superop
         # Recompose with the ideal gate
@@ -423,7 +420,7 @@ class ChannelProtocol(Protocol):
 
         A Pauli channel has a diagonal Pauli transfer matrix (noise-only part).
         """
-        ptm = qx.to_pauli_liouville(self.noise_process).matrix
+        ptm = qx.to_pauli_liouville(self.as_post_gate_noise()).matrix
         mask = ~jnp.eye(ptm.shape[0], dtype=bool)
         return bool(jnp.allclose(ptm[mask], 0))
 
@@ -433,7 +430,7 @@ class ChannelProtocol(Protocol):
         Returns the vector of probabilities for each Pauli error in lexicographic
         order (II, IX, IY, IZ, XI, XX, ...). The vector sums to 1.0.
         """
-        noise_superop = self.noise_process.matrix
+        noise_superop = self.as_post_gate_noise().matrix
         num_qubits = self.num_qubits
         dim = noise_superop.shape[0]
 
@@ -449,29 +446,25 @@ class ChannelProtocol(Protocol):
 
         return jnp.array(pauli_error_rates, dtype=float)
 
-    @cached_property
-    def pauli_vector(self) -> Array:
-        """The Pauli error probability vector of the noise channel."""
-        return self.to_pauli_vector()
-
     # ──────────────────────────────────────────────
     # Visualization
     # ──────────────────────────────────────────────
 
-    def plot(self, only_noise: bool = True, show_identity: bool = False) -> Figure:
+    def plot(self, noise_only: bool = True, show_identity: bool = False) -> Figure:
         """Plot the Pauli transfer matrix of the channel.
 
-        :param only_noise: If True, plot the noise-only channel (gate unitary factored out).
+        :param noise_only: If True (default), plot the noise-only channel (the post-gate
+            noise, with the ideal gate unitary factored out; see :meth:`as_post_gate_noise`).
             If False, plot the full channel including the gate unitary.
         :param show_identity: If True, include the identity component in the noise-only plot.
             If False (default), visualize the generator of the noise channel via the matrix
             logarithm of the PTM.  For near-identity noise this approximates PTM - I, but
             correctly captures the Lie-algebraic structure of the channel.
-            Only applies when ``only_noise=True``.
+            Only applies when ``noise_only=True``.
         :return: A Plotly Figure.
         """
-        if only_noise:
-            channel = self.noise_process
+        if noise_only:
+            channel = self.as_post_gate_noise()
             if not show_identity:
                 ptm = qx.to_pauli_liouville(channel)
                 log_ptm = scipy_logm(np.asarray(ptm.matrix))
@@ -514,7 +507,7 @@ class ChannelProtocol(Protocol):
             return False
         return bool(
             jnp.array_equal(self.process.matrix, other.process.matrix)  # type: ignore[attr-defined]
-            and jnp.array_equal(self.target_unitary.matrix, other.target_unitary.matrix)  # type: ignore[attr-defined]
+            and jnp.array_equal(self.unitary.matrix, other.unitary.matrix)  # type: ignore[attr-defined]
         )
 
     __hash__ = None  # type: ignore[assignment]
@@ -576,7 +569,7 @@ class SuperopChannel(ChannelProtocol):
 
     The superoperator *includes* the gate unitary, so the channel replaces the gate rather than
     being applied after it, and can be converted to alternative representations (Choi, Kraus,
-    Pauli-Liouville) via ``quax``. Fidelity metrics are computed relative to ``target_unitary``.
+    Pauli-Liouville) via ``quax``. Fidelity metrics are computed relative to ``unitary``.
     """
 
     inst: Gate
@@ -585,7 +578,7 @@ class SuperopChannel(ChannelProtocol):
     process: qx.SuperOp
     """The noisy process (superoperator) for the gate, including the gate unitary."""
 
-    target_unitary: qx.Unitary
+    unitary: qx.Unitary
     """The noiseless unitary of the gate."""
 
     # ──────────────────────────────────────────────
@@ -649,7 +642,7 @@ class SuperopChannel(ChannelProtocol):
         kraus_map = qx.KrausMap.from_matrix(kraus_matrices, unitary.dims)
 
         process_superop = qx.to_superop(kraus_map @ unitary)
-        return cls(inst=inst, process=process_superop, target_unitary=unitary)
+        return cls(inst=inst, process=process_superop, unitary=unitary)
 
     # ──────────────────────────────────────────────
     # Serialization
@@ -661,12 +654,10 @@ class SuperopChannel(ChannelProtocol):
         :return: JSON string representation.
         """
         data = {
-            "schema_version": 1,
             "inst": self.inst.out(),
             "superop": _pack_operator(self.process),
+            "unitary": _pack_operator(self.unitary),
         }
-        data["target_unitary"] = _pack_operator(self.target_unitary)
-
         return json.dumps(data)
 
     @classmethod
@@ -682,21 +673,12 @@ class SuperopChannel(ChannelProtocol):
             raise TypeError(f"SuperopChannel JSON must contain a gate instruction, got {type(inst).__name__}.")
 
         superop_data = data["superop"]
-        shape = tuple(superop_data["shape"])
-        superop_array = _unpack_complex_array(superop_data)
-        dims = _unpack_operator_dims(superop_data, shape, superoperator=True)
-        superop = qx.SuperOp.from_matrix(superop_array, dims)
+        superop = qx.SuperOp.from_matrix(_unpack_complex_array(superop_data), _unpack_dims(superop_data["dims"]))
 
-        if "target_unitary" in data:
-            u_data = data["target_unitary"]
-            u_shape = tuple(u_data["shape"])
-            u_array = _unpack_complex_array(u_data)
-            u_dims = _unpack_operator_dims(u_data, u_shape, superoperator=False)
-            target_unitary = qx.Unitary.from_matrix(u_array, u_dims)
-        else:
-            target_unitary = get_instruction_unitary(inst)
+        u_data = data["unitary"]
+        unitary = qx.Unitary.from_matrix(_unpack_complex_array(u_data), _unpack_dims(u_data["dims"]))
 
-        return cls(inst=inst, process=superop, target_unitary=target_unitary)
+        return cls(inst=inst, process=superop, unitary=unitary)
 
 
 @runtime_checkable
@@ -743,14 +725,24 @@ class _LindbladianBacked(Protocol):
 
 @dataclass(frozen=True, eq=False)
 class Channel(_LindbladianBacked, ChannelProtocol):
-    r"""A noise channel that attaches a Lindbladian generator to a specific gate.
+    r"""A noisy quantum gate: the ideal gate together with the noise that accompanies it.
 
-    The Lindbladian *includes* the gate Hamiltonian, so the channel *replaces* the gate rather
-    than being applied after it. The ``process`` superoperator is obtained on demand via
-    ``qx.evolve(lindbladian, gate_time)``.
+    ``Channel`` is the primary way to describe gate noise. Rather than a raw error matrix, it
+    holds a physical *generator* — a GKSL (Lindblad) master-equation model that combines the
+    ideal gate's coherent evolution with dissipation (relaxation, dephasing, leakage) and
+    coherent errors (over-rotations, unwanted couplings). Evolving that generator for
+    ``gate_time`` yields the noisy ``process`` (a CPTP superoperator) that *replaces* the ideal
+    gate in a circuit.
 
-    Compared with :class:`SuperopChannel` (a stored superoperator), a Lindbladian-backed channel makes
-    two operations natural and CPTP-safe:
+    Build one from whatever noise data is available via the ``from_*`` constructors — an average
+    or process fidelity, a depolarizing constant, T1/T2 coherence times, Pauli generator rates, a
+    mixture of unitary errors, a random coherent error, or a Lindbladian directly. Once built, a
+    channel reports a full suite of fidelity and error metrics (:attr:`fidelity`,
+    :attr:`pauli_fidelity`, :attr:`coherent_infidelity`, :attr:`stochastic_infidelity`,
+    :attr:`unitarity`, ...), can be visualized with :meth:`plot`, decomposed into coherent and
+    stochastic parts, Pauli-twirled, composed, and serialized.
+
+    Because the noise is stored as a generator, two operations are natural and always CPTP-safe:
 
     - :meth:`__pow__` scales the *noise* (jump rates and coherent-noise Hamiltonian) while keeping
       the ideal gate, sweeping noise strength in a physically meaningful way.
@@ -758,7 +750,7 @@ class Channel(_LindbladianBacked, ChannelProtocol):
 
     ``gate_time`` defaults to ``1.0`` (dimensionless). It may instead be a physical duration (e.g.
     ``~40e-9`` s), in which case the Hamiltonian and jump operators are in physical units; the gate
-    Hamiltonian is scaled so that evolving for ``gate_time`` reproduces the ideal ``target_unitary``.
+    Hamiltonian is scaled so that evolving for ``gate_time`` reproduces the ideal ``unitary``.
     """
 
     inst: Gate
@@ -767,22 +759,22 @@ class Channel(_LindbladianBacked, ChannelProtocol):
     lindbladian: qx.Lindbladian
     """The GKSL generator for the gate, including the (scaled) gate Hamiltonian."""
 
-    target_unitary: qx.Unitary
+    unitary: qx.Unitary
     """The noiseless unitary of the gate."""
 
     gate_time: float = 1.0
     """Evolution time for ``evolve(lindbladian, gate_time)``. Default 1.0 (dimensionless)."""
 
     @cached_property
-    def _gate_hamiltonian(self) -> qx.Observable:
-        """Coherent generator whose evolution over ``gate_time`` yields ``target_unitary``."""
-        return qx.unitary_to_hamiltonian(self.target_unitary) * (1.0 / self.gate_time)
+    def gate_hamiltonian(self) -> qx.Observable:
+        """Coherent generator whose evolution over ``gate_time`` yields ``unitary``."""
+        return qx.unitary_to_hamiltonian(self.unitary) * (1.0 / self.gate_time)
 
     @cached_property
     def _noise_lindbladian(self) -> qx.Lindbladian:
         """The generator with the coherent gate Hamiltonian factored out (dissipation + coherent noise)."""
         hamiltonian = self.lindbladian.hamiltonian
-        noise_hamiltonian = hamiltonian - self._gate_hamiltonian if hamiltonian is not None else None
+        noise_hamiltonian = hamiltonian - self.gate_hamiltonian if hamiltonian is not None else None
         return qx.Lindbladian(hamiltonian=noise_hamiltonian, jump_operators=self.lindbladian.jump_operators)
 
     # ──────────────────────────────────────────────
@@ -806,12 +798,12 @@ class Channel(_LindbladianBacked, ChannelProtocol):
         :param custom_gates: Optional dictionary of custom gate definitions.
         :return: A Channel instance.
         """
-        target_unitary = get_instruction_unitary(inst, custom_gates)
-        gate_hamiltonian = qx.unitary_to_hamiltonian(target_unitary) * (1.0 / gate_time)
+        unitary = get_instruction_unitary(inst, custom_gates)
+        gate_hamiltonian = qx.unitary_to_hamiltonian(unitary) * (1.0 / gate_time)
         noise_hamiltonian = noise_lindbladian.hamiltonian
         total_hamiltonian = gate_hamiltonian if noise_hamiltonian is None else noise_hamiltonian + gate_hamiltonian
         lindbladian = qx.Lindbladian(hamiltonian=total_hamiltonian, jump_operators=noise_lindbladian.jump_operators)
-        return cls(inst=inst, lindbladian=lindbladian, target_unitary=target_unitary, gate_time=gate_time)
+        return cls(inst=inst, lindbladian=lindbladian, unitary=unitary, gate_time=gate_time)
 
     @classmethod
     def from_gate_fidelity(
@@ -1022,7 +1014,7 @@ class Channel(_LindbladianBacked, ChannelProtocol):
         hamiltonian = qx.unitary_to_hamiltonian(noisy_unitary) * (1.0 / gate_time)
         zero_jumps = qx.Operator.from_matrix(jnp.zeros((1, d, d), dtype=complex), ideal.dims)
         lindbladian = qx.Lindbladian(hamiltonian=hamiltonian, jump_operators=zero_jumps)
-        return cls(inst=inst, lindbladian=lindbladian, target_unitary=ideal, gate_time=gate_time)
+        return cls(inst=inst, lindbladian=lindbladian, unitary=ideal, gate_time=gate_time)
 
     # ──────────────────────────────────────────────
     # Lindbladian-native operations
@@ -1037,7 +1029,7 @@ class Channel(_LindbladianBacked, ChannelProtocol):
         """
         if not isinstance(power, (int, float)):
             return NotImplemented
-        scaled = self._scaled_noise_generator(power, gate_hamiltonian=self._gate_hamiltonian)
+        scaled = self._scaled_noise_generator(power, gate_hamiltonian=self.gate_hamiltonian)
         return replace(self, lindbladian=scaled)
 
     def __add__(self, other: Channel) -> Channel:
@@ -1053,7 +1045,7 @@ class Channel(_LindbladianBacked, ChannelProtocol):
         if self.inst != other.inst:
             raise ValueError(f"Cannot add channels for different gates: {self.inst.out()} vs {other.inst.out()}")
         combined_noise = self._noise_lindbladian + other._noise_lindbladian
-        gate_hamiltonian = self._gate_hamiltonian
+        gate_hamiltonian = self.gate_hamiltonian
         combined_hamiltonian = (
             gate_hamiltonian if combined_noise.hamiltonian is None else combined_noise.hamiltonian + gate_hamiltonian
         )
@@ -1068,10 +1060,9 @@ class Channel(_LindbladianBacked, ChannelProtocol):
         """Serialize Channel to a JSON string."""
         hamiltonian = self.lindbladian.hamiltonian
         data = {
-            "schema_version": 1,
             "inst": self.inst.out(),
             "gate_time": self.gate_time,
-            "target_unitary": _pack_operator(self.target_unitary),
+            "unitary": _pack_operator(self.unitary),
             "hamiltonian": None if hamiltonian is None else _pack_operator(hamiltonian),
             "jump_operators": _pack_operator(self.lindbladian.jump_operators),
         }
@@ -1085,8 +1076,8 @@ class Channel(_LindbladianBacked, ChannelProtocol):
         if not isinstance(inst, Gate):
             raise TypeError(f"Channel JSON must contain a gate instruction, got {type(inst).__name__}.")
 
-        u_data = data["target_unitary"]
-        target_unitary = qx.Unitary.from_matrix(_unpack_complex_array(u_data), _unpack_dims(u_data["dims"]))
+        u_data = data["unitary"]
+        unitary = qx.Unitary.from_matrix(_unpack_complex_array(u_data), _unpack_dims(u_data["dims"]))
 
         ham_data = data["hamiltonian"]
         hamiltonian = (
@@ -1097,7 +1088,7 @@ class Channel(_LindbladianBacked, ChannelProtocol):
         jump_data = data["jump_operators"]
         jump_operators = qx.Operator.from_matrix(_unpack_complex_array(jump_data), _unpack_dims(jump_data["dims"]))
         lindbladian = qx.Lindbladian(hamiltonian=hamiltonian, jump_operators=jump_operators)
-        return cls(inst=inst, lindbladian=lindbladian, target_unitary=target_unitary, gate_time=data["gate_time"])
+        return cls(inst=inst, lindbladian=lindbladian, unitary=unitary, gate_time=data["gate_time"])
 
 
 @dataclass(frozen=True)
@@ -1371,7 +1362,6 @@ class MeasurementChannel:
             instrument_data.append(_pack_operator(superop_i))
 
         data = {
-            "schema_version": 1,
             "inst": self.inst.out(),
             "instruments": instrument_data,
             "measured_qudits": list(self.process.measured_qudits),
@@ -1396,9 +1386,8 @@ class MeasurementChannel:
         superop_matrices = []
         instrument_dims = None
         for inst_data in data["instruments"]:
-            shape = tuple(inst_data["shape"])
             arr = _unpack_complex_array(inst_data)
-            op_dims = _unpack_operator_dims(inst_data, shape, superoperator=True)
+            op_dims = _unpack_dims(inst_data["dims"])
             if instrument_dims is None:
                 instrument_dims = op_dims
             elif instrument_dims != op_dims:
@@ -1466,7 +1455,7 @@ class _ResetChannelBase(Protocol):
     """Shared behavior for reset noise channels backed by a superoperator ``process``.
 
     A reset channel replaces a targeted reset with a CPTP ``process`` (a ``qx.SuperOp`` that
-    *includes* the ideal reset). Unlike gate channels there is no ``target_unitary``; fidelity is
+    *includes* the ideal reset). Unlike gate channels there is no unitary; fidelity is
     measured against the ideal reset ``qx.gates.RESET``. Concrete subclasses supply ``inst`` and
     ``process`` — a stored field for :class:`SuperopResetChannel`, or derived from a generator for
     :class:`ResetChannel`.
@@ -1490,39 +1479,43 @@ class _ResetChannelBase(Protocol):
         return [qubit.index if hasattr(qubit, "index") else int(qubit)]
 
     @cached_property
-    def fidelity(self) -> float:
-        r"""Process fidelity of the reset channel relative to the ideal reset.
-
-        Defined as :math:`F = \mathrm{Tr}[\Lambda_{\mathrm{ideal}}^\dagger \Lambda] / d^2`
-        where :math:`\Lambda` is the Choi matrix of the noisy channel and
-        :math:`\Lambda_{\mathrm{ideal}}` is the ideal-reset Choi.
-        """
-        dim = self.process.dims[0][0]
-        ideal_choi = qx.to_choi(qx.gates.RESET(dim=dim))
-        noisy_choi = qx.to_choi(self.process)
-        # Process fidelity = Tr[ideal_choi† @ noisy_choi] / d^2
-        d2 = float(dim * dim)
-        return float(jnp.real(jnp.trace(ideal_choi.matrix.conj().T @ noisy_choi.matrix)) / d2)
+    def _ideal_reset(self) -> qx.SuperOp:
+        """The ideal reset superoperator matching this channel's dimension."""
+        return qx.gates.RESET(dim=self.process.dims[0][0])
 
     @cached_property
-    def noise_process(self) -> qx.SuperOp:
-        """The noise-only channel (ideal reset factored out).
+    def fidelity(self) -> float:
+        r"""Process fidelity of the reset channel relative to the ideal reset :math:`F_e \in [0, 1]`."""
+        return float(qx.process_fidelity(self.process, self._ideal_reset))
 
-        For a reset channel the noise framing is less natural than for unitary gates;
-        this property returns the full process superoperator.
+    def as_post_gate_noise(self) -> qx.SuperOp:
+        r"""The noise as a superoperator applied *after* the ideal reset.
+
+        The full channel factors as :math:`\mathcal{E} = \mathcal{N} \circ \mathcal{R}`, where
+        :math:`\mathcal{R}` is the ideal reset and :math:`\mathcal{N}` the post-reset noise.
+        The ideal reset is not invertible, so :math:`\mathcal{N}` is recovered with its
+        Moore-Penrose pseudo-inverse, :math:`\mathcal{N} = \mathcal{E} \circ \mathcal{R}^{+}`.
+        This is exact for channels built as noise-after-reset (e.g.
+        :meth:`SuperopResetChannel.from_reset_fidelity`); for relaxation-type resets it is the
+        representative that agrees with the channel on the reset's output subspace
+        (:math:`\mathcal{N} \circ \mathcal{R} = \mathcal{E}` always holds).
         """
-        return self.process
+        ideal = self._ideal_reset
+        noise_matrix = self.process.matrix @ jnp.linalg.pinv(ideal.matrix)
+        return qx.SuperOp.from_matrix(noise_matrix, self.process.dims)
 
-    def plot(self) -> Figure:
+    def plot(self, noise_only: bool = False) -> Figure:
         """Plot the Pauli transfer matrix of the reset channel.
 
+        :param noise_only: If True, plot the post-reset noise (see :meth:`as_post_gate_noise`)
+            instead of the full process. Defaults to False (the full channel).
         :return: A Plotly Figure.
         """
-        fig = qx.plot(self.process)
+        channel = self.as_post_gate_noise() if noise_only else self.process
+        title_prefix = "Reset noise" if noise_only else "Reset channel"
+        fig = qx.plot(channel)
         qubit_str = str(self.qubits[0]) if self.qubits else "?"
-        fig.update_layout(
-            title=(f"Reset SuperopChannel RESET {qubit_str}<br><sub>F_χ={self.fidelity * 100:.2f}%</sub>")
-        )
+        fig.update_layout(title=(f"{title_prefix} RESET {qubit_str}<br><sub>F_χ={self.fidelity * 100:.2f}%</sub>"))
         return fig
 
     def __str__(self) -> str:
@@ -1568,38 +1561,25 @@ class SuperopResetChannel(_ResetChannelBase):
     ) -> SuperopResetChannel:
         r"""Create a SuperopResetChannel with depolarizing noise scaled to the given process fidelity.
 
-        The ideal reset channel maps every state to :math:`|0\rangle\langle 0|`.  Noise is
-        modelled as a depolarising channel applied after the ideal reset.
+        The ideal reset maps every state to :math:`|0\rangle\langle 0|`; noise is a depolarizing
+        channel applied *after* it, so the process is ``depolarizing @ RESET`` — every state is
+        reset and then shrunk toward the maximally-mixed state by a factor ``fidelity``.
 
         :param inst: The reset instruction.
         :param fidelity: Process fidelity of the reset channel, :math:`F \in [0, 1]`.
-            1.0 yields an ideal reset; values below 1 introduce depolarising noise.
+            1.0 yields an ideal reset; values below 1 introduce depolarizing noise.
         :param dim: Hilbert-space dimension (2 for qubits).
         :return: A SuperopResetChannel instance.
         """
         if not isinstance(inst, ResetQubit):
             raise TypeError("SuperopResetChannel only supports targeted ResetQubit instructions.")
 
-        ideal_superop = qx.gates.RESET(dim=dim)
-        p = 1.0 - fidelity
+        # Depolarizing rate whose evolution shrinks every traceless operator by exactly ``fidelity``.
         d2 = dim * dim
-        # Depolarising channel in superop form: (1-p)*S_ideal + p*(I/d) for all inputs
-        # The completely depolarising superop maps everything to I/d:
-        # its rows are all zero except the diagonal entries corresponding to
-        # the trace extraction (maps vec(ρ) → vec(I/d) = vec(I)/d).
-        depol_superop_matrix = jnp.zeros((d2, d2), dtype=complex)
-        # vec(I/d) has value 1/d at positions 0, d+1, 2(d+1), ... i.e. diagonal entries
-        vec_identity_over_d = jnp.zeros(d2, dtype=complex)
-        for i in range(dim):
-            vec_identity_over_d = vec_identity_over_d.at[i * dim + i].set(1.0 / dim)
-        # The trace functional extracts sum of diagonal: positions 0, d+1, ...
-        trace_row = jnp.zeros(d2, dtype=complex)
-        for i in range(dim):
-            trace_row = trace_row.at[i * dim + i].set(1.0)
-        # Depolarising superop: each row of output is vec(I/d) * Tr(ρ)
-        depol_superop_matrix = jnp.outer(vec_identity_over_d, trace_row)
-        noisy_superop_matrix = (1.0 - p) * ideal_superop.matrix + p * depol_superop_matrix
-        noisy_superop = qx.SuperOp.from_matrix(noisy_superop_matrix, ideal_superop.dims)
+        shrink = float(np.clip(fidelity, np.finfo(float).tiny, 1.0))
+        gamma = -np.log(shrink) * (d2 - 1) / d2
+        depol = qx.channels.depolarizing(gamma, (dim,))
+        noisy_superop = qx.to_superop(depol @ qx.gates.RESET(dim=dim))
         return cls(inst=inst, process=noisy_superop)
 
     # ──────────────────────────────────────────────
@@ -1612,7 +1592,6 @@ class SuperopResetChannel(_ResetChannelBase):
         :return: JSON string representation.
         """
         data = {
-            "schema_version": 1,
             "inst": self.inst.out(),
             "superop": _pack_operator(self.process),
         }
@@ -1632,10 +1611,7 @@ class SuperopResetChannel(_ResetChannelBase):
                 f"SuperopResetChannel JSON must contain a targeted reset instruction, got {type(inst).__name__}."
             )
         superop_data = data["superop"]
-        shape = tuple(superop_data["shape"])
-        arr = _unpack_complex_array(superop_data)
-        dims = _unpack_operator_dims(superop_data, shape, superoperator=True)
-        process = qx.SuperOp.from_matrix(arr, dims)
+        process = qx.SuperOp.from_matrix(_unpack_complex_array(superop_data), _unpack_dims(superop_data["dims"]))
         return cls(inst=inst, process=process)
 
 
@@ -1708,7 +1684,6 @@ class ResetChannel(_LindbladianBacked, _ResetChannelBase):
         """Serialize ResetChannel to a JSON string."""
         hamiltonian = self.lindbladian.hamiltonian
         data = {
-            "schema_version": 1,
             "inst": self.inst.out(),
             "gate_time": self.gate_time,
             "hamiltonian": None if hamiltonian is None else _pack_operator(hamiltonian),

--- a/pyquil/noise/_channels.py
+++ b/pyquil/noise/_channels.py
@@ -15,7 +15,7 @@
 ##############################################################################
 """Noise channel classes and gate-resolution utilities.
 
-This module defines ``Channel``, ``MeasurementChannel``, ``ResetChannel``, and
+This module defines ``SuperopChannel``, ``MeasurementChannel``, ``SuperopResetChannel``, and
 ``CycleChannel`` dataclasses for representing noise in quantum circuits, along
 with helper functions for resolving gate unitaries and extracting custom gate
 definitions from Quil programs.
@@ -30,7 +30,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from functools import cached_property, reduce
 from itertools import product
-from typing import TYPE_CHECKING, Any, Protocol, SupportsFloat, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, SupportsFloat, runtime_checkable
 
 import jax.numpy as jnp
 import numpy as np
@@ -39,7 +39,6 @@ from jax import Array
 from jax.scipy.linalg import expm as jax_expm
 from quil.expression import Expression as QuilExpression
 from quil.instructions import Instruction as RSInstruction
-from scipy.linalg import expm as scipy_expm
 from scipy.linalg import logm as scipy_logm
 
 from pyquil.quilatom import Expression, FormalArgument, MemoryReference, Parameter, substitute
@@ -52,7 +51,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Type alias for the custom-gate lookup map used throughout the Channel constructors.
+# Type alias for the custom-gate lookup map used throughout the SuperopChannel constructors.
 CustomGateMap = dict[str, qx.Unitary | Callable[..., qx.Unitary]]
 
 
@@ -113,18 +112,7 @@ def _unpack_dims(data: list[list[int]]) -> tuple[tuple[int, ...], tuple[int, ...
     return (tuple(int(dim) for dim in data[0]), tuple(int(dim) for dim in data[1]))
 
 
-def _infer_legacy_qubit_dims(shape: tuple[int, ...], *, superoperator: bool) -> tuple[tuple[int, ...], tuple[int, ...]]:
-    """Infer qubit-only dims for data serialized before dims were stored."""
-    hilbert_dim = round(float(np.sqrt(shape[0]))) if superoperator else int(shape[0])
-    num_qubits = round(float(np.log2(hilbert_dim)))
-    if 2**num_qubits != hilbert_dim:
-        raise ValueError(
-            "Serialized operator data does not include dims and its shape is not compatible with qubit-only dims."
-        )
-    return ((2,) * num_qubits, (2,) * num_qubits)
-
-
-def _pack_operator(operator: qx.SuperOp | qx.Unitary | qx.Choi) -> dict[str, Any]:
+def _pack_operator(operator: qx.SuperOp | qx.Unitary | qx.Choi | qx.Observable | qx.Operator) -> dict[str, Any]:
     """Pack a quax operator matrix with explicit dimension metadata."""
     data = _pack_complex_array(operator.matrix)
     data["dims"] = _pack_dims(operator.dims)
@@ -134,36 +122,16 @@ def _pack_operator(operator: qx.SuperOp | qx.Unitary | qx.Choi) -> dict[str, Any
 def _unpack_operator_dims(
     data: dict[str, Any], shape: tuple[int, ...], *, superoperator: bool
 ) -> tuple[tuple[int, ...], tuple[int, ...]]:
-    """Read explicit dims, falling back to the legacy qubit-only inference."""
-    if "dims" in data:
-        return _unpack_dims(data["dims"])
-    return _infer_legacy_qubit_dims(shape, superoperator=superoperator)
-
-
-def _real_part(value: SupportsFloat | complex, source: object) -> float:
-    """Return the real part of ``value``, warning if a non-negligible imaginary part is dropped.
-
-    Gate parameters are expected to be real; a non-real value is most likely a mistake
-    (and is not differentiable), so the imaginary part is discarded with a warning rather
-    than silently or fatally.
-    """
-    as_complex = complex(value)
-    if abs(as_complex.imag) > 1e-12:
-        logger.warning(
-            "Gate parameter %r has a non-zero imaginary part %g; discarding it and using the real part %g.",
-            source,
-            as_complex.imag,
-            as_complex.real,
-        )
-    return as_complex.real
+    """Read the explicit operator dims stored by :func:`_pack_operator`."""
+    return _unpack_dims(data["dims"])
 
 
 def _resolve_params(params: list[ResolvableParam]) -> list[float]:
     """Resolve gate parameters to concrete float values.
 
-    Gate parameters are expected to be real. If a parameter evaluates to a complex
-    number with a non-negligible imaginary part, the imaginary part is discarded with
-    a warning (see :func:`_real_part`).
+    Gate parameters are expected to be real. If a parameter evaluates to a complex number with a
+    non-negligible imaginary part (detected via :func:`numpy.real_if_close`), the imaginary part is
+    discarded with a warning.
 
     :param params: The gate parameters (may include symbolic Parameters or Expressions).
     :return: A list of concrete float values.
@@ -173,19 +141,21 @@ def _resolve_params(params: list[ResolvableParam]) -> list[float]:
     fixed_params = []
     for p in params:
         if isinstance(p, (Parameter, Expression)):
-            evaluated = p._evaluate()
-            if isinstance(evaluated, (Parameter, Expression)):
+            value: Any = p._evaluate()
+            if isinstance(value, (Parameter, Expression)):
                 raise ValueError(
                     f"Cannot resolve symbolic parameter {p}. Provide a gate with concrete numeric parameters."
                 )
-            fixed_params.append(_real_part(evaluated, p))
         elif isinstance(p, QuilExpression):
             # QuilExpression.evaluate returns a plain complex when fully resolved.
-            result = p.evaluate({}, {})
-            fixed_params.append(_real_part(result, p))
+            value = p.evaluate({}, {})
         else:
-            # Remaining values are concrete numbers (float/int/complex/numpy scalars).
-            fixed_params.append(_real_part(cast("SupportsFloat | complex", p), p))
+            value = p
+
+        resolved = np.real_if_close(value)
+        if np.iscomplexobj(resolved):
+            logger.warning("Gate parameter %r has a non-negligible imaginary part; using its real part.", p)
+        fixed_params.append(float(np.real(resolved)))
     return fixed_params
 
 
@@ -277,29 +247,28 @@ def get_instruction_unitary(
     return result
 
 
-@dataclass(frozen=True)
-class Channel:
-    """A noise channel attaches a superoperator to a specific gate.
+@runtime_checkable
+class ChannelProtocol(Protocol):
+    """Shared behavior for gate noise channels backed by a superoperator ``process``.
 
-    The superoperator *includes* the gate unitary, so the channel replaces the gate
-    rather than being applied after it.
+    A gate channel attaches a CPTP ``process`` (a ``qx.SuperOp`` that *includes* the ideal
+    gate) to a :class:`~pyquil.quilbase.Gate`, with fidelity metrics measured against the
+    ideal ``target_unitary``. Concrete subclasses supply the three attributes below; the
+    ``process`` may be a stored field (:class:`SuperopChannel`) or derived from a generator
+    (:class:`Channel`). Every method here depends only on those three attributes,
+    so it works identically regardless of how ``process`` is produced.
 
-    The ``process`` field is a ``qx.SuperOp`` which can be converted to alternative
-    representations (Choi, Kraus, Pauli-Liouville) via ``quax``.
-
-    Fidelity metrics are computed relative to the ideal gate unitary stored in
-    ``target_unitary``. For standard gates use the class methods (e.g.
-    :meth:`from_gate_fidelity`) which resolve the unitary automatically.
+    Operations that leave the superoperator/Lindbladian structure — composition (``@``),
+    :meth:`pauli_twirl`, :meth:`to_coherent_channel`, :meth:`to_stochastic_channel` — return
+    a plain :class:`SuperopChannel`, since their result is a generic superoperator and not
+    necessarily a Lindbladian generator.
     """
 
-    inst: Gate
-    """Quil gate to which the channel applies."""
-
-    process: qx.SuperOp
-    """The noisy process (superoperator) for the gate, including the gate unitary."""
-
-    target_unitary: qx.Unitary
-    """The noiseless unitary of the gate."""
+    # Provided by concrete subclasses (as dataclass fields or cached properties).
+    if TYPE_CHECKING:
+        inst: Gate
+        process: qx.SuperOp
+        target_unitary: qx.Unitary
 
     @cached_property
     def unitary(self) -> qx.Unitary:
@@ -315,302 +284,6 @@ class Channel:
     def num_qubits(self) -> int:
         """The number of qubits the channel acts on."""
         return len(self.qubits)
-
-    # ──────────────────────────────────────────────
-    # Constructors
-    # ──────────────────────────────────────────────
-
-    @classmethod
-    def from_gate_fidelity(
-        cls: type[Channel],
-        inst: Gate,
-        fidelity: float,
-        custom_gates: CustomGateMap | None = None,
-    ) -> Channel:
-        r"""Create a depolarizing noise channel from an average gate fidelity.
-
-        The resulting channel is the composition of the ideal gate unitary with a
-        depolarizing channel calibrated to the specified fidelity:
-        :math:`\mathcal{E} = \mathcal{D}_p \circ \mathcal{U}`
-
-        :param inst: The gate to which the channel applies.
-        :param fidelity: The average gate fidelity, :math:`F_{\mathrm{avg}} \in [0, 1]`.
-        :param custom_gates: Optional dictionary of custom gate definitions.
-        :return: A Channel instance.
-        """
-        unitary = get_instruction_unitary(inst, custom_gates)
-        p = qx.average_fidelity_to_depolarizing_constant(fidelity, unitary.dims[0])
-        return cls.from_depolarizing_constant(inst, p, custom_gates)
-
-    @classmethod
-    def from_pauli_fidelity(
-        cls: type[Channel],
-        inst: Gate,
-        pauli_fidelity: float,
-        custom_gates: CustomGateMap | None = None,
-    ) -> Channel:
-        r"""Create a depolarizing noise channel from a process (Pauli) fidelity.
-
-        The process fidelity :math:`F_e` is related to the average gate fidelity by
-        :math:`F_{\mathrm{avg}} = (d \cdot F_e + 1) / (d + 1)`.
-
-        :param inst: The gate to which the channel applies.
-        :param pauli_fidelity: The process fidelity (entanglement fidelity), :math:`F_e \in [0, 1]`.
-        :param custom_gates: Optional dictionary of custom gate definitions.
-        :return: A Channel instance.
-        """
-        unitary = get_instruction_unitary(inst, custom_gates)
-        p = qx.process_fidelity_to_depolarizing_constant(pauli_fidelity, unitary.dims[0])
-        return cls.from_depolarizing_constant(inst, p, custom_gates)
-
-    @classmethod
-    def from_depolarizing_constant(
-        cls: type[Channel],
-        inst: Gate,
-        depolarizing_constant: float,
-        custom_gates: CustomGateMap | None = None,
-    ) -> Channel:
-        r"""Create a depolarizing noise channel from a depolarization constant.
-
-        The depolarizing constant :math:`p` parameterizes the channel as
-        :math:`\mathcal{D}_p(\rho) = p \, \rho + (1-p) \, I/d`.
-
-        :param inst: The gate to which the channel applies.
-        :param depolarizing_constant: The depolarization constant, e.g. 0.98 for 2% depolarization.
-        :param custom_gates: Optional dictionary of custom gate definitions.
-        :return: A Channel instance.
-        """
-        unitary = get_instruction_unitary(inst, custom_gates)
-        dims = unitary.dims[0]
-        d = int(np.prod(dims))
-        # Build the depolarizing channel via the quax depolarizing Lindbladian evolved for
-        # unit time. Its generator shrinks every traceless operator uniformly, so choosing
-        # the rate ``gamma`` with ``exp(-gamma * (d**2 - 1) / d**2) == depolarizing_constant``
-        # reproduces ``D_p(rho) = p * rho + (1 - p) * I/d`` exactly. Full depolarization
-        # (``depolarizing_constant -> 0``) is the infinite-time limit, so clamp away from zero.
-        shrink = float(np.clip(depolarizing_constant, np.finfo(float).tiny, 1.0))
-        gamma = -np.log(shrink) * (d**2 - 1) / d**2
-        depolarizing_superop = qx.channels.depolarizing(gamma, dims, 1.0)
-        combined_superop = depolarizing_superop @ unitary
-        return cls(inst=inst, process=qx.to_superop(combined_superop), target_unitary=unitary)
-
-    @classmethod
-    def from_pauli_noise(
-        cls: type[Channel],
-        inst: Gate,
-        pauli_noise: dict[str, float],
-        custom_gates: CustomGateMap | None = None,
-    ) -> Channel:
-        """Create a stochastic Pauli noise channel from Pauli error rates.
-
-        The noise is specified as a dictionary mapping Pauli strings to error probabilities,
-        e.g. ``{"XX": 0.03, "ZI": 0.001}``. The probabilities must sum to at most 1.0;
-        any remainder is assigned to the identity (no-error) term.
-
-        :param inst: The gate to which the channel applies.
-        :param pauli_noise: Pauli error rates, e.g. ``{"IX": 0.01, "ZZ": 0.02}``.
-        :param custom_gates: Optional dictionary of custom gate definitions.
-        :return: A Channel instance.
-        """
-        unitary = get_instruction_unitary(inst, custom_gates)
-        num_qubits = len(unitary.dims[0])
-
-        total_error_rate = 0.0
-        for pauli, error_rate in pauli_noise.items():
-            if error_rate < 0.0:
-                raise ValueError(f"Pauli term '{pauli}' has negative error rate {error_rate}.")
-            total_error_rate += error_rate
-        if total_error_rate > 1.0:
-            raise ValueError(f"Pauli error rates must sum to at most 1.0, got {total_error_rate}.")
-
-        for pauli in pauli_noise:
-            if len(pauli) != num_qubits:
-                raise ValueError(f"Pauli term '{pauli}' has length {len(pauli)}, expected {num_qubits}.")
-
-        all_pauli_terms = tuple("".join(term) for term in product("IXYZ", repeat=num_qubits))
-
-        pauli_error_rates: list[float] = []
-        for term in reversed(all_pauli_terms):
-            if term in pauli_noise:
-                error_rate = pauli_noise[term]
-            elif all(p == "I" for p in term):
-                error_rate = 1 - sum(pauli_error_rates)
-            else:
-                error_rate = 0
-            pauli_error_rates.append(error_rate)
-        if not jnp.isclose(1.0, sum(pauli_error_rates)):
-            raise ValueError("Pauli error rates plus the implicit identity rate must sum to 1.0.")
-        pauli_error_rates = list(reversed(pauli_error_rates))
-
-        # Build the 4**num_qubits Pauli operators as tensor (Kronecker) products of the
-        # single-qubit Paulis, in lexicographic (I, X, Y, Z) order matching pauli_error_rates.
-        single_pauli_matrices = qx.ensembles.PAULIS.matrix  # (4, 2, 2): I, X, Y, Z
-        pauli_op_matrices = jnp.stack(
-            [reduce(jnp.kron, paulis) for paulis in product(single_pauli_matrices, repeat=num_qubits)]
-        )  # (4**num_qubits, 2**num_qubits, 2**num_qubits)
-
-        # Scale each Pauli by sqrt(probability) to form Kraus operators
-        coeffs = jnp.sqrt(jnp.array(pauli_error_rates, dtype=float))
-        kraus_matrices = coeffs[:, None, None] * pauli_op_matrices
-        kraus_map = qx.KrausMap.from_matrix(kraus_matrices, unitary.dims)
-
-        process_superop = qx.to_superop(kraus_map @ unitary)
-        return cls(inst=inst, process=process_superop, target_unitary=unitary)
-
-    @classmethod
-    def from_random_coherent_error(
-        cls: type[Channel],
-        inst: Gate,
-        process_fidelity: float,
-        rng: np.random.Generator | None = None,
-        custom_gates: CustomGateMap | None = None,
-    ) -> Channel:
-        r"""Create a channel with a random coherent (unitary) error at the specified process fidelity.
-
-        A random unitary close to identity is generated with the given process fidelity,
-        then composed with the ideal gate.
-
-        :param inst: The gate to which the channel applies.
-        :param process_fidelity: The process fidelity of the coherent error, :math:`F_e \in [0, 1]`.
-        :param rng: NumPy random number generator for reproducibility.
-        :param custom_gates: Optional dictionary of custom gate definitions.
-        :return: A Channel instance.
-        """
-        if rng is None:
-            rng = np.random.default_rng()
-
-        ideal = get_instruction_unitary(inst, custom_gates)
-        num_qubits = len(ideal.dims[0])
-        d = 2**num_qubits
-
-        # Generate a random unitary error with the specified process fidelity
-        # using Pauli generator decomposition
-        angle = jnp.arccos(2 * process_fidelity - 1) / (2 * jnp.pi)
-        id_coeff = 1 - float(angle)
-        coeffs = rng.random(4**num_qubits - 1)
-        coeffs = (1 - id_coeff) / np.sqrt(np.sum(np.square(coeffs))) * coeffs
-
-        # Build Pauli generator sum using quax Pauli matrices
-        pauli_matrices = qx.ensembles.PAULIS.matrix  # shape (4, 2, 2)
-        pauli_sum = jnp.eye(d, dtype=complex) * id_coeff
-        pauli_products = list(itertools.product(pauli_matrices, repeat=num_qubits))[1:]
-        for paulis, coefficient in zip(pauli_products, coeffs, strict=False):
-            pauli_sum = pauli_sum + reduce(jnp.kron, paulis) * coefficient
-
-        error_unitary = jax_expm(-1j * jnp.pi * pauli_sum)
-        # Fix global phase
-        phase = jnp.exp(-1j * jnp.angle(error_unitary[0, 0]))
-        error_unitary = error_unitary * phase
-
-        error_u = qx.Unitary.from_matrix(error_unitary, ideal.dims)
-        noisy_superop = qx.to_superop(error_u @ ideal)
-        return cls(inst=inst, process=noisy_superop, target_unitary=ideal)
-
-    @classmethod
-    def from_mixture(
-        cls: type[Channel],
-        inst: Gate,
-        constituents: list[qx.Unitary],
-        probabilities: list[float],
-        custom_gates: CustomGateMap | None = None,
-    ) -> Channel:
-        r"""Create a mixture channel from a set of unitary errors with given probabilities.
-
-        The channel is :math:`\mathcal{E}(\rho) = (1-\sum p_i) U\rho U^\dagger + \sum p_i V_i U \rho U^\dagger V_i^\dagger`
-        where :math:`U` is the ideal gate and :math:`V_i` are the error unitaries.
-
-        :param inst: The gate to which the channel applies.
-        :param constituents: Unitary error operators to mix.
-        :param probabilities: Probability of each unitary error. Must sum to at most 1.0.
-        :param custom_gates: Optional dictionary of custom gate definitions.
-        :return: A Channel instance.
-        """
-        ideal = get_instruction_unitary(inst, custom_gates)
-
-        if len(constituents) != len(probabilities):
-            raise ValueError("The number of constituents and probabilities must match.")
-        error_prob = sum(probabilities)
-        if error_prob > 1.0:
-            raise ValueError(f"The sum of probabilities ({error_prob}) must be at most 1.0.")
-
-        # Build the mixture superop: (1-p_total) S(U) + sum p_i S(V_i @ U)
-        p0 = 1.0 - error_prob
-        noisy_superop_matrix = p0 * qx.to_superop(ideal).matrix
-        for p, v in zip(probabilities, constituents, strict=False):
-            composed = v @ ideal
-            noisy_superop_matrix = noisy_superop_matrix + p * qx.to_superop(composed).matrix
-        noisy_superop = qx.SuperOp.from_matrix(noisy_superop_matrix, ideal.dims)
-        return cls(inst=inst, process=noisy_superop, target_unitary=ideal)
-
-    @classmethod
-    def from_coherence_times(
-        cls: type[Channel],
-        inst: Gate,
-        gate_duration: float,
-        t1s: list[float],
-        t2s: list[float] | None = None,
-        custom_gates: CustomGateMap | None = None,
-    ) -> Channel:
-        """Create a decoherence Channel based on the coherence times.
-
-        In this construction, decoherence is applied _after_ the ideal gate unitary.
-
-        :param inst: The target instruction.
-        :param gate_duration: The duration of the gate.
-        :param t1s: The t1 time(s) of the qubits
-        :param t2s: The t2 time(s) of the qubits. Default to 2*t1.
-        """
-        unitary = get_instruction_unitary(inst, custom_gates)
-        qubits = inst.get_qubit_indices()
-        num_sys = len(qubits)
-        if num_sys != len(t1s):
-            raise ValueError(f"Expected {num_sys} T1 values for {inst.out()}, got {len(t1s)}.")
-        if t2s is None:
-            t2s = [2 * t1 for t1 in t1s]
-        else:
-            if num_sys != len(t2s):
-                raise ValueError(f"Expected {num_sys} T2 values for {inst.out()}, got {len(t2s)}.")
-
-        t1_array = jnp.asarray(t1s)
-        tphi_array = 1 / (1 / jnp.asarray(t2s) - 1 / t1_array)
-
-        # One thermal-relaxation channel per subsystem, tensored into a joint superoperator.
-        per_qubit = [
-            qx.channels.thermal_relaxation(t1, tphi, t=gate_duration)
-            for t1, tphi in zip(t1_array, tphi_array, strict=True)
-        ]
-        relaxation = reduce(qx.tensor_superop, per_qubit)
-        process = qx.to_superop(relaxation @ unitary)
-        return cls(
-            inst=inst,
-            process=process,
-            target_unitary=unitary,
-        )
-
-    @classmethod
-    def from_superoperator(
-        cls: type[Channel],
-        inst: Gate,
-        process: qx.SuperOp,
-        target_unitary: qx.Unitary | None = None,
-        custom_gates: CustomGateMap | None = None,
-    ) -> Channel:
-        """Create a Channel from a pre-built superoperator.
-
-        If ``target_unitary`` is not provided it is inferred from the gate
-        instruction using the standard gate set (and ``custom_gates`` if given).
-
-        :param inst: The gate to which the channel applies.
-        :param process: The noisy process superoperator (includes the gate unitary).
-        :param target_unitary: The ideal gate unitary.  Resolved automatically
-            when omitted.
-        :param custom_gates: Optional dictionary of custom gate definitions,
-            used only when ``target_unitary`` is ``None``.
-        :return: A Channel instance.
-        """
-        if target_unitary is None:
-            target_unitary = get_instruction_unitary(inst, custom_gates)
-        return cls(inst=inst, process=process, target_unitary=target_unitary)
 
     # ──────────────────────────────────────────────
     # Cached representation conversions
@@ -676,10 +349,14 @@ class Channel:
         return float(qx.unitarity(self.noise_process))
 
     # ──────────────────────────────────────────────
-    # Channel analysis methods
+    # SuperopChannel analysis methods
     # ──────────────────────────────────────────────
 
-    def pauli_twirl(self) -> Channel:
+    def _as_channel(self, process: qx.SuperOp) -> SuperopChannel:
+        """Wrap a derived superoperator as a plain :class:`SuperopChannel` for this gate."""
+        return SuperopChannel(inst=self.inst, process=process, target_unitary=self.target_unitary)
+
+    def pauli_twirl(self) -> SuperopChannel:
         """Return a Pauli-twirled version of this channel.
 
         Pauli twirling projects the channel onto the Pauli diagonal, eliminating
@@ -691,7 +368,7 @@ class Channel:
         # Keep only the diagonal of the PTM
         twirled_ptm_matrix = jnp.diag(jnp.diag(ptm.matrix))
         twirled_superop = qx.to_superop(qx.PauliLiouville.from_matrix(twirled_ptm_matrix, self.process.dims))
-        return replace(self, process=twirled_superop)
+        return self._as_channel(twirled_superop)
 
     @cached_property
     def _unitary_error_component(self) -> Array:
@@ -711,7 +388,7 @@ class Channel:
         u, _, vh = jnp.linalg.svd(dominant_eigenvector.reshape(d, d).T)
         return u @ vh
 
-    def to_coherent_channel(self) -> Channel:
+    def to_coherent_channel(self) -> SuperopChannel:
         """Isolate the coherent (unitary) component of the noise.
 
         Extracts the dominant unitary from the noise Choi matrix via polar
@@ -721,9 +398,9 @@ class Channel:
         u_error = self._unitary_error_component
         u_error_qx = qx.Unitary.from_matrix(u_error, self.process.dims)
         coherent_superop = qx.to_superop(u_error_qx @ self.unitary)
-        return replace(self, process=coherent_superop)
+        return self._as_channel(coherent_superop)
 
-    def to_stochastic_channel(self) -> Channel:
+    def to_stochastic_channel(self) -> SuperopChannel:
         r"""Isolate the stochastic (incoherent) component of the noise.
 
         The full channel decomposes as
@@ -739,7 +416,7 @@ class Channel:
         # Recompose with the ideal gate
         ideal_superop = jnp.kron(self.unitary.matrix, self.unitary.matrix.conj())
         stochastic_superop = stochastic_noise_superop @ ideal_superop
-        return replace(self, process=qx.SuperOp.from_matrix(stochastic_superop, self.process.dims))
+        return self._as_channel(qx.SuperOp.from_matrix(stochastic_superop, self.process.dims))
 
     def is_pauli(self) -> bool:
         """Check if the noise channel is a Pauli (stochastic Pauli) channel.
@@ -799,10 +476,10 @@ class Channel:
                 ptm = qx.to_pauli_liouville(channel)
                 log_ptm = scipy_logm(np.asarray(ptm.matrix))
                 channel = qx.PauliLiouville.from_matrix(jnp.array(log_ptm), channel.dims)
-            title_prefix = "Noise Channel"
+            title_prefix = "Noise SuperopChannel"
         else:
             channel = self.process
-            title_prefix = "Full Channel"
+            title_prefix = "Full SuperopChannel"
 
         fig = qx.plot(channel)
         fig.update_layout(
@@ -816,11 +493,170 @@ class Channel:
         return fig
 
     # ──────────────────────────────────────────────
+    # Dunder methods
+    # ──────────────────────────────────────────────
+
+    def __str__(self) -> str:
+        """Return a simplified string representation showing the gate and process fidelity."""
+        return f"<{self.inst.out()} ~ ({100 * self.pauli_fidelity:.2f}%)>"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality by concrete type, instruction, and exact process/ideal-gate matrices.
+
+        Equality is exact (no fidelity tolerance): two channels are equal only if they are the
+        same concrete class, share the same instruction, and have bit-for-bit identical process
+        and target-unitary matrices. Making tolerance decisions on the user's behalf is
+        deliberately avoided.
+        """
+        if type(self) is not type(other):
+            return False
+        if self.inst != other.inst:  # type: ignore[attr-defined]
+            return False
+        return bool(
+            jnp.array_equal(self.process.matrix, other.process.matrix)  # type: ignore[attr-defined]
+            and jnp.array_equal(self.target_unitary.matrix, other.target_unitary.matrix)  # type: ignore[attr-defined]
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __matmul__(self, other: ChannelProtocol) -> SuperopChannel:
+        r"""Compose two channels: ``channel_B @ channel_A``.
+
+        Both channels share the same gate instruction. The composition factors
+        out one copy of the gate unitary so the result represents the sequential
+        application of the two noisy processes:
+
+        :math:`\mathcal{E}_B \circ \mathcal{U}^\dagger \circ \mathcal{E}_A`
+
+        This is the natural composition: if ``channel_A`` already includes the
+        gate, applying ``channel_B`` after it should not double-count the gate.
+        The result is a plain :class:`SuperopChannel` (a superoperator composition).
+        """
+        if not isinstance(other, ChannelProtocol):
+            return NotImplemented
+        if self.inst != other.inst:
+            raise ValueError(f"Cannot compose channels for different gates: {self.inst.out()} vs {other.inst.out()}")
+        # E_B @ U† @ E_A  (factor out one gate unitary between the two channels)
+        u_dag_superop = qx.to_superop(self.unitary.h)
+        composed_superop = qx.to_superop(self.process @ u_dag_superop @ other.process)
+        return self._as_channel(composed_superop)
+
+    def __or__(self, other: ChannelProtocol | MeasurementChannel) -> CycleChannel:
+        """Tensor product of two channels on disjoint qubits, producing a CycleChannel.
+
+        The result represents a cycle containing both operations acting in parallel
+        on disjoint qubits. The DefCircuit encodes the parallel operations as
+        formal instructions.
+
+        :param other: Another gate channel or MeasurementChannel on disjoint qubits.
+        :return: A CycleChannel representing the tensor product.
+        """
+        if not isinstance(other, (ChannelProtocol, MeasurementChannel)):
+            return NotImplemented
+
+        # Validate disjoint qubits
+        self_qubits = set(self.qubits)
+        other_qubits = set(other.qubits)
+        if self_qubits & other_qubits:
+            raise ValueError(f"Cannot tensor channels with overlapping qubits: {self_qubits & other_qubits}")
+
+        return _build_cycle_channel([self, other])
+
+
+@dataclass(frozen=True, eq=False)
+class SuperopChannel(ChannelProtocol):
+    """A noise channel that stores a superoperator directly, for a specific gate.
+
+    This is the special case of :class:`ChannelProtocol` whose ``process`` is a stored
+    ``qx.SuperOp`` (rather than derived from a Lindbladian generator, as :class:`Channel`). It is
+    what the manifold-leaving operations (composition ``@``, :meth:`pauli_twirl`,
+    :meth:`to_coherent_channel`, :meth:`to_stochastic_channel`) return, and is useful when only a
+    raw superoperator is available. Prefer :class:`Channel` and its ``from_*`` constructors when a
+    generator description is available.
+
+    The superoperator *includes* the gate unitary, so the channel replaces the gate rather than
+    being applied after it, and can be converted to alternative representations (Choi, Kraus,
+    Pauli-Liouville) via ``quax``. Fidelity metrics are computed relative to ``target_unitary``.
+    """
+
+    inst: Gate
+    """Quil gate to which the channel applies."""
+
+    process: qx.SuperOp
+    """The noisy process (superoperator) for the gate, including the gate unitary."""
+
+    target_unitary: qx.Unitary
+    """The noiseless unitary of the gate."""
+
+    # ──────────────────────────────────────────────
+    # Constructors
+    # ──────────────────────────────────────────────
+
+    @classmethod
+    def from_pauli_noise(
+        cls: type[SuperopChannel],
+        inst: Gate,
+        pauli_noise: dict[str, float],
+        custom_gates: CustomGateMap | None = None,
+    ) -> SuperopChannel:
+        r"""Create a traditional post-gate stochastic Pauli error channel from error probabilities.
+
+        This is the one-shot mixed-Pauli model applied *after* the ideal gate:
+        :math:`\mathcal{E}(\rho) = \sum_i p_i\, P_i U \rho U^\dagger P_i^\dagger`, where the
+        probabilities ``p_i`` (plus the implicit identity term) sum to 1. Unlike
+        :meth:`Channel.from_pauli_generators`, the resulting channel reproduces the given error
+        probabilities exactly (no exponentiation).
+
+        :param inst: The gate to which the channel applies.
+        :param pauli_noise: Pauli error probabilities, e.g. ``{"IX": 0.01, "ZZ": 0.02}``. Must sum
+            to at most 1.0; the remainder is assigned to the identity (no-error) term.
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A SuperopChannel instance.
+        """
+        unitary = get_instruction_unitary(inst, custom_gates)
+        num_qubits = len(unitary.dims[0])
+
+        total_error_rate = 0.0
+        for pauli, error_rate in pauli_noise.items():
+            if error_rate < 0.0:
+                raise ValueError(f"Pauli term '{pauli}' has negative error rate {error_rate}.")
+            if len(pauli) != num_qubits:
+                raise ValueError(f"Pauli term '{pauli}' has length {len(pauli)}, expected {num_qubits}.")
+            total_error_rate += error_rate
+        if total_error_rate > 1.0:
+            raise ValueError(f"Pauli error rates must sum to at most 1.0, got {total_error_rate}.")
+
+        all_pauli_terms = tuple("".join(term) for term in product("IXYZ", repeat=num_qubits))
+        pauli_error_rates: list[float] = []
+        for term in reversed(all_pauli_terms):
+            if term in pauli_noise:
+                error_rate = pauli_noise[term]
+            elif all(p == "I" for p in term):
+                error_rate = 1 - sum(pauli_error_rates)
+            else:
+                error_rate = 0
+            pauli_error_rates.append(error_rate)
+        pauli_error_rates = list(reversed(pauli_error_rates))
+
+        # Kraus operators are the Pauli tensor products scaled by sqrt(probability), in
+        # lexicographic (I, X, Y, Z) order matching pauli_error_rates, applied after the gate.
+        single_pauli_matrices = qx.ensembles.PAULIS.matrix  # (4, 2, 2): I, X, Y, Z
+        pauli_op_matrices = jnp.stack(
+            [reduce(jnp.kron, paulis) for paulis in product(single_pauli_matrices, repeat=num_qubits)]
+        )
+        coeffs = jnp.sqrt(jnp.array(pauli_error_rates, dtype=float))
+        kraus_matrices = coeffs[:, None, None] * pauli_op_matrices
+        kraus_map = qx.KrausMap.from_matrix(kraus_matrices, unitary.dims)
+
+        process_superop = qx.to_superop(kraus_map @ unitary)
+        return cls(inst=inst, process=process_superop, target_unitary=unitary)
+
+    # ──────────────────────────────────────────────
     # Serialization
     # ──────────────────────────────────────────────
 
     def to_json(self) -> str:
-        """Serialize Channel to a JSON string.
+        """Serialize SuperopChannel to a JSON string.
 
         :return: JSON string representation.
         """
@@ -834,16 +670,16 @@ class Channel:
         return json.dumps(data)
 
     @classmethod
-    def from_json(cls: type[Channel], json_str: str) -> Channel:
-        """Deserialize a Channel from a JSON string.
+    def from_json(cls: type[SuperopChannel], json_str: str) -> SuperopChannel:
+        """Deserialize a SuperopChannel from a JSON string.
 
         :param json_str: JSON string as produced by :meth:`to_json`.
-        :return: Channel instance.
+        :return: SuperopChannel instance.
         """
         data = json.loads(json_str)
         inst = _parse_quil_instruction(data["inst"])
         if not isinstance(inst, Gate):
-            raise TypeError(f"Channel JSON must contain a gate instruction, got {type(inst).__name__}.")
+            raise TypeError(f"SuperopChannel JSON must contain a gate instruction, got {type(inst).__name__}.")
 
         superop_data = data["superop"]
         shape = tuple(superop_data["shape"])
@@ -862,73 +698,406 @@ class Channel:
 
         return cls(inst=inst, process=superop, target_unitary=target_unitary)
 
+
+@runtime_checkable
+class _LindbladianBacked(Protocol):
+    """Mixin for channels whose ``process`` is generated by a ``qx.Lindbladian``.
+
+    Provides the ``process`` superoperator (``evolve(lindbladian, gate_time)``) and a helper for
+    the CPTP-safe power operation. Concrete subclasses supply ``lindbladian`` and ``gate_time``.
+    """
+
+    if TYPE_CHECKING:
+        lindbladian: qx.Lindbladian
+        gate_time: float
+
+    @cached_property
+    def process(self) -> qx.SuperOp:
+        """The channel superoperator, obtained by evolving the generator for ``gate_time``."""
+        return qx.evolve(self.lindbladian, self.gate_time)
+
+    def _scaled_noise_generator(self, power: float, *, gate_hamiltonian: qx.Observable | None) -> qx.Lindbladian:
+        r"""Scale the dissipative + coherent-noise part of the generator by ``power``, keeping the gate.
+
+        Physically powers the noise: each jump rate :math:`\gamma_k \to \text{power} \cdot \gamma_k`
+        (so :math:`L_k \to \sqrt{\text{power}}\,L_k`) and the coherent-noise Hamiltonian
+        :math:`H_{\text{noise}} \to \text{power} \cdot H_{\text{noise}}`, while the coherent gate
+        generator ``gate_hamiltonian`` (``None`` for a purely dissipative reset) is preserved. The
+        result is CPTP for ``power >= 0``.
+        """
+        if power < 0:
+            raise ValueError(f"Lindbladian channel power must be non-negative, got {power}.")
+        hamiltonian = self.lindbladian.hamiltonian
+        if gate_hamiltonian is not None and hamiltonian is not None:
+            noise_hamiltonian: qx.Observable | None = hamiltonian - gate_hamiltonian
+        else:
+            noise_hamiltonian = hamiltonian
+        scaled_hamiltonian = noise_hamiltonian * float(power) if noise_hamiltonian is not None else None
+        if gate_hamiltonian is not None:
+            scaled_hamiltonian = (
+                gate_hamiltonian if scaled_hamiltonian is None else scaled_hamiltonian + gate_hamiltonian
+            )
+        scaled_jumps = self.lindbladian.jump_operators * float(np.sqrt(power))
+        return qx.Lindbladian(hamiltonian=scaled_hamiltonian, jump_operators=scaled_jumps)
+
+
+@dataclass(frozen=True, eq=False)
+class Channel(_LindbladianBacked, ChannelProtocol):
+    r"""A noise channel that attaches a Lindbladian generator to a specific gate.
+
+    The Lindbladian *includes* the gate Hamiltonian, so the channel *replaces* the gate rather
+    than being applied after it. The ``process`` superoperator is obtained on demand via
+    ``qx.evolve(lindbladian, gate_time)``.
+
+    Compared with :class:`SuperopChannel` (a stored superoperator), a Lindbladian-backed channel makes
+    two operations natural and CPTP-safe:
+
+    - :meth:`__pow__` scales the *noise* (jump rates and coherent-noise Hamiltonian) while keeping
+      the ideal gate, sweeping noise strength in a physically meaningful way.
+    - :meth:`__add__` combines the *noise* of two channels on the same gate, keeping the gate.
+
+    ``gate_time`` defaults to ``1.0`` (dimensionless). It may instead be a physical duration (e.g.
+    ``~40e-9`` s), in which case the Hamiltonian and jump operators are in physical units; the gate
+    Hamiltonian is scaled so that evolving for ``gate_time`` reproduces the ideal ``target_unitary``.
+    """
+
+    inst: Gate
+    """Quil gate to which the channel applies."""
+
+    lindbladian: qx.Lindbladian
+    """The GKSL generator for the gate, including the (scaled) gate Hamiltonian."""
+
+    target_unitary: qx.Unitary
+    """The noiseless unitary of the gate."""
+
+    gate_time: float = 1.0
+    """Evolution time for ``evolve(lindbladian, gate_time)``. Default 1.0 (dimensionless)."""
+
+    @cached_property
+    def _gate_hamiltonian(self) -> qx.Observable:
+        """Coherent generator whose evolution over ``gate_time`` yields ``target_unitary``."""
+        return qx.unitary_to_hamiltonian(self.target_unitary) * (1.0 / self.gate_time)
+
+    @cached_property
+    def _noise_lindbladian(self) -> qx.Lindbladian:
+        """The generator with the coherent gate Hamiltonian factored out (dissipation + coherent noise)."""
+        hamiltonian = self.lindbladian.hamiltonian
+        noise_hamiltonian = hamiltonian - self._gate_hamiltonian if hamiltonian is not None else None
+        return qx.Lindbladian(hamiltonian=noise_hamiltonian, jump_operators=self.lindbladian.jump_operators)
+
     # ──────────────────────────────────────────────
-    # Dunder methods
+    # Constructors
     # ──────────────────────────────────────────────
 
-    def __str__(self) -> str:
-        """Return a simplified string representation showing the gate and process fidelity."""
-        return f"<{self.inst.out()} ~ ({100 * self.pauli_fidelity:.2f}%)>"
+    @classmethod
+    def from_lindbladian(
+        cls: type[Channel],
+        inst: Gate,
+        noise_lindbladian: qx.Lindbladian,
+        gate_time: float = 1.0,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        """Create a channel from a noise-only Lindbladian, folding in the gate.
 
-    def __eq__(self, other: object) -> bool:
-        """Check equality by instruction and exact process and ideal-gate matrices.
+        :param inst: The gate to which the channel applies.
+        :param noise_lindbladian: The noise generator (e.g. from ``qx.lindbladians``), *without*
+            the gate Hamiltonian. Its rates are interpreted per unit time and evolved for ``gate_time``.
+        :param gate_time: Evolution time (default 1.0).
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A Channel instance.
+        """
+        target_unitary = get_instruction_unitary(inst, custom_gates)
+        gate_hamiltonian = qx.unitary_to_hamiltonian(target_unitary) * (1.0 / gate_time)
+        noise_hamiltonian = noise_lindbladian.hamiltonian
+        total_hamiltonian = gate_hamiltonian if noise_hamiltonian is None else noise_hamiltonian + gate_hamiltonian
+        lindbladian = qx.Lindbladian(hamiltonian=total_hamiltonian, jump_operators=noise_lindbladian.jump_operators)
+        return cls(inst=inst, lindbladian=lindbladian, target_unitary=target_unitary, gate_time=gate_time)
 
-        Equality is exact (no fidelity tolerance): two channels are equal only if they
-        share the same instruction and bit-for-bit identical process and target-unitary
-        matrices. Making tolerance decisions on the user's behalf is deliberately avoided.
+    @classmethod
+    def from_gate_fidelity(
+        cls: type[Channel],
+        inst: Gate,
+        fidelity: float,
+        gate_time: float = 1.0,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        """Create a depolarizing Lindbladian channel from an average gate fidelity."""
+        unitary = get_instruction_unitary(inst, custom_gates)
+        p = qx.average_fidelity_to_depolarizing_constant(fidelity, unitary.dims[0])
+        return cls.from_depolarizing_constant(inst, p, gate_time, custom_gates)
+
+    @classmethod
+    def from_pauli_fidelity(
+        cls: type[Channel],
+        inst: Gate,
+        pauli_fidelity: float,
+        gate_time: float = 1.0,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        """Create a depolarizing Lindbladian channel from a process (Pauli) fidelity."""
+        unitary = get_instruction_unitary(inst, custom_gates)
+        p = qx.process_fidelity_to_depolarizing_constant(pauli_fidelity, unitary.dims[0])
+        return cls.from_depolarizing_constant(inst, p, gate_time, custom_gates)
+
+    @classmethod
+    def from_depolarizing_constant(
+        cls: type[Channel],
+        inst: Gate,
+        depolarizing_constant: float,
+        gate_time: float = 1.0,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        r"""Create a depolarizing Lindbladian channel from a depolarization constant.
+
+        Matches :meth:`SuperopChannel.from_depolarizing_constant`: the depolarizing constant :math:`p`
+        parameterizes :math:`\mathcal{D}_p(\rho) = p\,\rho + (1-p)\,I/d`. The rate is chosen so that
+        evolving for ``gate_time`` shrinks every traceless operator by exactly ``p``.
+        """
+        unitary = get_instruction_unitary(inst, custom_gates)
+        dims = unitary.dims[0]
+        d = int(np.prod(dims))
+        shrink = float(np.clip(depolarizing_constant, np.finfo(float).tiny, 1.0))
+        gamma_unit_time = -np.log(shrink) * (d**2 - 1) / d**2
+        noise = qx.lindbladians.depolarizing(gamma_unit_time / gate_time, dims)
+        return cls.from_lindbladian(inst, noise, gate_time, custom_gates)
+
+    @classmethod
+    def from_coherence_times(
+        cls: type[Channel],
+        inst: Gate,
+        gate_duration: float,
+        t1s: list[float],
+        t2s: list[float] | None = None,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        """Create a decoherence channel from T1/T2 coherence times, evolved over ``gate_duration``.
+
+        The gate and thermal relaxation happen together over ``gate_duration`` (``gate_time`` is set
+        to ``gate_duration``). Physical rates come from ``qx.lindbladians.thermal_relaxation``.
+
+        :param inst: The target instruction.
+        :param gate_duration: The duration of the gate (used as ``gate_time``).
+        :param t1s: The T1 time(s) of the qudits.
+        :param t2s: The T2 time(s) of the qudits. Default to ``2 * t1``.
+        """
+        qubits = inst.get_qubit_indices()
+        num_sys = len(qubits)
+        if num_sys != len(t1s):
+            raise ValueError(f"Expected {num_sys} T1 values for {inst.out()}, got {len(t1s)}.")
+        if t2s is None:
+            t2s = [2 * t1 for t1 in t1s]
+        elif num_sys != len(t2s):
+            raise ValueError(f"Expected {num_sys} T2 values for {inst.out()}, got {len(t2s)}.")
+
+        t1_array = jnp.asarray(t1s)
+        tphi_array = 1 / (1 / jnp.asarray(t2s) - 1 / t1_array)
+        per_qubit = [
+            qx.lindbladians.thermal_relaxation(t1, tphi) for t1, tphi in zip(t1_array, tphi_array, strict=True)
+        ]
+        noise = reduce(lambda a, b: a | b, per_qubit)
+        return cls.from_lindbladian(inst, noise, gate_duration, custom_gates)
+
+    @classmethod
+    def from_pauli_generators(
+        cls: type[Channel],
+        inst: Gate,
+        pauli_generators: dict[str, float],
+        gate_time: float = 1.0,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        """Create a Pauli-dissipation channel from Pauli generator rates.
+
+        Each Pauli term ``P`` with rate ``r`` contributes a jump operator ``sqrt(r) * P`` to the
+        Lindbladian generator, so the rates are per-unit-time *generator* rates (not one-shot
+        probabilities); over ``gate_time`` the channel is the corresponding continuously-generated
+        Pauli channel. For a traditional post-gate stochastic Pauli error model with exact
+        probabilities, use :meth:`SuperopChannel.from_pauli_noise`.
+
+        :param inst: The gate to which the channel applies.
+        :param pauli_generators: Pauli generator rates, e.g. ``{"IX": 0.01, "ZZ": 0.02}``.
+        :param gate_time: Evolution time (default 1.0).
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A Channel instance.
+        """
+        unitary = get_instruction_unitary(inst, custom_gates)
+        num_qubits = len(unitary.dims[0])
+        single_pauli_matrices = qx.ensembles.PAULIS.matrix  # (4, 2, 2): I, X, Y, Z
+        pauli_index = {"I": 0, "X": 1, "Y": 2, "Z": 3}
+
+        jump_matrices = []
+        for pauli, rate in pauli_generators.items():
+            if rate < 0.0:
+                raise ValueError(f"Pauli term '{pauli}' has negative rate {rate}.")
+            if len(pauli) != num_qubits:
+                raise ValueError(f"Pauli term '{pauli}' has length {len(pauli)}, expected {num_qubits}.")
+            op = reduce(jnp.kron, [single_pauli_matrices[pauli_index[p]] for p in pauli])
+            jump_matrices.append(jnp.sqrt(rate) * op)
+
+        d = 2**num_qubits
+        stacked = jnp.stack(jump_matrices) if jump_matrices else jnp.zeros((1, d, d), dtype=complex)
+        jump_operators = qx.Operator.from_matrix(stacked, unitary.dims)
+        noise = qx.Lindbladian(hamiltonian=None, jump_operators=jump_operators)
+        return cls.from_lindbladian(inst, noise, gate_time, custom_gates)
+
+    @classmethod
+    def from_mixture(
+        cls: type[Channel],
+        inst: Gate,
+        constituents: list[qx.Unitary],
+        probabilities: list[float],
+        gate_time: float = 1.0,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        r"""Create a mixture channel from a set of unitary errors with given probabilities.
+
+        Each error unitary ``V_i`` with probability ``p_i`` contributes a jump operator
+        ``sqrt(p_i) * V_i`` to the generator; over ``gate_time`` this is the exponentiated
+        mixture channel composed with the ideal gate.
+
+        :param inst: The gate to which the channel applies.
+        :param constituents: Unitary error operators to mix.
+        :param probabilities: Probability of each unitary error.
+        :param gate_time: Evolution time (default 1.0).
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A Channel instance.
+        """
+        ideal = get_instruction_unitary(inst, custom_gates)
+        if len(constituents) != len(probabilities):
+            raise ValueError("The number of constituents and probabilities must match.")
+        if any(p < 0.0 for p in probabilities):
+            raise ValueError("Mixture probabilities must be non-negative.")
+
+        d = int(np.prod(ideal.dims[0]))
+        jump_matrices = [jnp.sqrt(p) * v.matrix for p, v in zip(probabilities, constituents, strict=True)]
+        stacked = jnp.stack(jump_matrices) if jump_matrices else jnp.zeros((1, d, d), dtype=complex)
+        jump_operators = qx.Operator.from_matrix(stacked, ideal.dims)
+        noise = qx.Lindbladian(hamiltonian=None, jump_operators=jump_operators)
+        return cls.from_lindbladian(inst, noise, gate_time, custom_gates)
+
+    @classmethod
+    def from_random_coherent_error(
+        cls: type[Channel],
+        inst: Gate,
+        process_fidelity: float,
+        rng: np.random.Generator | None = None,
+        gate_time: float = 1.0,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        r"""Create a channel with a random coherent (unitary) error at the specified process fidelity.
+
+        A random unitary close to identity is generated with the given process fidelity and composed
+        with the ideal gate; the result is a purely coherent :class:`Channel` (Hamiltonian only,
+        no jump operators).
+
+        :param inst: The gate to which the channel applies.
+        :param process_fidelity: The process fidelity of the coherent error, :math:`F_e \in [0, 1]`.
+        :param rng: NumPy random number generator for reproducibility.
+        :param gate_time: Evolution time (default 1.0).
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A Channel instance.
+        """
+        if rng is None:
+            rng = np.random.default_rng()
+
+        ideal = get_instruction_unitary(inst, custom_gates)
+        num_qubits = len(ideal.dims[0])
+        d = 2**num_qubits
+
+        angle = jnp.arccos(2 * process_fidelity - 1) / (2 * jnp.pi)
+        id_coeff = 1 - float(angle)
+        coeffs = rng.random(4**num_qubits - 1)
+        coeffs = (1 - id_coeff) / np.sqrt(np.sum(np.square(coeffs))) * coeffs
+
+        pauli_matrices = qx.ensembles.PAULIS.matrix  # shape (4, 2, 2)
+        pauli_sum = jnp.eye(d, dtype=complex) * id_coeff
+        pauli_products = list(itertools.product(pauli_matrices, repeat=num_qubits))[1:]
+        for paulis, coefficient in zip(pauli_products, coeffs, strict=False):
+            pauli_sum = pauli_sum + reduce(jnp.kron, paulis) * coefficient
+
+        error_unitary = jax_expm(-1j * jnp.pi * pauli_sum)
+        phase = jnp.exp(-1j * jnp.angle(error_unitary[0, 0]))
+        error_unitary = error_unitary * phase
+
+        noisy_unitary = qx.Unitary.from_matrix(error_unitary @ ideal.matrix, ideal.dims)
+        hamiltonian = qx.unitary_to_hamiltonian(noisy_unitary) * (1.0 / gate_time)
+        zero_jumps = qx.Operator.from_matrix(jnp.zeros((1, d, d), dtype=complex), ideal.dims)
+        lindbladian = qx.Lindbladian(hamiltonian=hamiltonian, jump_operators=zero_jumps)
+        return cls(inst=inst, lindbladian=lindbladian, target_unitary=ideal, gate_time=gate_time)
+
+    # ──────────────────────────────────────────────
+    # Lindbladian-native operations
+    # ──────────────────────────────────────────────
+
+    def __pow__(self, power: float) -> Channel:
+        """Scale the noise to a (non-negative) ``power`` while preserving the gate.
+
+        ``power = 0`` yields the ideal gate, ``1`` leaves the channel unchanged, and ``> 1``
+        strengthens the noise. Unlike a fractional matrix power of a superoperator, this is always
+        CPTP because it acts on the generator's jump operators and coherent-noise Hamiltonian.
+        """
+        if not isinstance(power, (int, float)):
+            return NotImplemented
+        scaled = self._scaled_noise_generator(power, gate_hamiltonian=self._gate_hamiltonian)
+        return replace(self, lindbladian=scaled)
+
+    def __add__(self, other: Channel) -> Channel:
+        """Combine the *noise* of two channels on the same gate, keeping the gate.
+
+        The gate Hamiltonian is factored out of each operand, the noise generators are summed
+        (jump operators concatenated, coherent-noise Hamiltonians added), and the gate is folded
+        back in. Adding two ``RX(pi/2)`` channels therefore yields an ``RX(pi/2)`` channel whose
+        noise is the union of the two.
         """
         if not isinstance(other, Channel):
-            return False
+            return NotImplemented
         if self.inst != other.inst:
-            return False
-        return bool(
-            jnp.array_equal(self.process.matrix, other.process.matrix)
-            and jnp.array_equal(self.target_unitary.matrix, other.target_unitary.matrix)
+            raise ValueError(f"Cannot add channels for different gates: {self.inst.out()} vs {other.inst.out()}")
+        combined_noise = self._noise_lindbladian + other._noise_lindbladian
+        gate_hamiltonian = self._gate_hamiltonian
+        combined_hamiltonian = (
+            gate_hamiltonian if combined_noise.hamiltonian is None else combined_noise.hamiltonian + gate_hamiltonian
         )
+        combined = qx.Lindbladian(hamiltonian=combined_hamiltonian, jump_operators=combined_noise.jump_operators)
+        return replace(self, lindbladian=combined)
 
-    __hash__ = None  # type: ignore[assignment]
+    # ──────────────────────────────────────────────
+    # Serialization
+    # ──────────────────────────────────────────────
 
-    def __matmul__(self, other: Channel) -> Channel:
-        r"""Compose two channels: ``channel_B @ channel_A``.
+    def to_json(self) -> str:
+        """Serialize Channel to a JSON string."""
+        hamiltonian = self.lindbladian.hamiltonian
+        data = {
+            "schema_version": 1,
+            "inst": self.inst.out(),
+            "gate_time": self.gate_time,
+            "target_unitary": _pack_operator(self.target_unitary),
+            "hamiltonian": None if hamiltonian is None else _pack_operator(hamiltonian),
+            "jump_operators": _pack_operator(self.lindbladian.jump_operators),
+        }
+        return json.dumps(data)
 
-        Both channels share the same gate instruction. The composition factors
-        out one copy of the gate unitary so the result represents the sequential
-        application of the two noisy processes:
+    @classmethod
+    def from_json(cls: type[Channel], json_str: str) -> Channel:
+        """Deserialize a Channel from a JSON string."""
+        data = json.loads(json_str)
+        inst = _parse_quil_instruction(data["inst"])
+        if not isinstance(inst, Gate):
+            raise TypeError(f"Channel JSON must contain a gate instruction, got {type(inst).__name__}.")
 
-        :math:`\mathcal{E}_B \circ \mathcal{U}^\dagger \circ \mathcal{E}_A`
+        u_data = data["target_unitary"]
+        target_unitary = qx.Unitary.from_matrix(_unpack_complex_array(u_data), _unpack_dims(u_data["dims"]))
 
-        This is the natural composition: if ``channel_A`` already includes the
-        gate, applying ``channel_B`` after it should not double-count the gate.
-        """
-        if not isinstance(other, Channel):
-            return NotImplemented
-        if self.inst != other.inst:
-            raise ValueError(f"Cannot compose channels for different gates: {self.inst.out()} vs {other.inst.out()}")
-        # E_B @ U† @ E_A  (factor out one gate unitary between the two channels)
-        u_dag_superop = qx.to_superop(self.unitary.h)
-        composed_superop = qx.to_superop(self.process @ u_dag_superop @ other.process)
-        return replace(self, process=composed_superop)
-
-    def __or__(self, other: Channel | MeasurementChannel) -> CycleChannel:
-        """Tensor product of two channels on disjoint qubits, producing a CycleChannel.
-
-        The result represents a cycle containing both operations acting in parallel
-        on disjoint qubits. The DefCircuit encodes the parallel operations as
-        formal instructions.
-
-        :param other: Another Channel or MeasurementChannel on disjoint qubits.
-        :return: A CycleChannel representing the tensor product.
-        """
-        if not isinstance(other, (Channel, MeasurementChannel)):
-            return NotImplemented
-
-        # Validate disjoint qubits
-        self_qubits = set(self.qubits)
-        other_qubits = set(other.qubits)
-        if self_qubits & other_qubits:
-            raise ValueError(f"Cannot tensor channels with overlapping qubits: {self_qubits & other_qubits}")
-
-        return _build_cycle_channel([self, other])
+        ham_data = data["hamiltonian"]
+        hamiltonian = (
+            None
+            if ham_data is None
+            else qx.Observable.from_matrix(_unpack_complex_array(ham_data), _unpack_dims(ham_data["dims"]))
+        )
+        jump_data = data["jump_operators"]
+        jump_operators = qx.Operator.from_matrix(_unpack_complex_array(jump_data), _unpack_dims(jump_data["dims"]))
+        lindbladian = qx.Lindbladian(hamiltonian=hamiltonian, jump_operators=jump_operators)
+        return cls(inst=inst, lindbladian=lindbladian, target_unitary=target_unitary, gate_time=data["gate_time"])
 
 
 @dataclass(frozen=True)
@@ -1275,54 +1444,13 @@ class MeasurementChannel:
         composed = self.process @ other.process
         return replace(self, process=composed)
 
-    def __pow__(self, power: float) -> MeasurementChannel:
-        r"""Raise the measurement's classification noise to a fractional ``power``.
-
-        The confusion and transition matrices are column-stochastic, so a fractional power is
-        only well-defined through their *generator*: with :math:`M = e^{G}` (where :math:`G` has
-        zero column sums), the principled power is :math:`M^{p} = e^{p G}`, which is again
-        column-stochastic.  This avoids the non-physical (e.g. negative) entries that a naive
-        ``fractional_matrix_power`` of a stochastic matrix can produce.
-
-        So ``power = 0`` is an ideal (noiseless) measurement, ``1`` leaves it unchanged, and
-        ``> 1`` degrades it, sweeping readout-noise strength.
-
-        :raises ValueError: If the matrix is not embeddable (no real generator) so that the
-            powered matrix is not a valid stochastic matrix.
-        """
-        if not isinstance(power, (int, float)):
-            return NotImplemented
-
-        def _powered_stochastic(matrix: Array) -> Array:
-            m = np.asarray(matrix, dtype=complex)
-            # Generator G = log(M); M**power = exp(power * G). Zero column sums of G are
-            # preserved under scaling, so exp(power * G) stays column-stochastic.
-            powered = scipy_expm(power * scipy_logm(m))
-            if np.max(np.abs(powered.imag)) > 1e-9:
-                raise ValueError(
-                    f"MeasurementChannel ** {power} has no real generator; the matrix is not "
-                    "embeddable, so the powered measurement is not a valid stochastic matrix."
-                )
-            powered = powered.real
-            if np.any(powered < -1e-9) or not np.allclose(powered.sum(axis=0), 1.0, atol=1e-6):
-                raise ValueError(
-                    f"MeasurementChannel ** {power} is not a valid (non-negative, column-stochastic) "
-                    "matrix; the underlying confusion/transition matrix is not embeddable for this power."
-                )
-            # Clip away sub-tolerance numerical negatives validated above.
-            return jnp.asarray(np.clip(powered, 0.0, None))
-
-        confusion = _powered_stochastic(self.confusion_matrix)
-        transition = _powered_stochastic(self.transition_matrix)
-        return MeasurementChannel.from_confusion_and_transition(self.inst, confusion, transition)
-
-    def __or__(self, other: Channel | MeasurementChannel) -> CycleChannel:
+    def __or__(self, other: SuperopChannel | MeasurementChannel) -> CycleChannel:
         """Tensor product of two channels on disjoint qubits, producing a CycleChannel.
 
-        :param other: Another Channel or MeasurementChannel on disjoint qubits.
+        :param other: Another SuperopChannel or MeasurementChannel on disjoint qubits.
         :return: A CycleChannel representing the tensor product.
         """
-        if not isinstance(other, (Channel, MeasurementChannel)):
+        if not isinstance(other, (SuperopChannel, MeasurementChannel)):
             return NotImplemented
 
         self_qubits = set(self.qubits)
@@ -1333,75 +1461,25 @@ class MeasurementChannel:
         return _build_cycle_channel([self, other])
 
 
-@dataclass(frozen=True)
-class ResetChannel:
-    """A reset noise channel attaches a superoperator to a specific reset operation.
+@runtime_checkable
+class _ResetChannelBase(Protocol):
+    """Shared behavior for reset noise channels backed by a superoperator ``process``.
 
-    The ``process`` field is a ``qx.SuperOp`` which *includes* the ideal reset, so the channel
-    replaces the reset instruction rather than being applied after it.
+    A reset channel replaces a targeted reset with a CPTP ``process`` (a ``qx.SuperOp`` that
+    *includes* the ideal reset). Unlike gate channels there is no ``target_unitary``; fidelity is
+    measured against the ideal reset ``qx.gates.RESET``. Concrete subclasses supply ``inst`` and
+    ``process`` — a stored field for :class:`SuperopResetChannel`, or derived from a generator for
+    :class:`ResetChannel`.
     """
 
-    inst: ResetQubit
-    """The reset operation to which the channel applies."""
-
-    process: qx.SuperOp
-    """A superoperator representation of the noisy reset (including ideal reset)."""
+    if TYPE_CHECKING:
+        inst: ResetQubit
+        process: qx.SuperOp
 
     def __post_init__(self) -> None:
-        """Validate that ResetChannel is attached to a targeted reset."""
+        """Validate that the channel is attached to a targeted reset."""
         if not isinstance(self.inst, ResetQubit):
-            raise TypeError("ResetChannel only supports targeted ResetQubit instructions.")
-
-    # ──────────────────────────────────────────────
-    # Constructors
-    # ──────────────────────────────────────────────
-
-    @classmethod
-    def from_reset_fidelity(
-        cls: type[ResetChannel],
-        inst: ResetQubit,
-        fidelity: float,
-        dim: int = 2,
-    ) -> ResetChannel:
-        r"""Create a ResetChannel with depolarizing noise scaled to the given process fidelity.
-
-        The ideal reset channel maps every state to :math:`|0\rangle\langle 0|`.  Noise is
-        modelled as a depolarising channel applied after the ideal reset.
-
-        :param inst: The reset instruction.
-        :param fidelity: Process fidelity of the reset channel, :math:`F \in [0, 1]`.
-            1.0 yields an ideal reset; values below 1 introduce depolarising noise.
-        :param dim: Hilbert-space dimension (2 for qubits).
-        :return: A ResetChannel instance.
-        """
-        if not isinstance(inst, ResetQubit):
-            raise TypeError("ResetChannel only supports targeted ResetQubit instructions.")
-
-        ideal_superop = qx.gates.RESET(dim=dim)
-        p = 1.0 - fidelity
-        d2 = dim * dim
-        # Depolarising channel in superop form: (1-p)*S_ideal + p*(I/d) for all inputs
-        # The completely depolarising superop maps everything to I/d:
-        # its rows are all zero except the diagonal entries corresponding to
-        # the trace extraction (maps vec(ρ) → vec(I/d) = vec(I)/d).
-        depol_superop_matrix = jnp.zeros((d2, d2), dtype=complex)
-        # vec(I/d) has value 1/d at positions 0, d+1, 2(d+1), ... i.e. diagonal entries
-        vec_identity_over_d = jnp.zeros(d2, dtype=complex)
-        for i in range(dim):
-            vec_identity_over_d = vec_identity_over_d.at[i * dim + i].set(1.0 / dim)
-        # The trace functional extracts sum of diagonal: positions 0, d+1, ...
-        trace_row = jnp.zeros(d2, dtype=complex)
-        for i in range(dim):
-            trace_row = trace_row.at[i * dim + i].set(1.0)
-        # Depolarising superop: each row of output is vec(I/d) * Tr(ρ)
-        depol_superop_matrix = jnp.outer(vec_identity_over_d, trace_row)
-        noisy_superop_matrix = (1.0 - p) * ideal_superop.matrix + p * depol_superop_matrix
-        noisy_superop = qx.SuperOp.from_matrix(noisy_superop_matrix, ideal_superop.dims)
-        return cls(inst=inst, process=noisy_superop)
-
-    # ──────────────────────────────────────────────
-    # Properties
-    # ──────────────────────────────────────────────
+            raise TypeError(f"{type(self).__name__} only supports targeted ResetQubit instructions.")
 
     @cached_property
     def qubits(self) -> list[int]:
@@ -1435,10 +1513,6 @@ class ResetChannel:
         """
         return self.process
 
-    # ──────────────────────────────────────────────
-    # Visualization
-    # ──────────────────────────────────────────────
-
     def plot(self) -> Figure:
         """Plot the Pauli transfer matrix of the reset channel.
 
@@ -1446,15 +1520,94 @@ class ResetChannel:
         """
         fig = qx.plot(self.process)
         qubit_str = str(self.qubits[0]) if self.qubits else "?"
-        fig.update_layout(title=(f"Reset Channel RESET {qubit_str}<br><sub>F_\u03c7={self.fidelity * 100:.2f}%</sub>"))
+        fig.update_layout(
+            title=(f"Reset SuperopChannel RESET {qubit_str}<br><sub>F_χ={self.fidelity * 100:.2f}%</sub>")
+        )
         return fig
+
+    def __str__(self) -> str:
+        """Return a simplified string representation."""
+        qubit_str = str(self.qubits[0]) if self.qubits else "?"
+        return f"<RESET({self.fidelity:.2f}) {qubit_str}>"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality by concrete type, instruction, and exact process matrix (no tolerance)."""
+        if type(self) is not type(other):
+            return False
+        if self.inst != other.inst:  # type: ignore[attr-defined]
+            return False
+        return bool(jnp.array_equal(self.process.matrix, other.process.matrix))  # type: ignore[attr-defined]
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True, eq=False)
+class SuperopResetChannel(_ResetChannelBase):
+    """A reset noise channel attaches a superoperator to a specific reset operation.
+
+    The ``process`` field is a ``qx.SuperOp`` which *includes* the ideal reset, so the channel
+    replaces the reset instruction rather than being applied after it.
+    """
+
+    inst: ResetQubit
+    """The reset operation to which the channel applies."""
+
+    process: qx.SuperOp
+    """A superoperator representation of the noisy reset (including ideal reset)."""
+
+    # ──────────────────────────────────────────────
+    # Constructors
+    # ──────────────────────────────────────────────
+
+    @classmethod
+    def from_reset_fidelity(
+        cls: type[SuperopResetChannel],
+        inst: ResetQubit,
+        fidelity: float,
+        dim: int = 2,
+    ) -> SuperopResetChannel:
+        r"""Create a SuperopResetChannel with depolarizing noise scaled to the given process fidelity.
+
+        The ideal reset channel maps every state to :math:`|0\rangle\langle 0|`.  Noise is
+        modelled as a depolarising channel applied after the ideal reset.
+
+        :param inst: The reset instruction.
+        :param fidelity: Process fidelity of the reset channel, :math:`F \in [0, 1]`.
+            1.0 yields an ideal reset; values below 1 introduce depolarising noise.
+        :param dim: Hilbert-space dimension (2 for qubits).
+        :return: A SuperopResetChannel instance.
+        """
+        if not isinstance(inst, ResetQubit):
+            raise TypeError("SuperopResetChannel only supports targeted ResetQubit instructions.")
+
+        ideal_superop = qx.gates.RESET(dim=dim)
+        p = 1.0 - fidelity
+        d2 = dim * dim
+        # Depolarising channel in superop form: (1-p)*S_ideal + p*(I/d) for all inputs
+        # The completely depolarising superop maps everything to I/d:
+        # its rows are all zero except the diagonal entries corresponding to
+        # the trace extraction (maps vec(ρ) → vec(I/d) = vec(I)/d).
+        depol_superop_matrix = jnp.zeros((d2, d2), dtype=complex)
+        # vec(I/d) has value 1/d at positions 0, d+1, 2(d+1), ... i.e. diagonal entries
+        vec_identity_over_d = jnp.zeros(d2, dtype=complex)
+        for i in range(dim):
+            vec_identity_over_d = vec_identity_over_d.at[i * dim + i].set(1.0 / dim)
+        # The trace functional extracts sum of diagonal: positions 0, d+1, ...
+        trace_row = jnp.zeros(d2, dtype=complex)
+        for i in range(dim):
+            trace_row = trace_row.at[i * dim + i].set(1.0)
+        # Depolarising superop: each row of output is vec(I/d) * Tr(ρ)
+        depol_superop_matrix = jnp.outer(vec_identity_over_d, trace_row)
+        noisy_superop_matrix = (1.0 - p) * ideal_superop.matrix + p * depol_superop_matrix
+        noisy_superop = qx.SuperOp.from_matrix(noisy_superop_matrix, ideal_superop.dims)
+        return cls(inst=inst, process=noisy_superop)
 
     # ──────────────────────────────────────────────
     # Serialization
     # ──────────────────────────────────────────────
 
     def to_json(self) -> str:
-        """Serialize ResetChannel to a JSON string.
+        """Serialize SuperopResetChannel to a JSON string.
 
         :return: JSON string representation.
         """
@@ -1466,16 +1619,18 @@ class ResetChannel:
         return json.dumps(data)
 
     @classmethod
-    def from_json(cls: type[ResetChannel], json_str: str) -> ResetChannel:
-        """Deserialize a ResetChannel from a JSON string.
+    def from_json(cls: type[SuperopResetChannel], json_str: str) -> SuperopResetChannel:
+        """Deserialize a SuperopResetChannel from a JSON string.
 
         :param json_str: JSON string as produced by :meth:`to_json`.
-        :return: ResetChannel instance.
+        :return: SuperopResetChannel instance.
         """
         data = json.loads(json_str)
         inst = _parse_quil_instruction(data["inst"])
         if not isinstance(inst, ResetQubit):
-            raise TypeError(f"ResetChannel JSON must contain a targeted reset instruction, got {type(inst).__name__}.")
+            raise TypeError(
+                f"SuperopResetChannel JSON must contain a targeted reset instruction, got {type(inst).__name__}."
+            )
         superop_data = data["superop"]
         shape = tuple(superop_data["shape"])
         arr = _unpack_complex_array(superop_data)
@@ -1483,24 +1638,101 @@ class ResetChannel:
         process = qx.SuperOp.from_matrix(arr, dims)
         return cls(inst=inst, process=process)
 
-    # ──────────────────────────────────────────────
-    # Dunder methods
-    # ──────────────────────────────────────────────
 
-    def __str__(self) -> str:
-        """Return a simplified string representation."""
-        qubit_str = str(self.qubits[0]) if self.qubits else "?"
-        return f"<RESET({self.fidelity:.2f}) {qubit_str}>"
+@dataclass(frozen=True, eq=False)
+class ResetChannel(_LindbladianBacked, _ResetChannelBase):
+    """A reset channel modeled as finite-time relaxation toward the ground state.
 
-    def __eq__(self, other: object) -> bool:
-        """Check equality by instruction and exact process matrix (no tolerance)."""
-        if not isinstance(other, ResetChannel):
-            return False
-        if self.inst != other.inst:
-            return False
-        return bool(jnp.array_equal(self.process.matrix, other.process.matrix))
+    The ``process`` is ``qx.evolve(lindbladian, gate_time)`` for a purely dissipative relaxation
+    generator (e.g. amplitude damping / thermal relaxation). The ideal reset is the strong-damping
+    (``gate_time -> infinity``) limit, so finite times give a physically-grounded *noisy* reset.
+    Like :class:`Channel`, :meth:`__pow__` scales the relaxation strength (there is no
+    gate Hamiltonian to preserve).
+    """
 
-    __hash__ = None  # type: ignore[assignment]
+    inst: ResetQubit
+    """The reset operation to which the channel applies."""
+
+    lindbladian: qx.Lindbladian
+    """The dissipative generator whose evolution over ``gate_time`` relaxes toward the ground state."""
+
+    gate_time: float = 1.0
+    """Evolution time for ``evolve(lindbladian, gate_time)``. Default 1.0 (dimensionless)."""
+
+    @classmethod
+    def from_lindbladian(
+        cls: type[ResetChannel],
+        inst: ResetQubit,
+        lindbladian: qx.Lindbladian,
+        gate_time: float = 1.0,
+    ) -> ResetChannel:
+        """Create a reset channel directly from a dissipative relaxation generator."""
+        return cls(inst=inst, lindbladian=lindbladian, gate_time=gate_time)
+
+    @classmethod
+    def from_amplitude_damping(
+        cls: type[ResetChannel],
+        inst: ResetQubit,
+        gamma: float,
+        gate_time: float = 1.0,
+        dim: int = 2,
+    ) -> ResetChannel:
+        """Create a reset channel from an amplitude-damping (decay-to-ground) generator.
+
+        :param gamma: Amplitude-damping rate. Larger ``gamma * gate_time`` gives a more complete reset.
+        :param dim: Hilbert-space dimension (2 for qubits).
+        """
+        return cls.from_lindbladian(inst, qx.lindbladians.amplitude_damping(gamma, (dim,)), gate_time)
+
+    @classmethod
+    def from_coherence_times(
+        cls: type[ResetChannel],
+        inst: ResetQubit,
+        duration: float,
+        t1: float,
+        t2: float | None = None,
+    ) -> ResetChannel:
+        """Create a reset channel from T1/T2 relaxation over ``duration`` (used as ``gate_time``)."""
+        t2_value = 2 * t1 if t2 is None else t2
+        tphi = 1 / (1 / t2_value - 1 / t1)
+        return cls.from_lindbladian(inst, qx.lindbladians.thermal_relaxation(t1, tphi), duration)
+
+    def __pow__(self, power: float) -> ResetChannel:
+        """Scale the relaxation to a (non-negative) ``power``; there is no gate to preserve."""
+        if not isinstance(power, (int, float)):
+            return NotImplemented
+        scaled = self._scaled_noise_generator(power, gate_hamiltonian=None)
+        return replace(self, lindbladian=scaled)
+
+    def to_json(self) -> str:
+        """Serialize ResetChannel to a JSON string."""
+        hamiltonian = self.lindbladian.hamiltonian
+        data = {
+            "schema_version": 1,
+            "inst": self.inst.out(),
+            "gate_time": self.gate_time,
+            "hamiltonian": None if hamiltonian is None else _pack_operator(hamiltonian),
+            "jump_operators": _pack_operator(self.lindbladian.jump_operators),
+        }
+        return json.dumps(data)
+
+    @classmethod
+    def from_json(cls: type[ResetChannel], json_str: str) -> ResetChannel:
+        """Deserialize a ResetChannel from a JSON string."""
+        data = json.loads(json_str)
+        inst = _parse_quil_instruction(data["inst"])
+        if not isinstance(inst, ResetQubit):
+            raise TypeError(f"ResetChannel JSON must contain a targeted reset instruction, got {type(inst).__name__}.")
+        ham_data = data["hamiltonian"]
+        hamiltonian = (
+            None
+            if ham_data is None
+            else qx.Observable.from_matrix(_unpack_complex_array(ham_data), _unpack_dims(ham_data["dims"]))
+        )
+        jump_data = data["jump_operators"]
+        jump_operators = qx.Operator.from_matrix(_unpack_complex_array(jump_data), _unpack_dims(jump_data["dims"]))
+        lindbladian = qx.Lindbladian(hamiltonian=hamiltonian, jump_operators=jump_operators)
+        return cls(inst=inst, lindbladian=lindbladian, gate_time=data["gate_time"])
 
 
 @dataclass(frozen=True)
@@ -1517,7 +1749,7 @@ class CycleChannel:
     defcircuit: DefCircuit
     """The DefCircuit representing the logical cycle to which instruction represents."""
 
-    channels: tuple[Channel | MeasurementChannel, ...]
+    channels: tuple[ChannelProtocol | MeasurementChannel, ...]
     """Constituent channels (one per operation in the cycle) on disjoint qubits."""
 
     def __post_init__(self) -> None:
@@ -1585,7 +1817,7 @@ class CycleChannel:
         """
         f = 1.0
         for ch in self.channels:
-            if isinstance(ch, Channel):
+            if isinstance(ch, ChannelProtocol):
                 f *= ch.pauli_fidelity
         return f
 
@@ -1597,7 +1829,7 @@ class CycleChannel:
         """
         f = 1.0
         for ch in self.channels:
-            if isinstance(ch, Channel):
+            if isinstance(ch, ChannelProtocol):
                 f *= ch.fidelity
         return f
 
@@ -1639,11 +1871,12 @@ class CycleChannel:
         :return: CycleChannel instance.
         """
         data = json.loads(json_str)
-        _type_map: dict[str, type[Channel | MeasurementChannel]] = {
+        _type_map: dict[str, type[ChannelProtocol | MeasurementChannel]] = {
+            "SuperopChannel": SuperopChannel,
             "Channel": Channel,
             "MeasurementChannel": MeasurementChannel,
         }
-        constituent_channels: list[Channel | MeasurementChannel] = [
+        constituent_channels: list[ChannelProtocol | MeasurementChannel] = [
             _type_map[ch_data["type"]].from_json(ch_data["data"]) for ch_data in data["channels"]
         ]
         return _build_cycle_channel(constituent_channels)
@@ -1667,9 +1900,9 @@ class CycleChannel:
     __hash__ = None  # type: ignore[assignment]
 
 
-def _channel_to_formal_inst(channel: Channel | MeasurementChannel) -> Gate | Measurement:
+def _channel_to_formal_inst(channel: ChannelProtocol | MeasurementChannel) -> Gate | Measurement:
     """Convert a channel's instruction to use formal arguments for DefCircuit."""
-    if isinstance(channel, Channel):
+    if isinstance(channel, ChannelProtocol):
         inst = channel.inst
         return Gate(
             name=inst.name,
@@ -1687,9 +1920,9 @@ def _channel_to_formal_inst(channel: Channel | MeasurementChannel) -> Gate | Mea
 
 
 def _build_cycle_channel(
-    channels: list[Channel | MeasurementChannel],
+    channels: list[ChannelProtocol | MeasurementChannel],
 ) -> CycleChannel:
-    """Build a CycleChannel from a list of Channel/MeasurementChannel on disjoint qubits."""
+    """Build a CycleChannel from a list of SuperopChannel/MeasurementChannel on disjoint qubits."""
     all_qubits = sorted(q for ch in channels for q in ch.qubits)
     cycle_name = "CYCLE"
     formal_insts = [_channel_to_formal_inst(ch) for ch in channels]

--- a/pyquil/noise/_channels.py
+++ b/pyquil/noise/_channels.py
@@ -269,7 +269,7 @@ class _ChannelBase(ABC):
         """Deserialize a channel from a JSON string produced by :meth:`to_json`."""
         ...
 
-    @cached_property
+    @property
     def qubits(self) -> list[int]:
         """The qubits which the channel applies to."""
         return self.inst.get_qubit_indices()
@@ -1141,7 +1141,7 @@ class MeasurementChannel:
     process: qx.QuantumInstrument
     """A quantum instrument representation of the noisy measurement."""
 
-    @cached_property
+    @property
     def qubits(self) -> list[int]:
         """The qubits which the measurement applies to."""
         qubit = self.inst.qubit
@@ -1516,7 +1516,7 @@ class _ResetChannelBase(ABC):
         if not isinstance(self.inst, ResetQubit):
             raise TypeError(f"{type(self).__name__} only supports targeted ResetQubit instructions.")
 
-    @cached_property
+    @property
     def qubits(self) -> list[int]:
         """The qubit(s) that the reset applies to."""
         qubit = self.inst.qubit
@@ -1849,7 +1849,7 @@ class CycleChannel:
         """Tuple of process superoperators, one per constituent channel."""
         return tuple(ch.process for ch in self.channels)
 
-    @cached_property
+    @property
     def qubits(self) -> list[int]:
         """All qubits in the cycle, derived from the instruction."""
         return self.inst.get_qubit_indices()

--- a/pyquil/noise/_channels.py
+++ b/pyquil/noise/_channels.py
@@ -26,11 +26,12 @@ from __future__ import annotations
 import itertools
 import json
 import logging
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from functools import cached_property, reduce
 from itertools import product
-from typing import TYPE_CHECKING, Any, Protocol, SupportsFloat, runtime_checkable
+from typing import TYPE_CHECKING, Any
 
 import jax.numpy as jnp
 import numpy as np
@@ -55,16 +56,9 @@ logger = logging.getLogger(__name__)
 CustomGateMap = dict[str, qx.Unitary | Callable[..., qx.Unitary]]
 
 
-@runtime_checkable
-class SupportsReal(Protocol):
-    """A value exposing a ``real`` attribute convertible to ``float`` (e.g. ``complex``)."""
-
-    @property
-    def real(self) -> SupportsFloat: ...
-
-
-# A gate parameter that :func:`_resolve_params` can reduce to a concrete float.
-ResolvableParam = Parameter | Expression | QuilExpression | SupportsReal
+# A gate parameter that :func:`_resolve_params` can reduce to a concrete float. The ``complex``
+# arm covers concrete numbers (``int``/``float``/``complex`` via the typing numeric tower).
+ResolvableParam = Parameter | Expression | QuilExpression | complex
 
 
 def _parse_quil_instruction(quil_str: str) -> Gate | Measurement | Reset:
@@ -240,9 +234,11 @@ def get_instruction_unitary(
     return result
 
 
-@runtime_checkable
-class ChannelProtocol(Protocol):
-    """Shared behavior for gate noise channels backed by a superoperator ``process``.
+class _ChannelBase(ABC):
+    """Shared behavior for noise channels backed by a superoperator ``process``.
+
+    Most noisy operations in quantum programs can be represented as superoperators,
+    including all Gates and Resets.
 
     A gate channel attaches a CPTP ``process`` (a ``qx.SuperOp`` that *includes* the ideal
     gate) to a :class:`~pyquil.quilbase.Gate`, with fidelity metrics measured against the
@@ -262,6 +258,21 @@ class ChannelProtocol(Protocol):
         inst: Gate
         process: qx.SuperOp
         unitary: qx.Unitary
+
+    # ──────────────────────────────────────────────
+    # Serialization contract (enforced on every concrete channel)
+    # ──────────────────────────────────────────────
+
+    @abstractmethod
+    def to_json(self) -> str:
+        """Serialize the channel to a JSON string."""
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_json(cls, json_str: str) -> _ChannelBase:
+        """Deserialize a channel from a JSON string produced by :meth:`to_json`."""
+        ...
 
     @cached_property
     def qubits(self) -> list[int]:
@@ -450,20 +461,20 @@ class ChannelProtocol(Protocol):
     # Visualization
     # ──────────────────────────────────────────────
 
-    def plot(self, noise_only: bool = True, show_identity: bool = False) -> Figure:
+    def plot(self, only_noise: bool = True, show_identity: bool = False) -> Figure:
         """Plot the Pauli transfer matrix of the channel.
 
-        :param noise_only: If True (default), plot the noise-only channel (the post-gate
+        :param only_noise: If True (default), plot the noise-only channel (the post-gate
             noise, with the ideal gate unitary factored out; see :meth:`as_post_gate_noise`).
             If False, plot the full channel including the gate unitary.
         :param show_identity: If True, include the identity component in the noise-only plot.
             If False (default), visualize the generator of the noise channel via the matrix
             logarithm of the PTM.  For near-identity noise this approximates PTM - I, but
             correctly captures the Lie-algebraic structure of the channel.
-            Only applies when ``noise_only=True``.
+            Only applies when ``only_noise=True``.
         :return: A Plotly Figure.
         """
-        if noise_only:
+        if only_noise:
             channel = self.as_post_gate_noise()
             if not show_identity:
                 ptm = qx.to_pauli_liouville(channel)
@@ -494,25 +505,25 @@ class ChannelProtocol(Protocol):
         return f"<{self.inst.out()} ~ ({100 * self.pauli_fidelity:.2f}%)>"
 
     def __eq__(self, other: object) -> bool:
-        """Check equality by concrete type, instruction, and exact process/ideal-gate matrices.
+        """Check equality by concrete type, instruction, and (approximate) process/unitary matrices.
 
-        Equality is exact (no fidelity tolerance): two channels are equal only if they are the
-        same concrete class, share the same instruction, and have bit-for-bit identical process
-        and target-unitary matrices. Making tolerance decisions on the user's behalf is
-        deliberately avoided.
+        Two channels are equal iff they are the same concrete class, share the same instruction,
+        and have element-wise-close ``process`` and ``unitary`` matrices (via :func:`jax.numpy.allclose`).
+        The comparison is approximate rather than bit-exact so it tolerates the small floating-point
+        differences between otherwise-equivalent constructions.
         """
         if type(self) is not type(other):
             return False
         if self.inst != other.inst:  # type: ignore[attr-defined]
             return False
         return bool(
-            jnp.array_equal(self.process.matrix, other.process.matrix)  # type: ignore[attr-defined]
-            and jnp.array_equal(self.unitary.matrix, other.unitary.matrix)  # type: ignore[attr-defined]
+            jnp.allclose(self.process.matrix, other.process.matrix)  # type: ignore[attr-defined]
+            and jnp.allclose(self.unitary.matrix, other.unitary.matrix)  # type: ignore[attr-defined]
         )
 
     __hash__ = None  # type: ignore[assignment]
 
-    def __matmul__(self, other: ChannelProtocol) -> SuperopChannel:
+    def __matmul__(self, other: _ChannelBase) -> _ChannelBase:
         r"""Compose two channels: ``channel_B @ channel_A``.
 
         Both channels share the same gate instruction. The composition factors
@@ -523,9 +534,11 @@ class ChannelProtocol(Protocol):
 
         This is the natural composition: if ``channel_A`` already includes the
         gate, applying ``channel_B`` after it should not double-count the gate.
-        The result is a plain :class:`SuperopChannel` (a superoperator composition).
+        This base implementation works purely with superoperators and returns a plain
+        :class:`SuperopChannel`; :class:`Channel` overrides it to compose at the Lindbladian
+        generator level (returning a :class:`Channel`) when both operands are Lindbladian-backed.
         """
-        if not isinstance(other, ChannelProtocol):
+        if not isinstance(other, _ChannelBase):
             return NotImplemented
         if self.inst != other.inst:
             raise ValueError(f"Cannot compose channels for different gates: {self.inst.out()} vs {other.inst.out()}")
@@ -534,17 +547,17 @@ class ChannelProtocol(Protocol):
         composed_superop = qx.to_superop(self.process @ u_dag_superop @ other.process)
         return self._as_channel(composed_superop)
 
-    def __or__(self, other: ChannelProtocol | MeasurementChannel) -> CycleChannel:
+    def __or__(self, other: _ChannelBase | _ResetChannelBase | MeasurementChannel) -> CycleChannel:
         """Tensor product of two channels on disjoint qubits, producing a CycleChannel.
 
         The result represents a cycle containing both operations acting in parallel
         on disjoint qubits. The DefCircuit encodes the parallel operations as
         formal instructions.
 
-        :param other: Another gate channel or MeasurementChannel on disjoint qubits.
+        :param other: Another gate channel, reset channel, or MeasurementChannel on disjoint qubits.
         :return: A CycleChannel representing the tensor product.
         """
-        if not isinstance(other, (ChannelProtocol, MeasurementChannel)):
+        if not isinstance(other, (_ChannelBase, _ResetChannelBase, MeasurementChannel)):
             return NotImplemented
 
         # Validate disjoint qubits
@@ -557,10 +570,10 @@ class ChannelProtocol(Protocol):
 
 
 @dataclass(frozen=True, eq=False)
-class SuperopChannel(ChannelProtocol):
+class SuperopChannel(_ChannelBase):
     """A noise channel that stores a superoperator directly, for a specific gate.
 
-    This is the special case of :class:`ChannelProtocol` whose ``process`` is a stored
+    This is the special case of :class:`_ChannelBase` whose ``process`` is a stored
     ``qx.SuperOp`` (rather than derived from a Lindbladian generator, as :class:`Channel`). It is
     what the manifold-leaving operations (composition ``@``, :meth:`pauli_twirl`,
     :meth:`to_coherent_channel`, :meth:`to_stochastic_channel`) return, and is useful when only a
@@ -681,8 +694,7 @@ class SuperopChannel(ChannelProtocol):
         return cls(inst=inst, process=superop, unitary=unitary)
 
 
-@runtime_checkable
-class _LindbladianBacked(Protocol):
+class _LindbladianBacked(ABC):  # noqa: B024  (abstract mixin; its contract, `lindbladian`/`gate_time`, is supplied as dataclass fields, not @abstractmethods)
     """Mixin for channels whose ``process`` is generated by a ``qx.Lindbladian``.
 
     Provides the ``process`` superoperator (``evolve(lindbladian, gate_time)``) and a helper for
@@ -724,7 +736,7 @@ class _LindbladianBacked(Protocol):
 
 
 @dataclass(frozen=True, eq=False)
-class Channel(_LindbladianBacked, ChannelProtocol):
+class Channel(_LindbladianBacked, _ChannelBase):
     r"""A noisy quantum gate: the ideal gate together with the noise that accompanies it.
 
     ``Channel`` is the primary way to describe gate noise. Rather than a raw error matrix, it
@@ -771,8 +783,23 @@ class Channel(_LindbladianBacked, ChannelProtocol):
         return qx.unitary_to_hamiltonian(self.unitary) * (1.0 / self.gate_time)
 
     @cached_property
-    def _noise_lindbladian(self) -> qx.Lindbladian:
-        """The generator with the coherent gate Hamiltonian factored out (dissipation + coherent noise)."""
+    def target_lindbladian(self) -> qx.Lindbladian:
+        """The ideal gate as a purely-coherent generator (``gate_hamiltonian`` with zero dissipation).
+
+        Together with :attr:`noise_lindbladian` this decomposes the full ``lindbladian`` into its
+        target (gate) and noise parts: ``lindbladian == noise_lindbladian + target_lindbladian``.
+        """
+        d = int(np.prod(self.unitary.dims[0]))
+        zero_jumps = qx.Operator.from_matrix(jnp.zeros((1, d, d), dtype=complex), self.unitary.dims)
+        return qx.Lindbladian(hamiltonian=self.gate_hamiltonian, jump_operators=zero_jumps)
+
+    @cached_property
+    def noise_lindbladian(self) -> qx.Lindbladian:
+        """The generator with the coherent gate Hamiltonian factored out (dissipation + coherent noise).
+
+        Together with :attr:`target_lindbladian` this decomposes the full ``lindbladian`` into its
+        target (gate) and noise parts: ``lindbladian == noise_lindbladian + target_lindbladian``.
+        """
         hamiltonian = self.lindbladian.hamiltonian
         noise_hamiltonian = hamiltonian - self.gate_hamiltonian if hamiltonian is not None else None
         return qx.Lindbladian(hamiltonian=noise_hamiltonian, jump_operators=self.lindbladian.jump_operators)
@@ -1032,19 +1059,33 @@ class Channel(_LindbladianBacked, ChannelProtocol):
         scaled = self._scaled_noise_generator(power, gate_hamiltonian=self.gate_hamiltonian)
         return replace(self, lindbladian=scaled)
 
+    def __matmul__(self, other: _ChannelBase) -> _ChannelBase:
+        """Compose two channels sharing the same gate.
+
+        For two Lindbladian-backed :class:`Channel`s the composition is formed at the generator
+        level: because the jump operators can be added directly, composition coincides with
+        combining the noise on the shared gate (:meth:`__add__`), yielding a :class:`Channel` that
+        stays CPTP and Lindbladian. Composing with a non-Lindbladian channel falls back to the
+        superoperator composition of :meth:`_ChannelBase.__matmul__`, which returns a plain
+        :class:`SuperopChannel`.
+        """
+        if isinstance(other, Channel):
+            return self + other
+        return super().__matmul__(other)
+
     def __add__(self, other: Channel) -> Channel:
         """Combine the *noise* of two channels on the same gate, keeping the gate.
 
-        The gate Hamiltonian is factored out of each operand, the noise generators are summed
-        (jump operators concatenated, coherent-noise Hamiltonians added), and the gate is folded
-        back in. Adding two ``RX(pi/2)`` channels therefore yields an ``RX(pi/2)`` channel whose
-        noise is the union of the two.
+        The gate Hamiltonian is factored out of each operand (via :attr:`noise_lindbladian`), the
+        noise generators are summed (jump operators concatenated, coherent-noise Hamiltonians
+        added), and the gate is folded back in. Adding two ``RX(pi/2)`` channels therefore yields an
+        ``RX(pi/2)`` channel whose noise is the union of the two.
         """
         if not isinstance(other, Channel):
             return NotImplemented
         if self.inst != other.inst:
-            raise ValueError(f"Cannot add channels for different gates: {self.inst.out()} vs {other.inst.out()}")
-        combined_noise = self._noise_lindbladian + other._noise_lindbladian
+            raise ValueError(f"Cannot combine channels for different gates: {self.inst.out()} vs {other.inst.out()}")
+        combined_noise = self.noise_lindbladian + other.noise_lindbladian
         gate_hamiltonian = self.gate_hamiltonian
         combined_hamiltonian = (
             gate_hamiltonian if combined_noise.hamiltonian is None else combined_noise.hamiltonian + gate_hamiltonian
@@ -1409,12 +1450,12 @@ class MeasurementChannel:
         return f"<MEASURE({self.classification_fidelity:.2f}) {self.qubits[0]} ~ QND({100 * self.non_demolition_fidelity:.2f}%)>"
 
     def __eq__(self, other: object) -> bool:
-        """Check equality by instruction and exact instrument matrix (no tolerance)."""
+        """Check equality by instruction and (approximate) instrument matrix (via :func:`jax.numpy.allclose`)."""
         if not isinstance(other, MeasurementChannel):
             return False
         if self.inst != other.inst:
             return False
-        return bool(jnp.array_equal(self.process.matrix, other.process.matrix))
+        return bool(jnp.allclose(self.process.matrix, other.process.matrix))
 
     __hash__ = None  # type: ignore[assignment]
 
@@ -1433,13 +1474,13 @@ class MeasurementChannel:
         composed = self.process @ other.process
         return replace(self, process=composed)
 
-    def __or__(self, other: SuperopChannel | MeasurementChannel) -> CycleChannel:
+    def __or__(self, other: _ChannelBase | _ResetChannelBase | MeasurementChannel) -> CycleChannel:
         """Tensor product of two channels on disjoint qubits, producing a CycleChannel.
 
-        :param other: Another SuperopChannel or MeasurementChannel on disjoint qubits.
+        :param other: Another gate channel, reset channel, or MeasurementChannel on disjoint qubits.
         :return: A CycleChannel representing the tensor product.
         """
-        if not isinstance(other, (SuperopChannel, MeasurementChannel)):
+        if not isinstance(other, (_ChannelBase, _ResetChannelBase, MeasurementChannel)):
             return NotImplemented
 
         self_qubits = set(self.qubits)
@@ -1450,8 +1491,7 @@ class MeasurementChannel:
         return _build_cycle_channel([self, other])
 
 
-@runtime_checkable
-class _ResetChannelBase(Protocol):
+class _ResetChannelBase(ABC):
     """Shared behavior for reset noise channels backed by a superoperator ``process``.
 
     A reset channel replaces a targeted reset with a CPTP ``process`` (a ``qx.SuperOp`` that
@@ -1464,6 +1504,17 @@ class _ResetChannelBase(Protocol):
     if TYPE_CHECKING:
         inst: ResetQubit
         process: qx.SuperOp
+
+    @abstractmethod
+    def to_json(self) -> str:
+        """Serialize the reset channel to a JSON string."""
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_json(cls, json_str: str) -> _ResetChannelBase:
+        """Deserialize a reset channel from a JSON string produced by :meth:`to_json`."""
+        ...
 
     def __post_init__(self) -> None:
         """Validate that the channel is attached to a targeted reset."""
@@ -1504,15 +1555,15 @@ class _ResetChannelBase(Protocol):
         noise_matrix = self.process.matrix @ jnp.linalg.pinv(ideal.matrix)
         return qx.SuperOp.from_matrix(noise_matrix, self.process.dims)
 
-    def plot(self, noise_only: bool = False) -> Figure:
+    def plot(self, only_noise: bool = False) -> Figure:
         """Plot the Pauli transfer matrix of the reset channel.
 
-        :param noise_only: If True, plot the post-reset noise (see :meth:`as_post_gate_noise`)
+        :param only_noise: If True, plot the post-reset noise (see :meth:`as_post_gate_noise`)
             instead of the full process. Defaults to False (the full channel).
         :return: A Plotly Figure.
         """
-        channel = self.as_post_gate_noise() if noise_only else self.process
-        title_prefix = "Reset noise" if noise_only else "Reset channel"
+        channel = self.as_post_gate_noise() if only_noise else self.process
+        title_prefix = "Reset noise" if only_noise else "Reset channel"
         fig = qx.plot(channel)
         qubit_str = str(self.qubits[0]) if self.qubits else "?"
         fig.update_layout(title=(f"{title_prefix} RESET {qubit_str}<br><sub>F_χ={self.fidelity * 100:.2f}%</sub>"))
@@ -1524,14 +1575,36 @@ class _ResetChannelBase(Protocol):
         return f"<RESET({self.fidelity:.2f}) {qubit_str}>"
 
     def __eq__(self, other: object) -> bool:
-        """Check equality by concrete type, instruction, and exact process matrix (no tolerance)."""
+        """Check equality by concrete type, instruction, and (approximate) process matrix.
+
+        Two reset channels are equal iff they are the same concrete class, share the same
+        instruction, and have element-wise-close ``process`` matrices (via :func:`jax.numpy.allclose`).
+        The comparison is approximate rather than bit-exact so it tolerates the small floating-point
+        differences between otherwise-equivalent constructions.
+        """
         if type(self) is not type(other):
             return False
         if self.inst != other.inst:  # type: ignore[attr-defined]
             return False
-        return bool(jnp.array_equal(self.process.matrix, other.process.matrix))  # type: ignore[attr-defined]
+        return bool(jnp.allclose(self.process.matrix, other.process.matrix))  # type: ignore[attr-defined]
 
     __hash__ = None  # type: ignore[assignment]
+
+    def __or__(self, other: _ChannelBase | _ResetChannelBase | MeasurementChannel) -> CycleChannel:
+        """Tensor product with another channel on disjoint qubits, producing a CycleChannel.
+
+        :param other: Another gate channel, reset channel, or MeasurementChannel on disjoint qubits.
+        :return: A CycleChannel representing the tensor product.
+        """
+        if not isinstance(other, (_ChannelBase, _ResetChannelBase, MeasurementChannel)):
+            return NotImplemented
+
+        self_qubits = set(self.qubits)
+        other_qubits = set(other.qubits)
+        if self_qubits & other_qubits:
+            raise ValueError(f"Cannot tensor channels with overlapping qubits: {self_qubits & other_qubits}")
+
+        return _build_cycle_channel([self, other])
 
 
 @dataclass(frozen=True, eq=False)
@@ -1710,11 +1783,15 @@ class ResetChannel(_LindbladianBacked, _ResetChannelBase):
         return cls(inst=inst, lindbladian=lindbladian, gate_time=data["gate_time"])
 
 
+# A single operation within a cycle: a gate channel, a reset channel, or a measurement channel.
+CycleConstituent = _ChannelBase | _ResetChannelBase | MeasurementChannel
+
+
 @dataclass(frozen=True)
 class CycleChannel:
     """A cycle noise channel attaches superoperators to a specific cycle.
 
-    Cycles can include gates and measurements. The constituent channels are stored
+    Cycles can include gates, resets, and measurements. The constituent channels are stored
     directly, allowing fidelity metrics and serialization to be derived from them.
     """
 
@@ -1724,7 +1801,7 @@ class CycleChannel:
     defcircuit: DefCircuit
     """The DefCircuit representing the logical cycle to which instruction represents."""
 
-    channels: tuple[ChannelProtocol | MeasurementChannel, ...]
+    channels: tuple[CycleConstituent, ...]
     """Constituent channels (one per operation in the cycle) on disjoint qubits."""
 
     def __post_init__(self) -> None:
@@ -1786,13 +1863,13 @@ class CycleChannel:
     def pauli_fidelity(self) -> float:
         """Product of process (Pauli) fidelities over all gate channels in the cycle.
 
-        Measurement channels do not contribute a gate fidelity and are skipped.
+        Reset and measurement channels do not contribute a gate fidelity and are skipped.
         For near-ideal noise the product approximation is exact since constituent
         channels act on disjoint subsystems.
         """
         f = 1.0
         for ch in self.channels:
-            if isinstance(ch, ChannelProtocol):
+            if isinstance(ch, _ChannelBase):
                 f *= ch.pauli_fidelity
         return f
 
@@ -1800,11 +1877,11 @@ class CycleChannel:
     def fidelity(self) -> float:
         """Product of average gate fidelities over all gate channels in the cycle.
 
-        Measurement channels do not contribute a gate fidelity and are skipped.
+        Reset and measurement channels do not contribute a gate fidelity and are skipped.
         """
         f = 1.0
         for ch in self.channels:
-            if isinstance(ch, ChannelProtocol):
+            if isinstance(ch, _ChannelBase):
                 f *= ch.fidelity
         return f
 
@@ -1846,12 +1923,14 @@ class CycleChannel:
         :return: CycleChannel instance.
         """
         data = json.loads(json_str)
-        _type_map: dict[str, type[ChannelProtocol | MeasurementChannel]] = {
+        _type_map: dict[str, type[CycleConstituent]] = {
             "SuperopChannel": SuperopChannel,
             "Channel": Channel,
             "MeasurementChannel": MeasurementChannel,
+            "SuperopResetChannel": SuperopResetChannel,
+            "ResetChannel": ResetChannel,
         }
-        constituent_channels: list[ChannelProtocol | MeasurementChannel] = [
+        constituent_channels: list[CycleConstituent] = [
             _type_map[ch_data["type"]].from_json(ch_data["data"]) for ch_data in data["channels"]
         ]
         return _build_cycle_channel(constituent_channels)
@@ -1875,9 +1954,9 @@ class CycleChannel:
     __hash__ = None  # type: ignore[assignment]
 
 
-def _channel_to_formal_inst(channel: ChannelProtocol | MeasurementChannel) -> Gate | Measurement:
+def _channel_to_formal_inst(channel: CycleConstituent) -> Gate | Measurement | ResetQubit:
     """Convert a channel's instruction to use formal arguments for DefCircuit."""
-    if isinstance(channel, ChannelProtocol):
+    if isinstance(channel, _ChannelBase):
         inst = channel.inst
         return Gate(
             name=inst.name,
@@ -1885,6 +1964,9 @@ def _channel_to_formal_inst(channel: ChannelProtocol | MeasurementChannel) -> Ga
             qubits=[FormalArgument(f"q{q}") for q in inst.get_qubit_indices()],
             modifiers=inst.modifiers,  # type: ignore[arg-type]
         )
+    elif isinstance(channel, _ResetChannelBase):
+        qubit_idx = channel.qubits[0]
+        return ResetQubit(qubit=FormalArgument(f"q{qubit_idx}"))
     elif isinstance(channel, MeasurementChannel):
         qubit_idx = channel.qubits[0]
         return Measurement(
@@ -1895,9 +1977,9 @@ def _channel_to_formal_inst(channel: ChannelProtocol | MeasurementChannel) -> Ga
 
 
 def _build_cycle_channel(
-    channels: list[ChannelProtocol | MeasurementChannel],
+    channels: list[CycleConstituent],
 ) -> CycleChannel:
-    """Build a CycleChannel from a list of SuperopChannel/MeasurementChannel on disjoint qubits."""
+    """Build a CycleChannel from gate/reset/measurement channels on disjoint qubits."""
     all_qubits = sorted(q for ch in channels for q in ch.qubits)
     cycle_name = "CYCLE"
     formal_insts = [_channel_to_formal_inst(ch) for ch in channels]

--- a/pyquil/noise/_channels.py
+++ b/pyquil/noise/_channels.py
@@ -1,0 +1,1654 @@
+##############################################################################
+# Copyright 2016-2026 Rigetti Computing
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+##############################################################################
+"""Noise channel classes and gate-resolution utilities.
+
+This module defines ``Channel``, ``MeasurementChannel``, ``ResetChannel``, and
+``CycleChannel`` dataclasses for representing noise in quantum circuits, along
+with helper functions for resolving gate unitaries and extracting custom gate
+definitions from Quil programs.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from functools import cached_property, reduce
+from itertools import product
+from typing import TYPE_CHECKING, Any
+
+import jax.numpy as jnp
+import numpy as np
+import quax as qx
+from jax import Array
+from quil.expression import Expression as QuilExpression
+from quil.program import Program as RSProgram
+from scipy.linalg import expm as scipy_expm
+from scipy.linalg import fractional_matrix_power
+from scipy.linalg import logm as scipy_logm
+
+from pyquil.quilatom import Expression, FormalArgument, Parameter, substitute
+from pyquil.quilbase import DefCircuit, DefGate, Gate, Measurement, Reset, ResetQubit
+
+if TYPE_CHECKING:
+    from plotly.graph_objs import Figure
+
+    from pyquil import Program
+
+logger = logging.getLogger(__name__)
+
+# Type alias for the custom-gate lookup map used throughout the Channel constructors.
+CustomGateMap = dict[str, qx.Unitary | Callable[..., qx.Unitary]]
+
+
+def _parse_quil_instruction(quil_str: str) -> Gate | Measurement | Reset:
+    """Parse a single Quil instruction string into a pyquil instruction object.
+
+    Uses the ``quil`` Rust parser directly, avoiding a dependency on ``pyquil.Program``.
+    """
+    rs_inst = RSProgram.parse(quil_str).body_instructions[0]
+    if rs_inst.is_gate():
+        return Gate._from_rs_gate(rs_inst.to_gate())
+    elif rs_inst.is_measurement():
+        return Measurement._from_rs_measurement(rs_inst.to_measurement())
+    elif rs_inst.is_reset():
+        reset = rs_inst.to_reset()
+        if reset.qubit is None:
+            return Reset._from_rs_reset(reset)
+        return ResetQubit._from_rs_reset(reset)
+    raise ValueError(f"Unsupported instruction type in: {quil_str}")
+
+
+def _pack_complex_array(array: Array | np.ndarray) -> dict[str, Any]:
+    """Pack a complex array into JSON-compatible real/imaginary pairs."""
+    np_array = np.asarray(array)
+    return {
+        "_complex_array": [[float(value.real), float(value.imag)] for value in np_array.flat],
+        "shape": list(np_array.shape),
+    }
+
+
+def _unpack_complex_array(data: dict[str, Any]) -> Array:
+    """Unpack a complex array from :func:`_pack_complex_array` data."""
+    shape = tuple(data["shape"])
+    return jnp.array([complex(pair[0], pair[1]) for pair in data["_complex_array"]], dtype=complex).reshape(shape)
+
+
+def _pack_dims(dims: tuple[tuple[int, ...], tuple[int, ...]]) -> list[list[int]]:
+    """Pack quax operator dims into JSON-compatible lists."""
+    return [list(dims[0]), list(dims[1])]
+
+
+def _unpack_dims(data: list[list[int]]) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Unpack quax operator dims from JSON-compatible lists."""
+    if len(data) != 2:
+        raise ValueError(f"Serialized operator dims must contain output and input dims, got {data}.")
+    return (tuple(int(dim) for dim in data[0]), tuple(int(dim) for dim in data[1]))
+
+
+def _infer_legacy_qubit_dims(shape: tuple[int, ...], *, superoperator: bool) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Infer qubit-only dims for data serialized before dims were stored."""
+    hilbert_dim = int(round(np.sqrt(shape[0]))) if superoperator else int(shape[0])
+    num_qubits = int(round(np.log2(hilbert_dim)))
+    if 2**num_qubits != hilbert_dim:
+        raise ValueError(
+            "Serialized operator data does not include dims and its shape is not compatible with qubit-only dims."
+        )
+    return ((2,) * num_qubits, (2,) * num_qubits)
+
+
+def _pack_operator(operator: qx.SuperOp | qx.Unitary | qx.Choi) -> dict[str, Any]:
+    """Pack a quax operator matrix with explicit dimension metadata."""
+    data = _pack_complex_array(operator.matrix)
+    data["dims"] = _pack_dims(operator.dims)
+    return data
+
+
+def _unpack_operator_dims(
+    data: dict[str, Any], shape: tuple[int, ...], *, superoperator: bool
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Read explicit dims, falling back to the legacy qubit-only inference."""
+    if "dims" in data:
+        return _unpack_dims(data["dims"])
+    return _infer_legacy_qubit_dims(shape, superoperator=superoperator)
+
+
+def _resolve_params(params: list) -> list[float]:
+    """Resolve gate parameters to concrete float values.
+
+    :param params: The gate parameters (may include symbolic Parameters or Expressions).
+    :return: A list of concrete float values.
+    :raises ValueError: If any parameter is symbolic and cannot be evaluated to a number.
+    """
+    fixed_params = []
+    for p in params:
+        if isinstance(p, (Parameter, Expression)):
+            evaluated = p._evaluate()
+            if isinstance(evaluated, (Parameter, Expression)):
+                raise ValueError(
+                    f"Cannot resolve symbolic parameter {p}. Provide a gate with concrete numeric parameters."
+                )
+            fixed_params.append(float(evaluated))
+        elif isinstance(p, QuilExpression):
+            result = p.evaluate({}, {})
+            fixed_params.append(float(result.to_number()) if hasattr(result, "to_number") else float(result))  # type: ignore[arg-type]
+        else:
+            fixed_params.append(float(p.real))
+    return fixed_params
+
+
+def get_custom_gates_from_program(program: Program) -> CustomGateMap:
+    """Extract custom gate definitions from a Quil program.
+
+    Returns a dictionary mapping gate names to unitary matrices (for fixed gates) or callables
+    (for parametric gates). Does not include the standard gate set — use this to augment
+    the standard ``qx.gates.QUANTUM_GATES`` when resolving instructions with custom gates.
+
+    :param program: A Quil program containing DefGate definitions.
+    :return: A dictionary of custom gate names to unitary matrices or callables.
+    """
+    custom_gates: CustomGateMap = {}
+    for defgate in program.defined_gates:
+        if defgate.parameters:
+
+            def parametric_gate(*args: float, defgate: DefGate = defgate) -> qx.Unitary:
+                parameter_map = {Parameter(p.name): arg for p, arg in zip(defgate.parameters, args, strict=False)}
+                matrix = jnp.asarray(
+                    [[substitute(element, parameter_map) for element in row] for row in defgate.matrix],  # type: ignore[arg-type]
+                    dtype=complex,
+                )
+                num_qubits = int(jnp.round(jnp.log2(matrix.shape[0])))
+                return qx.Unitary.from_matrix(matrix, ((2,) * num_qubits, (2,) * num_qubits))
+
+            custom_gates[defgate.name] = parametric_gate
+        else:
+            matrix = jnp.asarray(defgate.matrix, dtype=complex)
+            num_qubits = int(jnp.round(jnp.log2(matrix.shape[0])))
+            custom_gates[defgate.name] = qx.Unitary.from_matrix(matrix, ((2,) * num_qubits, (2,) * num_qubits))
+    return custom_gates
+
+
+def get_instruction_unitary(
+    inst: Gate,
+    custom_gates: CustomGateMap | None = None,
+) -> qx.Unitary:
+    """Get the unitary matrix associated with a gate instruction.
+
+    Looks up the gate by name — first in ``custom_gates`` (if provided), then in the
+    standard quax gate table ``qx.gates.QUANTUM_GATES``. Parametric gates are supported
+    provided all parameters are concrete numeric values.
+
+    :param inst: The gate instruction.
+    :param custom_gates: Optional dictionary of additional gate definitions (e.g. from
+        :func:`get_custom_gates_from_program`). Takes precedence over the standard gate set.
+    :return: The unitary matrix.
+    :raises ValueError: If any gate parameter is symbolic.
+    :raises KeyError: If the gate name is not found in either the custom or standard gate set.
+    """
+    name = inst.name
+
+    # Look up gate definition: custom gates take precedence
+    if custom_gates is not None and name in custom_gates:
+        gate_def = custom_gates[name]
+    elif name in qx.gates.QUANTUM_GATES:
+        gate_def = qx.gates.QUANTUM_GATES[name]
+    else:
+        raise KeyError(f"Unknown gate '{name}'. Provide it via custom_gates (e.g. custom_gates={{'{name}': matrix}}).")
+
+    if inst.params:
+        fixed_params = _resolve_params(list(inst.params))
+        if not callable(gate_def):
+            raise ValueError(f"Gate '{name}' is not parametric but parameters were provided.")
+        result = gate_def(*fixed_params)
+    else:
+        if callable(gate_def):
+            result = gate_def()
+        else:
+            result = gate_def
+
+    # quax parametric gates may return Operator instead of Unitary; wrap if needed
+    if not isinstance(result, qx.Unitary):
+        result = qx.Unitary.from_matrix(result.matrix, result.dims)
+    return result
+
+
+@dataclass(frozen=True)
+class Channel:
+    """A noise channel attaches a superoperator to a specific gate.
+
+    The superoperator *includes* the gate unitary, so the channel replaces the gate
+    rather than being applied after it.
+
+    The ``process`` field is a ``qx.SuperOp`` which can be converted to alternative
+    representations (Choi, Kraus, Pauli-Liouville) via ``quax``.
+
+    Fidelity metrics are computed relative to the ideal gate unitary stored in
+    ``target_unitary``. For standard gates use the class methods (e.g.
+    :meth:`from_gate_fidelity`) which resolve the unitary automatically.
+    """
+
+    inst: Gate
+    """Quil gate to which the channel applies."""
+
+    process: qx.SuperOp
+    """The noisy process (superoperator) for the gate, including the gate unitary."""
+
+    target_unitary: qx.Unitary
+    """The noiseless unitary of the gate."""
+
+    @cached_property
+    def unitary(self) -> qx.Unitary:
+        """The noiseless unitary of the gate."""
+        return self.target_unitary
+
+    @cached_property
+    def qubits(self) -> list[int]:
+        """The qubits which the channel applies to."""
+        return self.inst.get_qubit_indices()
+
+    @cached_property
+    def num_qubits(self) -> int:
+        """The number of qubits the channel acts on."""
+        return len(self.qubits)
+
+    # ──────────────────────────────────────────────
+    # Constructors
+    # ──────────────────────────────────────────────
+
+    @classmethod
+    def from_gate_fidelity(
+        cls: type[Channel],
+        inst: Gate,
+        fidelity: float,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        r"""Create a depolarizing noise channel from an average gate fidelity.
+
+        The resulting channel is the composition of the ideal gate unitary with a
+        depolarizing channel calibrated to the specified fidelity:
+        :math:`\\mathcal{E} = \\mathcal{D}_p \\circ \\mathcal{U}`
+
+        :param inst: The gate to which the channel applies.
+        :param fidelity: The average gate fidelity, :math:`F_{\\mathrm{avg}} \\in [0, 1]`.
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A Channel instance.
+        """
+        unitary = get_instruction_unitary(inst, custom_gates)
+        p = qx.average_fidelity_to_depolarizing_constant(fidelity, unitary.dims[0])
+        return cls.from_depolarizing_constant(inst, p, custom_gates)
+
+    @classmethod
+    def from_pauli_fidelity(
+        cls: type[Channel],
+        inst: Gate,
+        pauli_fidelity: float,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        r"""Create a depolarizing noise channel from a process (Pauli) fidelity.
+
+        The process fidelity :math:`F_e` is related to the average gate fidelity by
+        :math:`F_{\\mathrm{avg}} = (d \\cdot F_e + 1) / (d + 1)`.
+
+        :param inst: The gate to which the channel applies.
+        :param pauli_fidelity: The process fidelity (entanglement fidelity), :math:`F_e \\in [0, 1]`.
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A Channel instance.
+        """
+        unitary = get_instruction_unitary(inst, custom_gates)
+        p = qx.process_fidelity_to_depolarizing_constant(pauli_fidelity, unitary.dims[0])
+        return cls.from_depolarizing_constant(inst, p, custom_gates)
+
+    @classmethod
+    def from_depolarizing_constant(
+        cls: type[Channel],
+        inst: Gate,
+        depolarizing_constant: float,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        r"""Create a depolarizing noise channel from a depolarization constant.
+
+        The depolarizing constant :math:`p` parameterizes the channel as
+        :math:`\\mathcal{D}_p(\\rho) = p \\, \\rho + (1-p) \\, I/d`.
+
+        :param inst: The gate to which the channel applies.
+        :param depolarizing_constant: The depolarization constant, e.g. 0.98 for 2% depolarization.
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A Channel instance.
+        """
+        unitary = get_instruction_unitary(inst, custom_gates)
+        depolarizing_superop = qx.depolarizing_channel_superoperator(1 - depolarizing_constant, unitary.dims[0])
+        combined_superop = depolarizing_superop @ unitary
+        return cls(inst=inst, process=qx.to_superop(combined_superop), target_unitary=unitary)
+
+    @classmethod
+    def from_pauli_noise(
+        cls: type[Channel],
+        inst: Gate,
+        pauli_noise: dict[str, float],
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        """Create a stochastic Pauli noise channel from Pauli error rates.
+
+        The noise is specified as a dictionary mapping Pauli strings to error probabilities,
+        e.g. ``{"XX": 0.03, "ZI": 0.001}``. The probabilities must sum to at most 1.0;
+        any remainder is assigned to the identity (no-error) term.
+
+        :param inst: The gate to which the channel applies.
+        :param pauli_noise: Pauli error rates, e.g. ``{"IX": 0.01, "ZZ": 0.02}``.
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A Channel instance.
+        """
+        unitary = get_instruction_unitary(inst, custom_gates)
+        num_qubits = len(unitary.dims[0])
+
+        total_error_rate = 0.0
+        for pauli, error_rate in pauli_noise.items():
+            if error_rate < 0.0:
+                raise ValueError(f"Pauli term '{pauli}' has negative error rate {error_rate}.")
+            total_error_rate += error_rate
+        if total_error_rate > 1.0:
+            raise ValueError(f"Pauli error rates must sum to at most 1.0, got {total_error_rate}.")
+
+        for pauli in pauli_noise:
+            if len(pauli) != num_qubits:
+                raise ValueError(f"Pauli term '{pauli}' has length {len(pauli)}, expected {num_qubits}.")
+
+        all_pauli_terms = tuple("".join(term) for term in product("IXYZ", repeat=num_qubits))
+
+        pauli_error_rates: list[float] = []
+        for term in reversed(all_pauli_terms):
+            if term in pauli_noise:
+                error_rate = pauli_noise[term]
+            elif all(p == "I" for p in term):
+                error_rate = 1 - sum(pauli_error_rates)
+            else:
+                error_rate = 0
+            pauli_error_rates.append(error_rate)
+        if not jnp.isclose(1.0, sum(pauli_error_rates)):
+            raise ValueError("Pauli error rates plus the implicit identity rate must sum to 1.0.")
+        pauli_error_rates = list(reversed(pauli_error_rates))
+
+        # Build the 4**num_qubits Pauli operators as tensor (Kronecker) products of the
+        # single-qubit Paulis, in lexicographic (I, X, Y, Z) order matching pauli_error_rates.
+        single_pauli_matrices = qx.ensembles.PAULIS.matrix  # (4, 2, 2): I, X, Y, Z
+        pauli_op_matrices = jnp.stack(
+            [reduce(jnp.kron, paulis) for paulis in product(single_pauli_matrices, repeat=num_qubits)]
+        )  # (4**num_qubits, 2**num_qubits, 2**num_qubits)
+
+        # Scale each Pauli by sqrt(probability) to form Kraus operators
+        coeffs = jnp.sqrt(jnp.array(pauli_error_rates, dtype=float))
+        kraus_matrices = coeffs[:, None, None] * pauli_op_matrices
+        kraus_map = qx.KrausMap.from_matrix(kraus_matrices, unitary.dims)
+
+        process_superop = qx.to_superop(kraus_map @ unitary)
+        return cls(inst=inst, process=process_superop, target_unitary=unitary)
+
+    @classmethod
+    def from_random_coherent_error(
+        cls: type[Channel],
+        inst: Gate,
+        process_fidelity: float,
+        rng: np.random.Generator | None = None,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        r"""Create a channel with a random coherent (unitary) error at the specified process fidelity.
+
+        A random unitary close to identity is generated with the given process fidelity,
+        then composed with the ideal gate.
+
+        :param inst: The gate to which the channel applies.
+        :param process_fidelity: The process fidelity of the coherent error, :math:`F_e \\in [0, 1]`.
+        :param rng: NumPy random number generator for reproducibility.
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A Channel instance.
+        """
+        if rng is None:
+            rng = np.random.default_rng()
+
+        ideal = get_instruction_unitary(inst, custom_gates)
+        num_qubits = len(ideal.dims[0])
+        d = 2**num_qubits
+
+        # Generate a random unitary error with the specified process fidelity
+        # using Pauli generator decomposition
+        angle = jnp.arccos(2 * process_fidelity - 1) / (2 * jnp.pi)
+        id_coeff = 1 - float(angle)
+        coeffs = rng.random(4**num_qubits - 1)
+        coeffs = (1 - id_coeff) / np.sqrt(np.sum(np.square(coeffs))) * coeffs
+
+        # Build Pauli generator sum using quax Pauli matrices
+        pauli_matrices = qx.ensembles.PAULIS.matrix  # shape (4, 2, 2)
+        pauli_sum = jnp.eye(d, dtype=complex) * id_coeff
+        pauli_products = list(itertools.product(pauli_matrices, repeat=num_qubits))[1:]
+        for paulis, coefficient in zip(pauli_products, coeffs, strict=False):
+            pauli_sum = pauli_sum + reduce(jnp.kron, paulis) * coefficient
+
+        from jax.scipy.linalg import expm as jax_expm
+
+        error_unitary = jax_expm(-1j * jnp.pi * pauli_sum)
+        # Fix global phase
+        phase = jnp.exp(-1j * jnp.angle(error_unitary[0, 0]))
+        error_unitary = error_unitary * phase
+
+        error_u = qx.Unitary.from_matrix(error_unitary, ideal.dims)
+        noisy_superop = qx.to_superop(error_u @ ideal)
+        return cls(inst=inst, process=noisy_superop, target_unitary=ideal)
+
+    @classmethod
+    def from_mixture(
+        cls: type[Channel],
+        inst: Gate,
+        constituents: list[qx.Unitary],
+        probabilities: list[float],
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        r"""Create a mixture channel from a set of unitary errors with given probabilities.
+
+        The channel is :math:`\\mathcal{E}(\\rho) = (1-\\sum p_i) U\\rho U^\\dagger + \\sum p_i V_i U \\rho U^\\dagger V_i^\\dagger`
+        where :math:`U` is the ideal gate and :math:`V_i` are the error unitaries.
+
+        :param inst: The gate to which the channel applies.
+        :param constituents: Unitary error operators to mix.
+        :param probabilities: Probability of each unitary error. Must sum to at most 1.0.
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :return: A Channel instance.
+        """
+        ideal = get_instruction_unitary(inst, custom_gates)
+
+        if len(constituents) != len(probabilities):
+            raise ValueError("The number of constituents and probabilities must match.")
+        error_prob = sum(probabilities)
+        if error_prob > 1.0:
+            raise ValueError(f"The sum of probabilities ({error_prob}) must be at most 1.0.")
+
+        # Build the mixture superop: (1-p_total) S(U) + sum p_i S(V_i @ U)
+        p0 = 1.0 - error_prob
+        noisy_superop_matrix = p0 * qx.to_superop(ideal).matrix
+        for p, v in zip(probabilities, constituents, strict=False):
+            composed = v @ ideal
+            noisy_superop_matrix = noisy_superop_matrix + p * qx.to_superop(composed).matrix
+        noisy_superop = qx.SuperOp.from_matrix(noisy_superop_matrix, ideal.dims)
+        return cls(inst=inst, process=noisy_superop, target_unitary=ideal)
+
+    @classmethod
+    def from_coherence_times(
+        cls: type[Channel],
+        inst: Gate,
+        gate_duration: float,
+        t1s: list[float],
+        t2s: list[float] | None = None,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        """Create a decoherence Channel based on the coherence times.
+
+        In this construction, decoherence is applied _after_ the ideal gate unitary.
+
+        :param inst: The target instruction.
+        :param gate_duration: The duration of the gate.
+        :param t1s: The t1 time(s) of the qubits
+        :param t2s: The t2 time(s) of the qubits. Default to 2*t1.
+        """
+        unitary = get_instruction_unitary(inst, custom_gates)
+        qubits = inst.get_qubit_indices()
+        num_sys = len(qubits)
+        if num_sys != len(t1s):
+            raise ValueError(f"Expected {num_sys} T1 values for {inst.out()}, got {len(t1s)}.")
+        if t2s is None:
+            t2s = [2 * t1 for t1 in t1s]
+        else:
+            if num_sys != len(t2s):
+                raise ValueError(f"Expected {num_sys} T2 values for {inst.out()}, got {len(t2s)}.")
+
+        t1_array = jnp.asarray(t1s)
+        tphi_array = 1 / (1 / jnp.asarray(t2s) - 1 / t1_array)
+
+        choi = qx.thermal_relaxation_choi(t1s=t1_array, tphis=tphi_array, duration=gate_duration)
+        process = qx.to_superop(choi @ unitary)
+        return cls(
+            inst=inst,
+            process=process,
+            target_unitary=unitary,
+        )
+
+    @classmethod
+    def from_superoperator(
+        cls: type[Channel],
+        inst: Gate,
+        process: qx.SuperOp,
+        target_unitary: qx.Unitary | None = None,
+        custom_gates: CustomGateMap | None = None,
+    ) -> Channel:
+        """Create a Channel from a pre-built superoperator.
+
+        If ``target_unitary`` is not provided it is inferred from the gate
+        instruction using the standard gate set (and ``custom_gates`` if given).
+
+        :param inst: The gate to which the channel applies.
+        :param process: The noisy process superoperator (includes the gate unitary).
+        :param target_unitary: The ideal gate unitary.  Resolved automatically
+            when omitted.
+        :param custom_gates: Optional dictionary of custom gate definitions,
+            used only when ``target_unitary`` is ``None``.
+        :return: A Channel instance.
+        """
+        if target_unitary is None:
+            target_unitary = get_instruction_unitary(inst, custom_gates)
+        return cls(inst=inst, process=process, target_unitary=target_unitary)
+
+    # ──────────────────────────────────────────────
+    # Cached representation conversions
+    # ──────────────────────────────────────────────
+
+    @cached_property
+    def noise_process(self) -> qx.SuperOp:
+        r"""The noise-only channel with the ideal gate unitary factored out.
+
+        If the full channel is :math:`\\mathcal{E} = \\Lambda \\circ \\mathcal{U}`, this
+        returns :math:`\\Lambda`.
+        """
+        return qx.to_superop(self.process @ self.unitary.h)
+
+    # ──────────────────────────────────────────────
+    # Fidelity properties
+    # ──────────────────────────────────────────────
+
+    @cached_property
+    def fidelity(self) -> float:
+        r"""Average gate fidelity :math:`F_{\\mathrm{avg}}` of the channel relative to the ideal gate."""
+        return float(qx.process_fidelity_to_average_fidelity(self.pauli_fidelity, dims=self.unitary.dims[0]))
+
+    @cached_property
+    def infidelity(self) -> float:
+        r"""Average gate infidelity :math:`1 - F_{\\mathrm{avg}}`."""
+        return 1.0 - self.fidelity
+
+    @cached_property
+    def pauli_fidelity(self) -> float:
+        """Process fidelity (entanglement fidelity) :math:`F_e` relative to the ideal gate."""
+        process, unitary = qx.promote_hilbert_space(self.process, qx.to_superop(self.unitary))
+        return float(qx.process_fidelity(process, unitary))
+
+    @cached_property
+    def pauli_infidelity(self) -> float:
+        """Process infidelity :math:`1 - F_e`."""
+        return 1.0 - self.pauli_fidelity
+
+    @cached_property
+    def stochastic_infidelity(self) -> float:
+        """Stochastic (incoherent) component of the process infidelity."""
+        return float(qx.stochastic_infidelity(self.noise_process))
+
+    @cached_property
+    def stochastic_fidelity(self) -> float:
+        """Stochastic fidelity :math:`1 - e_S`."""
+        return 1.0 - self.stochastic_infidelity
+
+    @cached_property
+    def coherent_infidelity(self) -> float:
+        """Coherent component of the process infidelity: :math:`e_C = e - e_S`."""
+        return self.pauli_infidelity - self.stochastic_infidelity
+
+    @cached_property
+    def coherent_fidelity(self) -> float:
+        """Coherent fidelity :math:`1 - e_C`."""
+        return 1.0 - self.coherent_infidelity
+
+    @cached_property
+    def unitarity(self) -> float:
+        """Unitarity of the channel."""
+        return float(qx.unitarity(self.noise_process))
+
+    # ──────────────────────────────────────────────
+    # Channel analysis methods
+    # ──────────────────────────────────────────────
+
+    def pauli_twirl(self) -> Channel:
+        """Return a Pauli-twirled version of this channel.
+
+        Pauli twirling projects the channel onto the Pauli diagonal, eliminating
+        off-diagonal coherences in the Pauli-Liouville representation. The
+        resulting channel is a stochastic Pauli channel with the same diagonal
+        error rates.
+        """
+        ptm = qx.to_pauli_liouville(self.process)
+        # Keep only the diagonal of the PTM
+        twirled_ptm_matrix = jnp.diag(jnp.diag(ptm.matrix))
+        twirled_superop = qx.to_superop(qx.PauliLiouville.from_matrix(twirled_ptm_matrix, self.process.dims))
+        return replace(self, process=twirled_superop)
+
+    @cached_property
+    def _unitary_error_component(self) -> Array:
+        """Extract the dominant unitary from the noise-only channel.
+
+        Uses eigendecomposition + SVD polar decomposition to find the closest
+        unitary to the noise channel.
+        """
+        choi_matrix = qx.to_choi(self.noise_process).matrix
+        d = 2**self.num_qubits
+
+        # Dominant eigenvector of the Choi matrix
+        eigenvalues, eigenvectors = jnp.linalg.eigh(choi_matrix)
+        dominant_eigenvector = eigenvectors[:, jnp.argmax(jnp.abs(eigenvalues))]
+
+        # SVD polar decomposition to extract the closest unitary
+        u, _, vh = jnp.linalg.svd(dominant_eigenvector.reshape(d, d).T)
+        return u @ vh
+
+    def to_coherent_channel(self) -> Channel:
+        """Isolate the coherent (unitary) component of the noise.
+
+        Extracts the dominant unitary from the noise Choi matrix via polar
+        decomposition and returns a channel consisting of that unitary error
+        composed with the ideal gate.
+        """
+        u_error = self._unitary_error_component
+        u_error_qx = qx.Unitary.from_matrix(u_error, self.process.dims)
+        coherent_superop = qx.to_superop(u_error_qx @ self.unitary)
+        return replace(self, process=coherent_superop)
+
+    def to_stochastic_channel(self) -> Channel:
+        r"""Isolate the stochastic (incoherent) component of the noise.
+
+        The full channel decomposes as
+        :math:`\\mathcal{E} = \\mathcal{S} \\circ \\mathcal{U}_{\\mathrm{err}} \\circ \\mathcal{U}_{\\mathrm{gate}}`.
+        This method factors out the coherent unitary error and returns
+        :math:`\\mathcal{S} \\circ \\mathcal{U}_{\\mathrm{gate}}`.
+        """
+        u_error = self._unitary_error_component
+        # Get the noise-only superoperator and compose with U_err†
+        noise_superop = self.noise_process.matrix
+        u_err_inv_superop = jnp.kron(u_error.conj(), u_error.conj().T)
+        stochastic_noise_superop = noise_superop @ u_err_inv_superop
+        # Recompose with the ideal gate
+        ideal_superop = jnp.kron(self.unitary.matrix, self.unitary.matrix.conj())
+        stochastic_superop = stochastic_noise_superop @ ideal_superop
+        return replace(self, process=qx.SuperOp.from_matrix(stochastic_superop, self.process.dims))
+
+    def is_pauli(self) -> bool:
+        """Check if the noise channel is a Pauli (stochastic Pauli) channel.
+
+        A Pauli channel has a diagonal Pauli transfer matrix (noise-only part).
+        """
+        ptm = qx.to_pauli_liouville(self.noise_process).matrix
+        mask = ~jnp.eye(ptm.shape[0], dtype=bool)
+        return bool(jnp.allclose(ptm[mask], 0))
+
+    def to_pauli_vector(self) -> Array:
+        """Convert the noise channel to a Pauli error probability vector.
+
+        Returns the vector of probabilities for each Pauli error in lexicographic
+        order (II, IX, IY, IZ, XI, XX, ...). The vector sums to 1.0.
+        """
+        noise_superop = self.noise_process.matrix
+        num_qubits = self.num_qubits
+        dim = noise_superop.shape[0]
+
+        # Build all Pauli operators and their superoperators
+        pauli_matrices = qx.ensembles.PAULIS.matrix  # (4, 2, 2): I, X, Y, Z
+        all_pauli_products = list(product(pauli_matrices, repeat=num_qubits))
+        pauli_error_rates = []
+        for pauli_tuple in all_pauli_products:
+            pauli_op = reduce(jnp.kron, pauli_tuple)
+            pauli_superop = jnp.kron(pauli_op, pauli_op.conj())
+            rate = float(jnp.abs(jnp.trace(noise_superop @ pauli_superop) / dim))
+            pauli_error_rates.append(rate)
+
+        return jnp.array(pauli_error_rates, dtype=float)
+
+    @cached_property
+    def pauli_vector(self) -> Array:
+        """The Pauli error probability vector of the noise channel."""
+        return self.to_pauli_vector()
+
+    # ──────────────────────────────────────────────
+    # Visualization
+    # ──────────────────────────────────────────────
+
+    def plot(self, only_noise: bool = True, show_identity: bool = False) -> Figure:
+        """Plot the Pauli transfer matrix of the channel.
+
+        :param only_noise: If True, plot the noise-only channel (gate unitary factored out).
+            If False, plot the full channel including the gate unitary.
+        :param show_identity: If True, include the identity component in the noise-only plot.
+            If False (default), visualize the generator of the noise channel via the matrix
+            logarithm of the PTM.  For near-identity noise this approximates PTM - I, but
+            correctly captures the Lie-algebraic structure of the channel.
+            Only applies when ``only_noise=True``.
+        :return: A Plotly Figure.
+        """
+        if only_noise:
+            channel = self.noise_process
+            if not show_identity:
+                ptm = qx.to_pauli_liouville(channel)
+                log_ptm = scipy_logm(np.asarray(ptm.matrix))
+                channel = qx.PauliLiouville.from_matrix(jnp.array(log_ptm), channel.dims)
+            title_prefix = "Noise Channel"
+        else:
+            channel = self.process
+            title_prefix = "Full Channel"
+
+        fig = qx.plot(channel)
+        fig.update_layout(
+            title=(
+                f"{title_prefix} for {self.inst.out()}<br>"
+                f"𝜀={self.pauli_infidelity * 100:.2f}%, "
+                f"𝜀<sub>u</sub>={self.coherent_infidelity * 100:.2f}%, "
+                f"𝜀<sub>s</sub>={self.stochastic_infidelity * 100:.2f}%"
+            )
+        )
+        return fig
+
+    # ──────────────────────────────────────────────
+    # Serialization
+    # ──────────────────────────────────────────────
+
+    def to_json(self) -> str:
+        """Serialize Channel to a JSON string.
+
+        :return: JSON string representation.
+        """
+        data = {
+            "schema_version": 1,
+            "inst": self.inst.out(),
+            "superop": _pack_operator(self.process),
+        }
+        data["target_unitary"] = _pack_operator(self.target_unitary)
+
+        return json.dumps(data)
+
+    @classmethod
+    def from_json(cls: type[Channel], json_str: str) -> Channel:
+        """Deserialize a Channel from a JSON string.
+
+        :param json_str: JSON string as produced by :meth:`to_json`.
+        :return: Channel instance.
+        """
+        data = json.loads(json_str)
+        inst = _parse_quil_instruction(data["inst"])
+        if not isinstance(inst, Gate):
+            raise TypeError(f"Channel JSON must contain a gate instruction, got {type(inst).__name__}.")
+
+        superop_data = data["superop"]
+        shape = tuple(superop_data["shape"])
+        superop_array = _unpack_complex_array(superop_data)
+        dims = _unpack_operator_dims(superop_data, shape, superoperator=True)
+        superop = qx.SuperOp.from_matrix(superop_array, dims)
+
+        if "target_unitary" in data:
+            u_data = data["target_unitary"]
+            u_shape = tuple(u_data["shape"])
+            u_array = _unpack_complex_array(u_data)
+            u_dims = _unpack_operator_dims(u_data, u_shape, superoperator=False)
+            target_unitary = qx.Unitary.from_matrix(u_array, u_dims)
+        else:
+            target_unitary = get_instruction_unitary(inst)
+
+        return cls(inst=inst, process=superop, target_unitary=target_unitary)
+
+    # ──────────────────────────────────────────────
+    # Dunder methods
+    # ──────────────────────────────────────────────
+
+    def __str__(self) -> str:
+        """Return a simplified string representation showing the gate and process fidelity."""
+        return f"<{self.inst.out()} ~ ({100 * self.pauli_fidelity:.2f}%)>"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality by instruction and exact process and ideal-gate matrices.
+
+        Equality is exact (no fidelity tolerance): two channels are equal only if they
+        share the same instruction and bit-for-bit identical process and target-unitary
+        matrices. Making tolerance decisions on the user's behalf is deliberately avoided.
+        """
+        if not isinstance(other, Channel):
+            return False
+        if self.inst != other.inst:
+            return False
+        return bool(
+            jnp.array_equal(self.process.matrix, other.process.matrix)
+            and jnp.array_equal(self.target_unitary.matrix, other.target_unitary.matrix)
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __matmul__(self, other: Channel) -> Channel:
+        r"""Compose two channels: ``channel_B @ channel_A``.
+
+        Both channels share the same gate instruction. The composition factors
+        out one copy of the gate unitary so the result represents the sequential
+        application of the two noisy processes:
+
+        :math:`\\mathcal{E}_B \\circ \\mathcal{U}^\\dagger \\circ \\mathcal{E}_A`
+
+        This is the natural composition: if ``channel_A`` already includes the
+        gate, applying ``channel_B`` after it should not double-count the gate.
+        """
+        if not isinstance(other, Channel):
+            return NotImplemented
+        if self.inst != other.inst:
+            raise ValueError(f"Cannot compose channels for different gates: {self.inst.out()} vs {other.inst.out()}")
+        # E_B @ U† @ E_A  (factor out one gate unitary between the two channels)
+        u_dag_superop = qx.to_superop(self.unitary.h)
+        composed_superop = qx.to_superop(self.process @ u_dag_superop @ other.process)
+        return replace(self, process=composed_superop)
+
+    def __pow__(self, power: float) -> Channel:
+        r"""Raise the channel's noise to a fractional ``power``, preserving the gate.
+
+        With the channel written :math:`\\mathcal{E} = \\Lambda \\circ \\mathcal{U}`, this returns
+        :math:`\\Lambda^{power} \\circ \\mathcal{U}`: only the noise :math:`\\Lambda` is raised to the
+        fractional matrix power, while the ideal gate is kept. So ``power = 0`` yields the noiseless
+        gate, ``1`` leaves the channel unchanged, and ``> 1`` strengthens the noise. This is the knob
+        used to sweep noise strength.
+        """
+        if not isinstance(power, (int, float)):
+            return NotImplemented
+        powered_noise_matrix = fractional_matrix_power(np.asarray(self.noise_process.matrix), power)
+        powered_noise = qx.SuperOp.from_matrix(jnp.asarray(powered_noise_matrix), self.noise_process.dims)
+        process = qx.to_superop(powered_noise @ qx.to_superop(self.unitary))
+        return replace(self, process=process)
+
+    def __or__(self, other: Channel | MeasurementChannel) -> CycleChannel:
+        """Tensor product of two channels on disjoint qubits, producing a CycleChannel.
+
+        The result represents a cycle containing both operations acting in parallel
+        on disjoint qubits. The DefCircuit encodes the parallel operations as
+        formal instructions.
+
+        :param other: Another Channel or MeasurementChannel on disjoint qubits.
+        :return: A CycleChannel representing the tensor product.
+        """
+        if not isinstance(other, (Channel, MeasurementChannel)):
+            return NotImplemented
+
+        # Validate disjoint qubits
+        self_qubits = set(self.qubits)
+        other_qubits = set(other.qubits)
+        if self_qubits & other_qubits:
+            raise ValueError(f"Cannot tensor channels with overlapping qubits: {self_qubits & other_qubits}")
+
+        return _build_cycle_channel([self, other])
+
+
+@dataclass(frozen=True)
+class MeasurementChannel:
+    """A measurement noise channel attaches a quantum instrument to a specific measurement operation.
+
+    The ``process`` field is a ``qx.QuantumInstrument`` which models both classification
+    errors and post-measurement back-action.
+    """
+
+    inst: Measurement
+    """The measurement operation to which the channel applies."""
+
+    process: qx.QuantumInstrument
+    """A quantum instrument representation of the noisy measurement."""
+
+    @cached_property
+    def qubits(self) -> list[int]:
+        """The qubits which the measurement applies to."""
+        qubit = self.inst.qubit
+        return [qubit.index if hasattr(qubit, "index") else int(qubit)]
+
+    # ──────────────────────────────────────────────
+    # Constructors
+    # ──────────────────────────────────────────────
+
+    @classmethod
+    def from_readout_fidelity(
+        cls: type[MeasurementChannel],
+        inst: Measurement,
+        fidelity: float,
+        asymmetry: float = 0.0,
+        dim: int = 2,
+    ) -> MeasurementChannel:
+        """Create a readout quantum instrument with optional asymmetry.
+
+        Produces a perfectly QND measurement with the given classification fidelity.
+        Error is distributed only between adjacent levels: P(j+1|j) and P(j|j+1).
+        Non-adjacent confusion is zero.
+
+        :param inst: The measurement instruction.
+        :param fidelity: The average readout fidelity.
+        :param asymmetry: Value between -1 and +1. Zero is symmetric.
+            Positive biases toward upward confusion P(j+1|j), negative toward downward P(j|j+1).
+        :param dim: The dimension of the measured system (2 for qubits, 3 for qutrits, etc.).
+        :return: A MeasurementChannel instance.
+        """
+        # Compute per-pair error factor so that the average diagonal equals fidelity.
+        # Each adjacent pair (j, j+1) contributes error_factor*(1+a) + error_factor*(1-a)
+        # = 2*error_factor to total off-diagonal sum. With (dim-1) pairs, the average
+        # column error is 2*(dim-1)*error_factor/dim, which we set equal to (1-fidelity).
+        error_factor = dim * (1 - fidelity) / (2 * (dim - 1))
+
+        confusion = jnp.zeros((dim, dim))
+        for j in range(dim - 1):
+            confusion = confusion.at[j + 1, j].set(error_factor * (1 + asymmetry))
+            confusion = confusion.at[j, j + 1].set(error_factor * (1 - asymmetry))
+        # Set diagonal so each column sums to 1
+        col_sums = confusion.sum(axis=0)
+        confusion = confusion + jnp.diag(1 - col_sums)
+
+        transition = jnp.eye(dim)
+        instrument = qx.instrument_from_confusion_and_transition(
+            confusion_matrix=confusion,
+            transition_matrix=transition,
+            dims=(dim,),
+            measured_qudits=(0,),
+        )
+        return cls(inst=inst, process=instrument)
+
+    @classmethod
+    def from_confusion_and_transition(
+        cls: type[MeasurementChannel],
+        inst: Measurement,
+        confusion_matrix: Array,
+        transition_matrix: Array,
+    ) -> MeasurementChannel:
+        """Create a MeasurementChannel from a confusion matrix and a transition matrix.
+
+        Provides independent control over measurement classification accuracy
+        and post-measurement quantum state evolution.
+
+        **Matrix Conventions (column-stochastic):**
+
+        - ``confusion_matrix[i, j]``: P(outcome i | prepared j)
+        - ``transition_matrix[k, j]``: P(ending in k | input j)
+        - Columns sum to 1.0
+
+        :param inst: The measurement instruction.
+        :param confusion_matrix: A (d, d) classification matrix.
+        :param transition_matrix: A (d, d) post-measurement transition matrix.
+        :return: A MeasurementChannel instance.
+        """
+        confusion = jnp.asarray(confusion_matrix)
+        dim = confusion.shape[0]
+        instrument = qx.instrument_from_confusion_and_transition(
+            confusion_matrix=confusion,
+            transition_matrix=jnp.asarray(transition_matrix),
+            dims=(dim,),
+            measured_qudits=(0,),
+        )
+        return cls(inst=inst, process=instrument)
+
+    @classmethod
+    def from_axis(
+        cls: type[MeasurementChannel],
+        inst: Measurement,
+        theta: float = 0.0,
+        phi: float = 0.0,
+        sharpness: float = 1.0,
+    ) -> MeasurementChannel:
+        """Create a MeasurementChannel from a Bloch sphere measurement axis.
+
+        The angles refer to the standard Bloch sphere notation.
+        Theta=0, phi=0 is the Z axis (computational basis measurement).
+
+        :param inst: The measurement instruction.
+        :param theta: The colatitude with respect to the z-axis.
+        :param phi: The longitude with respect to the x-axis.
+        :param sharpness: The sharpness of the measurement. 1.0 is projective,
+            0.0 is no measurement. 0 < s < 1 is a weak measurement.
+        :return: A MeasurementChannel instance.
+        """
+        instrument = qx.instrument_from_axis(
+            theta=theta,
+            phi=phi,
+            sharpness=sharpness,
+        )
+        return cls(inst=inst, process=instrument)
+
+    @classmethod
+    def from_binary_discriminator(
+        cls: type[MeasurementChannel],
+        inst: Measurement,
+        dim: int,
+        threshold: int,
+        fidelity: float = 1.0,
+    ) -> MeasurementChannel:
+        """Create a MeasurementChannel for a binary discriminator.
+
+        Models a measurement that reports a single classical *bit* for a
+        ``dim``-level system by thresholding: levels ``[0, threshold)`` yield
+        outcome ``0`` and levels ``[threshold, dim)`` yield outcome ``1``.  The
+        resulting instrument therefore always has exactly two outcomes, so leaked
+        levels are lumped in with whichever side of the threshold they fall on
+        (the usual case being a "dark" ground state vs. everything "bright").
+
+        For example, ``threshold=1, dim=2`` is an ordinary qubit readout
+        (``{0}`` -> 0, ``{1}`` -> 1); ``threshold=1, dim=3`` discriminates
+        ``{0}`` vs ``{1, 2}`` (ground vs. excited-or-leaked); ``threshold=2,
+        dim=3`` discriminates ``{0, 1}`` vs ``{2}`` (i.e. flags leakage only).
+
+        An optional ``fidelity`` parameter degrades the ideal discriminator with
+        uniform classification noise.
+
+        :param inst: The measurement instruction.
+        :param dim: The dimension of the measured system.
+        :param threshold: The split point: levels below it report 0, levels at or
+            above it report 1.  Must satisfy ``1 <= threshold < dim``.
+        :param fidelity: Additional classification fidelity applied on top of the
+            discrimination (1.0 = perfect discriminator).
+        :return: A MeasurementChannel instance.
+        """
+        if not (1 <= threshold < dim):
+            raise ValueError(f"threshold must satisfy 1 <= threshold < dim, got threshold={threshold}, dim={dim}")
+
+        # Ideal two-outcome confusion matrix of shape (num_outcomes=2, dim):
+        # column j (prepared level j) puts all its weight on outcome 0 if
+        # j < threshold, else on outcome 1.  Two rows so the instrument has
+        # exactly two outcomes (never a phantom, zero-probability outcome).
+        confusion = jnp.zeros((2, dim))
+        for j in range(dim):
+            confusion = confusion.at[int(j >= threshold), j].set(1.0)
+
+        # Optionally degrade with uniform noise across the two outcomes.
+        if fidelity < 1.0:
+            confusion = fidelity * confusion + (1 - fidelity) * jnp.ones((2, dim)) / 2
+
+        transition = jnp.eye(dim)
+        instrument = qx.instrument_from_confusion_and_transition(
+            confusion_matrix=confusion,
+            transition_matrix=transition,
+            dims=(dim,),
+            measured_qudits=(0,),
+        )
+        return cls(inst=inst, process=instrument)
+
+    # ──────────────────────────────────────────────
+    # Properties
+    # ──────────────────────────────────────────────
+
+    @cached_property
+    def confusion_matrix(self) -> Array:
+        """The confusion matrix of the measurement.
+
+        Shape ``(num_outcomes, d_measured)``.
+        Entry ``[i, j]`` is P(outcome i | prepared j).
+        """
+        return self.process.confusion_matrix  # type: ignore[no-any-return]
+
+    @cached_property
+    def transition_matrix(self) -> Array:
+        """The post-measurement transition matrix.
+
+        Shape ``(d, d)``. Entry ``[k, j]`` is P(ending in k | input j),
+        marginalized over all measurement outcomes.
+        """
+        return self.process.transition_matrix  # type: ignore[no-any-return]
+
+    @cached_property
+    def non_demolition_fidelity(self) -> float:
+        """Quantum non-demolition (QND) fidelity.
+
+        Measures how well the measurement preserves computational basis states,
+        averaged over outcomes and input states.
+        """
+        return float(qx.non_demolition_fidelity(self.process))
+
+    @cached_property
+    def instrument_fidelity(self) -> float:
+        """Overall instrument fidelity w.r.t. ideal QND measurement.
+
+        Accounts for both classification errors and post-measurement state disturbance.
+        """
+        return float(qx.instrument_fidelity(self.process))
+
+    @cached_property
+    def classification_fidelity(self) -> float:
+        """Classification fidelity: average probability of correctly identifying the measurement outcome."""
+        return float(qx.classification_fidelity(self.process))
+
+    # ──────────────────────────────────────────────
+    # Visualization
+    # ──────────────────────────────────────────────
+
+    def plot(self) -> Figure:
+        """Plot the quantum instrument using the quax visualization.
+
+        Shows per-outcome superoperator matrices and the total CPTP channel.
+
+        :return: A Plotly Figure.
+        """
+        fig = qx.plot(self.process)
+        fig.update_layout(
+            title=(
+                f"Quantum Instrument MEASURE {self.qubits[0]}<br>"
+                f"<sub>Cls: {100 * self.classification_fidelity:.2f}%, "
+                f"QND: {100 * self.non_demolition_fidelity:.2f}%, "
+                f"Instrument: {100 * self.instrument_fidelity:.2f}%</sub>"
+            )
+        )
+        return fig
+
+    # ──────────────────────────────────────────────
+    # Serialization
+    # ──────────────────────────────────────────────
+
+    def to_json(self) -> str:
+        """Serialize MeasurementChannel to a JSON string.
+
+        :return: JSON string representation.
+        """
+        # Store per-outcome superoperator matrices.
+        instrument_data = []
+        for i in range(self.process.num_outcomes):
+            superop_i, _ = self.process.outcome_superop(i)
+            instrument_data.append(_pack_operator(superop_i))
+
+        data = {
+            "schema_version": 1,
+            "inst": self.inst.out(),
+            "instruments": instrument_data,
+            "measured_qudits": list(self.process.measured_qudits),
+        }
+        return json.dumps(data)
+
+    @classmethod
+    def from_json(cls: type[MeasurementChannel], json_str: str) -> MeasurementChannel:
+        """Deserialize a MeasurementChannel from a JSON string.
+
+        :param json_str: JSON string as produced by :meth:`to_json`.
+        :return: MeasurementChannel instance.
+        """
+        data = json.loads(json_str)
+        inst = _parse_quil_instruction(data["inst"])
+        if not isinstance(inst, Measurement):
+            raise TypeError(
+                f"MeasurementChannel JSON must contain a measurement instruction, got {type(inst).__name__}."
+            )
+        measured_qudits = tuple(data["measured_qudits"])
+
+        superop_matrices = []
+        instrument_dims = None
+        for inst_data in data["instruments"]:
+            shape = tuple(inst_data["shape"])
+            arr = _unpack_complex_array(inst_data)
+            op_dims = _unpack_operator_dims(inst_data, shape, superoperator=True)
+            if instrument_dims is None:
+                instrument_dims = op_dims
+            elif instrument_dims != op_dims:
+                raise ValueError("All serialized measurement outcomes must have the same dims.")
+            superop_matrices.append(arr)
+
+        if instrument_dims is None:
+            raise ValueError("MeasurementChannel JSON must contain at least one outcome superoperator.")
+
+        instrument = qx.QuantumInstrument.from_matrix(jnp.stack(superop_matrices), instrument_dims, measured_qudits)
+        return cls(inst=inst, process=instrument)
+
+    # ──────────────────────────────────────────────
+    # Dunder methods
+    # ──────────────────────────────────────────────
+
+    def __str__(self) -> str:
+        """Return a simplified string representation."""
+        return f"<MEASURE({self.classification_fidelity:.2f}) {self.qubits[0]} ~ QND({100 * self.non_demolition_fidelity:.2f}%)>"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality by instruction and exact instrument matrix (no tolerance)."""
+        if not isinstance(other, MeasurementChannel):
+            return False
+        if self.inst != other.inst:
+            return False
+        return bool(jnp.array_equal(self.process.matrix, other.process.matrix))
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __matmul__(self, other: MeasurementChannel) -> MeasurementChannel:
+        """Compose two measurement channels on the same qubit.
+
+        Models sequential application: ``channel_B @ channel_A`` means
+        apply ``channel_A`` first, then ``channel_B``.
+        """
+        if not isinstance(other, MeasurementChannel):
+            return NotImplemented
+        if self.inst != other.inst:
+            raise ValueError(
+                f"Cannot compose measurement channels for different qubits: {self.inst.out()} vs {other.inst.out()}"
+            )
+        composed = self.process @ other.process
+        return replace(self, process=composed)
+
+    def __pow__(self, power: float) -> MeasurementChannel:
+        r"""Raise the measurement's classification noise to a fractional ``power``.
+
+        The confusion and transition matrices are column-stochastic, so a fractional power is
+        only well-defined through their *generator*: with :math:`M = e^{G}` (where :math:`G` has
+        zero column sums), the principled power is :math:`M^{p} = e^{p G}`, which is again
+        column-stochastic.  This avoids the non-physical (e.g. negative) entries that a naive
+        ``fractional_matrix_power`` of a stochastic matrix can produce.
+
+        So ``power = 0`` is an ideal (noiseless) measurement, ``1`` leaves it unchanged, and
+        ``> 1`` degrades it.  Mirrors :meth:`Channel.__pow__` for sweeping readout-noise strength.
+
+        :raises ValueError: If the matrix is not embeddable (no real generator) so that the
+            powered matrix is not a valid stochastic matrix.
+        """
+        if not isinstance(power, (int, float)):
+            return NotImplemented
+
+        def _powered_stochastic(matrix: Array) -> Array:
+            m = np.asarray(matrix, dtype=complex)
+            # Generator G = log(M); M**power = exp(power * G). Zero column sums of G are
+            # preserved under scaling, so exp(power * G) stays column-stochastic.
+            powered = scipy_expm(power * scipy_logm(m))
+            if np.max(np.abs(powered.imag)) > 1e-9:
+                raise ValueError(
+                    f"MeasurementChannel ** {power} has no real generator; the matrix is not "
+                    "embeddable, so the powered measurement is not a valid stochastic matrix."
+                )
+            powered = powered.real
+            if np.any(powered < -1e-9) or not np.allclose(powered.sum(axis=0), 1.0, atol=1e-6):
+                raise ValueError(
+                    f"MeasurementChannel ** {power} is not a valid (non-negative, column-stochastic) "
+                    "matrix; the underlying confusion/transition matrix is not embeddable for this power."
+                )
+            # Clip away sub-tolerance numerical negatives validated above.
+            return jnp.asarray(np.clip(powered, 0.0, None))
+
+        confusion = _powered_stochastic(self.confusion_matrix)
+        transition = _powered_stochastic(self.transition_matrix)
+        return MeasurementChannel.from_confusion_and_transition(self.inst, confusion, transition)
+
+    def __or__(self, other: Channel | MeasurementChannel) -> CycleChannel:
+        """Tensor product of two channels on disjoint qubits, producing a CycleChannel.
+
+        :param other: Another Channel or MeasurementChannel on disjoint qubits.
+        :return: A CycleChannel representing the tensor product.
+        """
+        if not isinstance(other, (Channel, MeasurementChannel)):
+            return NotImplemented
+
+        self_qubits = set(self.qubits)
+        other_qubits = set(other.qubits)
+        if self_qubits & other_qubits:
+            raise ValueError(f"Cannot tensor channels with overlapping qubits: {self_qubits & other_qubits}")
+
+        return _build_cycle_channel([self, other])
+
+
+@dataclass(frozen=True)
+class ResetChannel:
+    """A reset noise channel attaches a superoperator to a specific reset operation.
+
+    The ``process`` field is a ``qx.SuperOp`` which *includes* the ideal reset, so the channel
+    replaces the reset instruction rather than being applied after it.
+    """
+
+    inst: ResetQubit
+    """The reset operation to which the channel applies."""
+
+    process: qx.SuperOp
+    """A superoperator representation of the noisy reset (including ideal reset)."""
+
+    def __post_init__(self) -> None:
+        """Validate that ResetChannel is attached to a targeted reset."""
+        if not isinstance(self.inst, ResetQubit):
+            raise TypeError("ResetChannel only supports targeted ResetQubit instructions.")
+
+    # ──────────────────────────────────────────────
+    # Constructors
+    # ──────────────────────────────────────────────
+
+    @classmethod
+    def from_reset_fidelity(
+        cls: type[ResetChannel],
+        inst: ResetQubit,
+        fidelity: float,
+        dim: int = 2,
+    ) -> ResetChannel:
+        r"""Create a ResetChannel with depolarizing noise scaled to the given process fidelity.
+
+        The ideal reset channel maps every state to :math:`|0\\rangle\\langle 0|`.  Noise is
+        modelled as a depolarising channel applied after the ideal reset.
+
+        :param inst: The reset instruction.
+        :param fidelity: Process fidelity of the reset channel, :math:`F \\in [0, 1]`.
+            1.0 yields an ideal reset; values below 1 introduce depolarising noise.
+        :param dim: Hilbert-space dimension (2 for qubits).
+        :return: A ResetChannel instance.
+        """
+        if not isinstance(inst, ResetQubit):
+            raise TypeError("ResetChannel only supports targeted ResetQubit instructions.")
+
+        ideal_superop = qx.gates.RESET(dim=dim)
+        p = 1.0 - fidelity
+        d2 = dim * dim
+        # Depolarising channel in superop form: (1-p)*S_ideal + p*(I/d) for all inputs
+        # The completely depolarising superop maps everything to I/d:
+        # its rows are all zero except the diagonal entries corresponding to
+        # the trace extraction (maps vec(ρ) → vec(I/d) = vec(I)/d).
+        depol_superop_matrix = jnp.zeros((d2, d2), dtype=complex)
+        # vec(I/d) has value 1/d at positions 0, d+1, 2(d+1), ... i.e. diagonal entries
+        vec_identity_over_d = jnp.zeros(d2, dtype=complex)
+        for i in range(dim):
+            vec_identity_over_d = vec_identity_over_d.at[i * dim + i].set(1.0 / dim)
+        # The trace functional extracts sum of diagonal: positions 0, d+1, ...
+        trace_row = jnp.zeros(d2, dtype=complex)
+        for i in range(dim):
+            trace_row = trace_row.at[i * dim + i].set(1.0)
+        # Depolarising superop: each row of output is vec(I/d) * Tr(ρ)
+        depol_superop_matrix = jnp.outer(vec_identity_over_d, trace_row)
+        noisy_superop_matrix = (1.0 - p) * ideal_superop.matrix + p * depol_superop_matrix
+        noisy_superop = qx.SuperOp.from_matrix(noisy_superop_matrix, ideal_superop.dims)
+        return cls(inst=inst, process=noisy_superop)
+
+    # ──────────────────────────────────────────────
+    # Properties
+    # ──────────────────────────────────────────────
+
+    @cached_property
+    def qubits(self) -> list[int]:
+        """The qubit(s) that the reset applies to."""
+        qubit = self.inst.qubit
+        if qubit is None:
+            return []
+        return [qubit.index if hasattr(qubit, "index") else int(qubit)]
+
+    @cached_property
+    def fidelity(self) -> float:
+        r"""Process fidelity of the reset channel relative to the ideal reset.
+
+        Defined as :math:`F = \\mathrm{Tr}[\\Lambda_{\\mathrm{ideal}}^\\dagger \\Lambda] / d^2`
+        where :math:`\\Lambda` is the Choi matrix of the noisy channel and
+        :math:`\\Lambda_{\\mathrm{ideal}}` is the ideal-reset Choi.
+        """
+        dim = self.process.dims[0][0]
+        ideal_choi = qx.to_choi(qx.gates.RESET(dim=dim))
+        noisy_choi = qx.to_choi(self.process)
+        # Process fidelity = Tr[ideal_choi† @ noisy_choi] / d^2
+        d2 = float(dim * dim)
+        return float(jnp.real(jnp.trace(ideal_choi.matrix.conj().T @ noisy_choi.matrix)) / d2)
+
+    @cached_property
+    def noise_process(self) -> qx.SuperOp:
+        """The noise-only channel (ideal reset factored out).
+
+        For a reset channel the noise framing is less natural than for unitary gates;
+        this property returns the full process superoperator.
+        """
+        return self.process
+
+    # ──────────────────────────────────────────────
+    # Visualization
+    # ──────────────────────────────────────────────
+
+    def plot(self) -> Figure:
+        """Plot the Pauli transfer matrix of the reset channel.
+
+        :return: A Plotly Figure.
+        """
+        fig = qx.plot(self.process)
+        qubit_str = str(self.qubits[0]) if self.qubits else "?"
+        fig.update_layout(title=(f"Reset Channel RESET {qubit_str}<br><sub>F_\u03c7={self.fidelity * 100:.2f}%</sub>"))
+        return fig
+
+    # ──────────────────────────────────────────────
+    # Serialization
+    # ──────────────────────────────────────────────
+
+    def to_json(self) -> str:
+        """Serialize ResetChannel to a JSON string.
+
+        :return: JSON string representation.
+        """
+        data = {
+            "schema_version": 1,
+            "inst": self.inst.out(),
+            "superop": _pack_operator(self.process),
+        }
+        return json.dumps(data)
+
+    @classmethod
+    def from_json(cls: type[ResetChannel], json_str: str) -> ResetChannel:
+        """Deserialize a ResetChannel from a JSON string.
+
+        :param json_str: JSON string as produced by :meth:`to_json`.
+        :return: ResetChannel instance.
+        """
+        data = json.loads(json_str)
+        inst = _parse_quil_instruction(data["inst"])
+        if not isinstance(inst, ResetQubit):
+            raise TypeError(f"ResetChannel JSON must contain a targeted reset instruction, got {type(inst).__name__}.")
+        superop_data = data["superop"]
+        shape = tuple(superop_data["shape"])
+        arr = _unpack_complex_array(superop_data)
+        dims = _unpack_operator_dims(superop_data, shape, superoperator=True)
+        process = qx.SuperOp.from_matrix(arr, dims)
+        return cls(inst=inst, process=process)
+
+    # ──────────────────────────────────────────────
+    # Dunder methods
+    # ──────────────────────────────────────────────
+
+    def __str__(self) -> str:
+        """Return a simplified string representation."""
+        qubit_str = str(self.qubits[0]) if self.qubits else "?"
+        return f"<RESET({self.fidelity:.2f}) {qubit_str}>"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality by instruction and exact process matrix (no tolerance)."""
+        if not isinstance(other, ResetChannel):
+            return False
+        if self.inst != other.inst:
+            return False
+        return bool(jnp.array_equal(self.process.matrix, other.process.matrix))
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class CycleChannel:
+    """A cycle noise channel attaches superoperators to a specific cycle.
+
+    Cycles can include gates and measurements. The constituent channels are stored
+    directly, allowing fidelity metrics and serialization to be derived from them.
+    """
+
+    inst: Gate
+    """The cycle to which the channel applies."""
+
+    defcircuit: DefCircuit
+    """The DefCircuit representing the logical cycle to which instruction represents."""
+
+    channels: tuple[Channel | MeasurementChannel, ...]
+    """Constituent channels (one per operation in the cycle) on disjoint qubits."""
+
+    def __post_init__(self) -> None:
+        """Validate that every instruction in the cycle body has a corresponding channel.
+
+        Downstream consumers (the resolver, the stim converter) use only ``channels`` and
+        ignore ``defcircuit``; a missing channel would silently drop that operation's noise.
+        Operations are matched by identity (name, params, concrete qubits), independent of
+        the DefCircuit's formal-argument naming.
+        """
+        if len(self.expanded_instructions) != len(self.channels):
+            raise ValueError(
+                "CycleChannel is incomplete: every instruction in the cycle's DefCircuit "
+                "body must have a corresponding channel. "
+                f"\nDefCircuit body: {self.expanded_instructions}"
+                f"\nChannels:        {self.channels}"
+            )
+        for instruction, channel in zip(self.expanded_instructions, self.channels, strict=True):
+            if str(instruction) != str(channel.inst):
+                raise ValueError(
+                    "CycleChannel is incomplete: every instruction in the cycle's DefCircuit "
+                    "body must have a corresponding channel. "
+                    f"\nDefCircuit body: {instruction}"
+                    f"\nChannels:        {channel.inst}"
+                )
+
+    # ──────────────────────────────────────────────
+    # Derived properties
+    # ──────────────────────────────────────────────
+
+    @cached_property
+    def expanded_instructions(self) -> list[Gate | Measurement | ResetQubit]:
+        """Return the expanded instructions of the defcircuit."""
+        qarg_to_qubit = dict(zip(self.defcircuit.qubit_variables, self.inst.get_qubit_indices(), strict=False))
+        instructions: list[Gate | Measurement | ResetQubit] = []
+        for inst in self.defcircuit.instructions:
+            match inst:
+                case Measurement():
+                    instructions.append(Measurement(qubit=qarg_to_qubit[inst.qubit], classical_reg=inst.classical_reg))  # type: ignore[index]
+                case ResetQubit():
+                    instructions.append(ResetQubit(qarg_to_qubit[inst.qubit]))  # type: ignore[index]
+                case Gate():
+                    instructions.append(Gate(inst.name, inst.params, [qarg_to_qubit[q] for q in inst.qubits]))  # type: ignore[index]
+                case _:
+                    raise TypeError(f"Unsupported instruction type in defcircuit: {type(inst).__name__}")
+        return instructions
+
+    @cached_property
+    def operator(self) -> tuple[qx.SuperOp | qx.QuantumInstrument, ...]:
+        """Tuple of process superoperators, one per constituent channel."""
+        return tuple(ch.process for ch in self.channels)
+
+    @cached_property
+    def qubits(self) -> list[int]:
+        """All qubits in the cycle, derived from the instruction."""
+        return self.inst.get_qubit_indices()
+
+    @cached_property
+    def pauli_fidelity(self) -> float:
+        """Product of process (Pauli) fidelities over all gate channels in the cycle.
+
+        Measurement channels do not contribute a gate fidelity and are skipped.
+        For near-ideal noise the product approximation is exact since constituent
+        channels act on disjoint subsystems.
+        """
+        f = 1.0
+        for ch in self.channels:
+            if isinstance(ch, Channel):
+                f *= ch.pauli_fidelity
+        return f
+
+    @cached_property
+    def fidelity(self) -> float:
+        """Product of average gate fidelities over all gate channels in the cycle.
+
+        Measurement channels do not contribute a gate fidelity and are skipped.
+        """
+        f = 1.0
+        for ch in self.channels:
+            if isinstance(ch, Channel):
+                f *= ch.fidelity
+        return f
+
+    @cached_property
+    def infidelity(self) -> float:
+        """``1 - fidelity``."""
+        return 1.0 - self.fidelity
+
+    @cached_property
+    def pauli_infidelity(self) -> float:
+        """``1 - pauli_fidelity``."""
+        return 1.0 - self.pauli_fidelity
+
+    # ──────────────────────────────────────────────
+    # Serialization
+    # ──────────────────────────────────────────────
+
+    def to_json(self) -> str:
+        """Serialize CycleChannel to a JSON string.
+
+        :return: JSON string representation.
+        """
+        ch_data = []
+        for ch in self.channels:
+            ch_data.append({"type": type(ch).__name__, "data": ch.to_json()})
+        data = {
+            "channels": ch_data,
+        }
+        return json.dumps(data)
+
+    @classmethod
+    def from_json(cls: type[CycleChannel], json_str: str) -> CycleChannel:
+        """Deserialize a CycleChannel from a JSON string.
+
+        The ``inst`` and ``defcircuit`` fields are reconstructed from the constituent
+        channels, consistent with how :func:`_build_cycle_channel` builds them.
+
+        :param json_str: JSON string as produced by :meth:`to_json`.
+        :return: CycleChannel instance.
+        """
+        data = json.loads(json_str)
+        _type_map: dict[str, type[Channel | MeasurementChannel]] = {
+            "Channel": Channel,
+            "MeasurementChannel": MeasurementChannel,
+        }
+        constituent_channels: list[Channel | MeasurementChannel] = [
+            _type_map[ch_data["type"]].from_json(ch_data["data"]) for ch_data in data["channels"]
+        ]
+        return _build_cycle_channel(constituent_channels)
+
+    # ──────────────────────────────────────────────
+    # Dunder methods
+    # ──────────────────────────────────────────────
+
+    def __str__(self) -> str:
+        """Return a simplified string representation showing the gate and process fidelity."""
+        return f"<{self.inst.out()} ~ ({100 * self.pauli_fidelity:.2f}%)>"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality based on instruction and constituent channels."""
+        if not isinstance(other, CycleChannel):
+            return False
+        if self.inst != other.inst:
+            return False
+        return self.channels == other.channels
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+def _channel_to_formal_inst(channel: Channel | MeasurementChannel) -> Gate | Measurement:
+    """Convert a channel's instruction to use formal arguments for DefCircuit."""
+    if isinstance(channel, Channel):
+        inst = channel.inst
+        return Gate(
+            name=inst.name,
+            params=inst.params,
+            qubits=[FormalArgument(f"q{q}") for q in inst.get_qubit_indices()],
+            modifiers=inst.modifiers,  # type: ignore[arg-type]
+        )
+    elif isinstance(channel, MeasurementChannel):
+        qubit_idx = channel.qubits[0]
+        return Measurement(
+            qubit=FormalArgument(f"q{qubit_idx}"),
+            classical_reg=None,
+        )
+    raise TypeError(f"Unsupported channel type: {type(channel)}")
+
+
+def _build_cycle_channel(
+    channels: list[Channel | MeasurementChannel],
+) -> CycleChannel:
+    """Build a CycleChannel from a list of Channel/MeasurementChannel on disjoint qubits."""
+    all_qubits = sorted(q for ch in channels for q in ch.qubits)
+    cycle_name = "CYCLE"
+    formal_insts = [_channel_to_formal_inst(ch) for ch in channels]
+
+    defcircuit = DefCircuit(
+        name=cycle_name,
+        parameters=[],
+        qubits=[FormalArgument(f"q{q}") for q in all_qubits],
+        instructions=list(formal_insts),
+    )
+    inst = Gate(name=cycle_name, params=[], qubits=all_qubits)
+    return CycleChannel(inst=inst, defcircuit=defcircuit, channels=tuple(channels))

--- a/pyquil/noise/_channels.py
+++ b/pyquil/noise/_channels.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright 2016-2026 Rigetti Computing
+# Copyright 2026 Rigetti Computing
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -30,20 +30,20 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from functools import cached_property, reduce
 from itertools import product
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, SupportsFloat, cast, runtime_checkable
 
 import jax.numpy as jnp
 import numpy as np
 import quax as qx
 from jax import Array
+from jax.scipy.linalg import expm as jax_expm
 from quil.expression import Expression as QuilExpression
-from quil.program import Program as RSProgram
+from quil.instructions import Instruction as RSInstruction
 from scipy.linalg import expm as scipy_expm
-from scipy.linalg import fractional_matrix_power
 from scipy.linalg import logm as scipy_logm
 
-from pyquil.quilatom import Expression, FormalArgument, Parameter, substitute
-from pyquil.quilbase import DefCircuit, DefGate, Gate, Measurement, Reset, ResetQubit
+from pyquil.quilatom import Expression, FormalArgument, MemoryReference, Parameter, substitute
+from pyquil.quilbase import DefCircuit, DefGate, Gate, Measurement, Reset, ResetQubit, _integer_base_and_exponent
 
 if TYPE_CHECKING:
     from plotly.graph_objs import Figure
@@ -56,12 +56,24 @@ logger = logging.getLogger(__name__)
 CustomGateMap = dict[str, qx.Unitary | Callable[..., qx.Unitary]]
 
 
+@runtime_checkable
+class SupportsReal(Protocol):
+    """A value exposing a ``real`` attribute convertible to ``float`` (e.g. ``complex``)."""
+
+    @property
+    def real(self) -> SupportsFloat: ...
+
+
+# A gate parameter that :func:`_resolve_params` can reduce to a concrete float.
+ResolvableParam = Parameter | Expression | QuilExpression | SupportsReal
+
+
 def _parse_quil_instruction(quil_str: str) -> Gate | Measurement | Reset:
     """Parse a single Quil instruction string into a pyquil instruction object.
 
     Uses the ``quil`` Rust parser directly, avoiding a dependency on ``pyquil.Program``.
     """
-    rs_inst = RSProgram.parse(quil_str).body_instructions[0]
+    rs_inst = RSInstruction.parse(quil_str)
     if rs_inst.is_gate():
         return Gate._from_rs_gate(rs_inst.to_gate())
     elif rs_inst.is_measurement():
@@ -86,7 +98,7 @@ def _pack_complex_array(array: Array | np.ndarray) -> dict[str, Any]:
 def _unpack_complex_array(data: dict[str, Any]) -> Array:
     """Unpack a complex array from :func:`_pack_complex_array` data."""
     shape = tuple(data["shape"])
-    return jnp.array([complex(pair[0], pair[1]) for pair in data["_complex_array"]], dtype=complex).reshape(shape)
+    return jnp.array([complex(*pair) for pair in data["_complex_array"]], dtype=complex).reshape(shape)
 
 
 def _pack_dims(dims: tuple[tuple[int, ...], tuple[int, ...]]) -> list[list[int]]:
@@ -103,8 +115,8 @@ def _unpack_dims(data: list[list[int]]) -> tuple[tuple[int, ...], tuple[int, ...
 
 def _infer_legacy_qubit_dims(shape: tuple[int, ...], *, superoperator: bool) -> tuple[tuple[int, ...], tuple[int, ...]]:
     """Infer qubit-only dims for data serialized before dims were stored."""
-    hilbert_dim = int(round(np.sqrt(shape[0]))) if superoperator else int(shape[0])
-    num_qubits = int(round(np.log2(hilbert_dim)))
+    hilbert_dim = round(float(np.sqrt(shape[0]))) if superoperator else int(shape[0])
+    num_qubits = round(float(np.log2(hilbert_dim)))
     if 2**num_qubits != hilbert_dim:
         raise ValueError(
             "Serialized operator data does not include dims and its shape is not compatible with qubit-only dims."
@@ -128,12 +140,35 @@ def _unpack_operator_dims(
     return _infer_legacy_qubit_dims(shape, superoperator=superoperator)
 
 
-def _resolve_params(params: list) -> list[float]:
+def _real_part(value: SupportsFloat | complex, source: object) -> float:
+    """Return the real part of ``value``, warning if a non-negligible imaginary part is dropped.
+
+    Gate parameters are expected to be real; a non-real value is most likely a mistake
+    (and is not differentiable), so the imaginary part is discarded with a warning rather
+    than silently or fatally.
+    """
+    as_complex = complex(value)
+    if abs(as_complex.imag) > 1e-12:
+        logger.warning(
+            "Gate parameter %r has a non-zero imaginary part %g; discarding it and using the real part %g.",
+            source,
+            as_complex.imag,
+            as_complex.real,
+        )
+    return as_complex.real
+
+
+def _resolve_params(params: list[ResolvableParam]) -> list[float]:
     """Resolve gate parameters to concrete float values.
+
+    Gate parameters are expected to be real. If a parameter evaluates to a complex
+    number with a non-negligible imaginary part, the imaginary part is discarded with
+    a warning (see :func:`_real_part`).
 
     :param params: The gate parameters (may include symbolic Parameters or Expressions).
     :return: A list of concrete float values.
     :raises ValueError: If any parameter is symbolic and cannot be evaluated to a number.
+    :raises quil.EvaluationError: If a ``quil`` expression cannot be evaluated to a single number.
     """
     fixed_params = []
     for p in params:
@@ -143,13 +178,28 @@ def _resolve_params(params: list) -> list[float]:
                 raise ValueError(
                     f"Cannot resolve symbolic parameter {p}. Provide a gate with concrete numeric parameters."
                 )
-            fixed_params.append(float(evaluated))
+            fixed_params.append(_real_part(evaluated, p))
         elif isinstance(p, QuilExpression):
+            # QuilExpression.evaluate returns a plain complex when fully resolved.
             result = p.evaluate({}, {})
-            fixed_params.append(float(result.to_number()) if hasattr(result, "to_number") else float(result))  # type: ignore[arg-type]
+            fixed_params.append(_real_part(result, p))
         else:
-            fixed_params.append(float(p.real))
+            # Remaining values are concrete numbers (float/int/complex/numpy scalars).
+            fixed_params.append(_real_part(cast("SupportsFloat | complex", p), p))
     return fixed_params
+
+
+def _qudit_dims(dimension: int) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Infer square operator dims ``((d,)*k, (d,)*k)`` from a matrix dimension ``d**k``.
+
+    Supports qudits: the base ``d`` is the qudit dimension (2 for qubits, 3 for qutrits, ...)
+    and ``k`` the number of qudits. Raises if ``dimension`` is not a prime power.
+    """
+    decomposition = _integer_base_and_exponent(dimension)
+    if decomposition is None:
+        raise ValueError(f"Matrix dimension {dimension} is not a prime power; cannot infer qudit dims.")
+    base, exponent = decomposition
+    return ((base,) * exponent, (base,) * exponent)
 
 
 def get_custom_gates_from_program(program: Program) -> CustomGateMap:
@@ -167,19 +217,19 @@ def get_custom_gates_from_program(program: Program) -> CustomGateMap:
         if defgate.parameters:
 
             def parametric_gate(*args: float, defgate: DefGate = defgate) -> qx.Unitary:
-                parameter_map = {Parameter(p.name): arg for p, arg in zip(defgate.parameters, args, strict=False)}
+                parameter_map: dict[Parameter | MemoryReference, float] = {
+                    Parameter(p.name): arg for p, arg in zip(defgate.parameters, args, strict=False)
+                }
                 matrix = jnp.asarray(
-                    [[substitute(element, parameter_map) for element in row] for row in defgate.matrix],  # type: ignore[arg-type]
+                    [[substitute(element, parameter_map) for element in row] for row in defgate.matrix],
                     dtype=complex,
                 )
-                num_qubits = int(jnp.round(jnp.log2(matrix.shape[0])))
-                return qx.Unitary.from_matrix(matrix, ((2,) * num_qubits, (2,) * num_qubits))
+                return qx.Unitary.from_matrix(matrix, _qudit_dims(matrix.shape[0]))
 
             custom_gates[defgate.name] = parametric_gate
         else:
             matrix = jnp.asarray(defgate.matrix, dtype=complex)
-            num_qubits = int(jnp.round(jnp.log2(matrix.shape[0])))
-            custom_gates[defgate.name] = qx.Unitary.from_matrix(matrix, ((2,) * num_qubits, (2,) * num_qubits))
+            custom_gates[defgate.name] = qx.Unitary.from_matrix(matrix, _qudit_dims(matrix.shape[0]))
     return custom_gates
 
 
@@ -281,10 +331,10 @@ class Channel:
 
         The resulting channel is the composition of the ideal gate unitary with a
         depolarizing channel calibrated to the specified fidelity:
-        :math:`\\mathcal{E} = \\mathcal{D}_p \\circ \\mathcal{U}`
+        :math:`\mathcal{E} = \mathcal{D}_p \circ \mathcal{U}`
 
         :param inst: The gate to which the channel applies.
-        :param fidelity: The average gate fidelity, :math:`F_{\\mathrm{avg}} \\in [0, 1]`.
+        :param fidelity: The average gate fidelity, :math:`F_{\mathrm{avg}} \in [0, 1]`.
         :param custom_gates: Optional dictionary of custom gate definitions.
         :return: A Channel instance.
         """
@@ -302,10 +352,10 @@ class Channel:
         r"""Create a depolarizing noise channel from a process (Pauli) fidelity.
 
         The process fidelity :math:`F_e` is related to the average gate fidelity by
-        :math:`F_{\\mathrm{avg}} = (d \\cdot F_e + 1) / (d + 1)`.
+        :math:`F_{\mathrm{avg}} = (d \cdot F_e + 1) / (d + 1)`.
 
         :param inst: The gate to which the channel applies.
-        :param pauli_fidelity: The process fidelity (entanglement fidelity), :math:`F_e \\in [0, 1]`.
+        :param pauli_fidelity: The process fidelity (entanglement fidelity), :math:`F_e \in [0, 1]`.
         :param custom_gates: Optional dictionary of custom gate definitions.
         :return: A Channel instance.
         """
@@ -323,7 +373,7 @@ class Channel:
         r"""Create a depolarizing noise channel from a depolarization constant.
 
         The depolarizing constant :math:`p` parameterizes the channel as
-        :math:`\\mathcal{D}_p(\\rho) = p \\, \\rho + (1-p) \\, I/d`.
+        :math:`\mathcal{D}_p(\rho) = p \, \rho + (1-p) \, I/d`.
 
         :param inst: The gate to which the channel applies.
         :param depolarizing_constant: The depolarization constant, e.g. 0.98 for 2% depolarization.
@@ -331,7 +381,16 @@ class Channel:
         :return: A Channel instance.
         """
         unitary = get_instruction_unitary(inst, custom_gates)
-        depolarizing_superop = qx.depolarizing_channel_superoperator(1 - depolarizing_constant, unitary.dims[0])
+        dims = unitary.dims[0]
+        d = int(np.prod(dims))
+        # Build the depolarizing channel via the quax depolarizing Lindbladian evolved for
+        # unit time. Its generator shrinks every traceless operator uniformly, so choosing
+        # the rate ``gamma`` with ``exp(-gamma * (d**2 - 1) / d**2) == depolarizing_constant``
+        # reproduces ``D_p(rho) = p * rho + (1 - p) * I/d`` exactly. Full depolarization
+        # (``depolarizing_constant -> 0``) is the infinite-time limit, so clamp away from zero.
+        shrink = float(np.clip(depolarizing_constant, np.finfo(float).tiny, 1.0))
+        gamma = -np.log(shrink) * (d**2 - 1) / d**2
+        depolarizing_superop = qx.channels.depolarizing(gamma, dims, 1.0)
         combined_superop = depolarizing_superop @ unitary
         return cls(inst=inst, process=qx.to_superop(combined_superop), target_unitary=unitary)
 
@@ -412,7 +471,7 @@ class Channel:
         then composed with the ideal gate.
 
         :param inst: The gate to which the channel applies.
-        :param process_fidelity: The process fidelity of the coherent error, :math:`F_e \\in [0, 1]`.
+        :param process_fidelity: The process fidelity of the coherent error, :math:`F_e \in [0, 1]`.
         :param rng: NumPy random number generator for reproducibility.
         :param custom_gates: Optional dictionary of custom gate definitions.
         :return: A Channel instance.
@@ -438,8 +497,6 @@ class Channel:
         for paulis, coefficient in zip(pauli_products, coeffs, strict=False):
             pauli_sum = pauli_sum + reduce(jnp.kron, paulis) * coefficient
 
-        from jax.scipy.linalg import expm as jax_expm
-
         error_unitary = jax_expm(-1j * jnp.pi * pauli_sum)
         # Fix global phase
         phase = jnp.exp(-1j * jnp.angle(error_unitary[0, 0]))
@@ -459,7 +516,7 @@ class Channel:
     ) -> Channel:
         r"""Create a mixture channel from a set of unitary errors with given probabilities.
 
-        The channel is :math:`\\mathcal{E}(\\rho) = (1-\\sum p_i) U\\rho U^\\dagger + \\sum p_i V_i U \\rho U^\\dagger V_i^\\dagger`
+        The channel is :math:`\mathcal{E}(\rho) = (1-\sum p_i) U\rho U^\dagger + \sum p_i V_i U \rho U^\dagger V_i^\dagger`
         where :math:`U` is the ideal gate and :math:`V_i` are the error unitaries.
 
         :param inst: The gate to which the channel applies.
@@ -517,8 +574,13 @@ class Channel:
         t1_array = jnp.asarray(t1s)
         tphi_array = 1 / (1 / jnp.asarray(t2s) - 1 / t1_array)
 
-        choi = qx.thermal_relaxation_choi(t1s=t1_array, tphis=tphi_array, duration=gate_duration)
-        process = qx.to_superop(choi @ unitary)
+        # One thermal-relaxation channel per subsystem, tensored into a joint superoperator.
+        per_qubit = [
+            qx.channels.thermal_relaxation(t1, tphi, t=gate_duration)
+            for t1, tphi in zip(t1_array, tphi_array, strict=True)
+        ]
+        relaxation = reduce(qx.tensor_superop, per_qubit)
+        process = qx.to_superop(relaxation @ unitary)
         return cls(
             inst=inst,
             process=process,
@@ -558,8 +620,8 @@ class Channel:
     def noise_process(self) -> qx.SuperOp:
         r"""The noise-only channel with the ideal gate unitary factored out.
 
-        If the full channel is :math:`\\mathcal{E} = \\Lambda \\circ \\mathcal{U}`, this
-        returns :math:`\\Lambda`.
+        If the full channel is :math:`\mathcal{E} = \Lambda \circ \mathcal{U}`, this
+        returns :math:`\Lambda`.
         """
         return qx.to_superop(self.process @ self.unitary.h)
 
@@ -569,12 +631,12 @@ class Channel:
 
     @cached_property
     def fidelity(self) -> float:
-        r"""Average gate fidelity :math:`F_{\\mathrm{avg}}` of the channel relative to the ideal gate."""
+        r"""Average gate fidelity :math:`F_{\mathrm{avg}}` of the channel relative to the ideal gate."""
         return float(qx.process_fidelity_to_average_fidelity(self.pauli_fidelity, dims=self.unitary.dims[0]))
 
     @cached_property
     def infidelity(self) -> float:
-        r"""Average gate infidelity :math:`1 - F_{\\mathrm{avg}}`."""
+        r"""Average gate infidelity :math:`1 - F_{\mathrm{avg}}`."""
         return 1.0 - self.fidelity
 
     @cached_property
@@ -665,9 +727,9 @@ class Channel:
         r"""Isolate the stochastic (incoherent) component of the noise.
 
         The full channel decomposes as
-        :math:`\\mathcal{E} = \\mathcal{S} \\circ \\mathcal{U}_{\\mathrm{err}} \\circ \\mathcal{U}_{\\mathrm{gate}}`.
+        :math:`\mathcal{E} = \mathcal{S} \circ \mathcal{U}_{\mathrm{err}} \circ \mathcal{U}_{\mathrm{gate}}`.
         This method factors out the coherent unitary error and returns
-        :math:`\\mathcal{S} \\circ \\mathcal{U}_{\\mathrm{gate}}`.
+        :math:`\mathcal{S} \circ \mathcal{U}_{\mathrm{gate}}`.
         """
         u_error = self._unitary_error_component
         # Get the noise-only superoperator and compose with U_err†
@@ -833,7 +895,7 @@ class Channel:
         out one copy of the gate unitary so the result represents the sequential
         application of the two noisy processes:
 
-        :math:`\\mathcal{E}_B \\circ \\mathcal{U}^\\dagger \\circ \\mathcal{E}_A`
+        :math:`\mathcal{E}_B \circ \mathcal{U}^\dagger \circ \mathcal{E}_A`
 
         This is the natural composition: if ``channel_A`` already includes the
         gate, applying ``channel_B`` after it should not double-count the gate.
@@ -846,22 +908,6 @@ class Channel:
         u_dag_superop = qx.to_superop(self.unitary.h)
         composed_superop = qx.to_superop(self.process @ u_dag_superop @ other.process)
         return replace(self, process=composed_superop)
-
-    def __pow__(self, power: float) -> Channel:
-        r"""Raise the channel's noise to a fractional ``power``, preserving the gate.
-
-        With the channel written :math:`\\mathcal{E} = \\Lambda \\circ \\mathcal{U}`, this returns
-        :math:`\\Lambda^{power} \\circ \\mathcal{U}`: only the noise :math:`\\Lambda` is raised to the
-        fractional matrix power, while the ideal gate is kept. So ``power = 0`` yields the noiseless
-        gate, ``1`` leaves the channel unchanged, and ``> 1`` strengthens the noise. This is the knob
-        used to sweep noise strength.
-        """
-        if not isinstance(power, (int, float)):
-            return NotImplemented
-        powered_noise_matrix = fractional_matrix_power(np.asarray(self.noise_process.matrix), power)
-        powered_noise = qx.SuperOp.from_matrix(jnp.asarray(powered_noise_matrix), self.noise_process.dims)
-        process = qx.to_superop(powered_noise @ qx.to_superop(self.unitary))
-        return replace(self, process=process)
 
     def __or__(self, other: Channel | MeasurementChannel) -> CycleChannel:
         """Tensor product of two channels on disjoint qubits, producing a CycleChannel.
@@ -929,7 +975,11 @@ class MeasurementChannel:
             Positive biases toward upward confusion P(j+1|j), negative toward downward P(j|j+1).
         :param dim: The dimension of the measured system (2 for qubits, 3 for qutrits, etc.).
         :return: A MeasurementChannel instance.
+        :raises ValueError: If ``dim < 2``.
         """
+        if dim < 2:
+            raise ValueError(f"Measured system dimension must be at least 2, got dim={dim}.")
+
         # Compute per-pair error factor so that the average diagonal equals fidelity.
         # Each adjacent pair (j, j+1) contributes error_factor*(1+a) + error_factor*(1-a)
         # = 2*error_factor to total off-diagonal sum. With (dim-1) pairs, the average
@@ -1235,7 +1285,7 @@ class MeasurementChannel:
         ``fractional_matrix_power`` of a stochastic matrix can produce.
 
         So ``power = 0`` is an ideal (noiseless) measurement, ``1`` leaves it unchanged, and
-        ``> 1`` degrades it.  Mirrors :meth:`Channel.__pow__` for sweeping readout-noise strength.
+        ``> 1`` degrades it, sweeping readout-noise strength.
 
         :raises ValueError: If the matrix is not embeddable (no real generator) so that the
             powered matrix is not a valid stochastic matrix.
@@ -1315,11 +1365,11 @@ class ResetChannel:
     ) -> ResetChannel:
         r"""Create a ResetChannel with depolarizing noise scaled to the given process fidelity.
 
-        The ideal reset channel maps every state to :math:`|0\\rangle\\langle 0|`.  Noise is
+        The ideal reset channel maps every state to :math:`|0\rangle\langle 0|`.  Noise is
         modelled as a depolarising channel applied after the ideal reset.
 
         :param inst: The reset instruction.
-        :param fidelity: Process fidelity of the reset channel, :math:`F \\in [0, 1]`.
+        :param fidelity: Process fidelity of the reset channel, :math:`F \in [0, 1]`.
             1.0 yields an ideal reset; values below 1 introduce depolarising noise.
         :param dim: Hilbert-space dimension (2 for qubits).
         :return: A ResetChannel instance.
@@ -1365,9 +1415,9 @@ class ResetChannel:
     def fidelity(self) -> float:
         r"""Process fidelity of the reset channel relative to the ideal reset.
 
-        Defined as :math:`F = \\mathrm{Tr}[\\Lambda_{\\mathrm{ideal}}^\\dagger \\Lambda] / d^2`
-        where :math:`\\Lambda` is the Choi matrix of the noisy channel and
-        :math:`\\Lambda_{\\mathrm{ideal}}` is the ideal-reset Choi.
+        Defined as :math:`F = \mathrm{Tr}[\Lambda_{\mathrm{ideal}}^\dagger \Lambda] / d^2`
+        where :math:`\Lambda` is the Choi matrix of the noisy channel and
+        :math:`\Lambda_{\mathrm{ideal}}` is the ideal-reset Choi.
         """
         dim = self.process.dims[0][0]
         ideal_choi = qx.to_choi(qx.gates.RESET(dim=dim))

--- a/pyquil/noise/_channels.py
+++ b/pyquil/noise/_channels.py
@@ -15,9 +15,15 @@
 ##############################################################################
 """Noise channel classes and gate-resolution utilities.
 
-This module defines ``SuperopChannel``, ``MeasurementChannel``, ``SuperopResetChannel``, and
-``CycleChannel`` dataclasses for representing noise in quantum circuits, along
-with helper functions for resolving gate unitaries and extracting custom gate
+This module defines the noise channel dataclasses used to describe noise in quantum circuits:
+
+- :class:`Channel` and :class:`SuperopChannel` for gates (Lindbladian-generated and raw
+  superoperator, respectively),
+- :class:`ResetChannel` and :class:`SuperopResetChannel` for targeted resets,
+- :class:`MeasurementChannel` for measurements, and
+- :class:`CycleChannel` for a set of operations acting in parallel on disjoint qubits.
+
+It also provides helper functions for resolving gate unitaries and extracting custom gate
 definitions from Quil programs.
 """
 
@@ -31,7 +37,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from functools import cached_property, reduce
 from itertools import product
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, cast, final
 
 import jax.numpy as jnp
 import numpy as np
@@ -41,6 +47,7 @@ from jax.scipy.linalg import expm as jax_expm
 from quil.expression import Expression as QuilExpression
 from quil.instructions import Instruction as RSInstruction
 from scipy.linalg import logm as scipy_logm
+from scipy.optimize import brentq
 
 from pyquil.quilatom import Expression, FormalArgument, MemoryReference, Parameter, ParameterDesignator, substitute
 from pyquil.quilbase import DefCircuit, DefGate, Gate, Measurement, Reset, ResetQubit, _integer_base_and_exponent
@@ -52,8 +59,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Type alias for the custom-gate lookup map used throughout the SuperopChannel constructors.
-CustomGateMap = dict[str, qx.Unitary | Callable[..., qx.Unitary]]
+_DEFAULT_GATE_TIME = 1.0
+"""Default evolution time for Lindbladian-backed channels.
+
+``1.0`` is *dimensionless*: the generator's rates are interpreted per unit gate, so a
+depolarizing rate of ``0.01`` means "1% per gate". Pass a physical duration instead (e.g.
+``40e-9`` seconds) when the Hamiltonian and jump operators carry physical units.
+"""
+
+_IMAGINARY_PARAM_TOLERANCE = 1e-12
+"""Largest imaginary part tolerated in a gate parameter before it is rejected."""
+
+CustomGateMap: TypeAlias = dict[str, qx.Unitary | Callable[..., qx.Unitary]]
+"""Lookup map from gate name to a unitary (fixed gates) or a factory (parametric gates).
+
+The callable form is deliberately left as ``Callable[..., qx.Unitary]``: quax gate factories
+are not uniformly positional-only, so a stricter signature would not hold for every entry.
+"""
 
 
 def _parse_quil_instruction(quil_str: str) -> Gate | Measurement | Reset:
@@ -74,7 +96,20 @@ def _parse_quil_instruction(quil_str: str) -> Gate | Measurement | Reset:
     raise ValueError(f"Unsupported instruction type in: {quil_str}")
 
 
-def _pack_complex_array(array: Array | np.ndarray) -> dict[str, Any]:
+class PackedArray(TypedDict):
+    """JSON payload for a complex array: flattened real/imaginary pairs plus its shape."""
+
+    _complex_array: list[list[float]]
+    shape: list[int]
+
+
+class PackedOperator(PackedArray):
+    """JSON payload for a quax operator: a :class:`PackedArray` plus its per-subsystem dims."""
+
+    dims: list[list[int]]
+
+
+def _pack_complex_array(array: Array | np.ndarray) -> PackedArray:
     """Pack a complex array into JSON-compatible real/imaginary pairs."""
     np_array = np.asarray(array)
     return {
@@ -83,41 +118,44 @@ def _pack_complex_array(array: Array | np.ndarray) -> dict[str, Any]:
     }
 
 
-def _unpack_complex_array(data: dict[str, Any]) -> Array:
+def _unpack_complex_array(data: PackedArray) -> Array:
     """Unpack a complex array from :func:`_pack_complex_array` data."""
     shape = tuple(data["shape"])
     return jnp.array([complex(*pair) for pair in data["_complex_array"]], dtype=complex).reshape(shape)
 
 
-def _pack_dims(dims: tuple[tuple[int, ...], tuple[int, ...]]) -> list[list[int]]:
-    """Pack quax operator dims into JSON-compatible lists."""
-    return [list(dims[0]), list(dims[1])]
-
-
 def _unpack_dims(data: list[list[int]]) -> tuple[tuple[int, ...], tuple[int, ...]]:
-    """Unpack quax operator dims from JSON-compatible lists."""
+    """Unpack (and validate) quax operator dims from their JSON representation."""
     if len(data) != 2:
         raise ValueError(f"Serialized operator dims must contain output and input dims, got {data}.")
     return (tuple(int(dim) for dim in data[0]), tuple(int(dim) for dim in data[1]))
 
 
-def _pack_operator(operator: qx.SuperOp | qx.Unitary | qx.Choi | qx.Observable | qx.Operator) -> dict[str, Any]:
-    """Pack a quax operator matrix with explicit dimension metadata."""
+def _pack_operator(operator: qx.SuperOp | qx.Unitary | qx.Choi | qx.Observable | qx.Operator) -> PackedOperator:
+    """Pack a quax operator matrix with explicit dimension metadata.
+
+    ``dims`` is a plain tuple of tuples, which :func:`json.dumps` already encodes as nested
+    lists, so no separate packing step is needed.
+    """
     data = _pack_complex_array(operator.matrix)
-    data["dims"] = _pack_dims(operator.dims)
-    return data
+    return {**data, "dims": [list(operator.dims[0]), list(operator.dims[1])]}
 
 
-def _resolve_params(params: Sequence[ParameterDesignator]) -> list[float]:
-    """Resolve gate parameters to concrete float values.
+def _evaluate_parameter_designators(params: Sequence[ParameterDesignator]) -> list[float]:
+    """Evaluate gate parameters to concrete float values.
 
-    Gate parameters are expected to be real. If a parameter evaluates to a complex number with a
-    non-negligible imaginary part (detected via :func:`numpy.real_if_close`), the imaginary part is
-    discarded with a warning.
+    This performs *arithmetic* evaluation only — it collapses expressions such as ``pi / 2`` to a
+    number. It does not substitute free parameters: a gate still carrying an unbound
+    ``%theta`` cannot be evaluated and is rejected. Substitute parameters first (e.g. with
+    :func:`pyquil.quilatom.substitute`) if the gate is parametric.
 
-    :param params: The gate parameters (may include symbolic Parameters or Expressions).
+    Gate parameters are required to be real, matching the standard gate set and the wider
+    literature. A parameter with an imaginary part beyond :data:`_IMAGINARY_PARAM_TOLERANCE` is
+    a caller error and is rejected rather than silently truncated.
+
+    :param params: The gate parameters (numbers, or expressions over them).
     :return: A list of concrete float values.
-    :raises ValueError: If any parameter is symbolic and cannot be evaluated to a number.
+    :raises ValueError: If a parameter is unbound, or has a non-negligible imaginary part.
     :raises quil.EvaluationError: If a ``quil`` expression cannot be evaluated to a single number.
     """
     fixed_params = []
@@ -134,14 +172,17 @@ def _resolve_params(params: Sequence[ParameterDesignator]) -> list[float]:
         else:
             value = p
 
-        resolved = np.real_if_close(value)
-        if np.iscomplexobj(resolved):
-            logger.warning("Gate parameter %r has a non-negligible imaginary part; using its real part.", p)
-        fixed_params.append(float(np.real(resolved)))
+        imaginary_part = float(np.imag(value))
+        if abs(imaginary_part) > _IMAGINARY_PARAM_TOLERANCE:
+            raise ValueError(
+                f"Gate parameter {p!r} has a non-negligible imaginary part ({imaginary_part!r}). "
+                "Gate parameters must be real."
+            )
+        fixed_params.append(float(np.real(value)))
     return fixed_params
 
 
-def _qudit_dims(dimension: int) -> tuple[tuple[int, ...], tuple[int, ...]]:
+def _operator_dims_from_dimension(dimension: int) -> tuple[tuple[int, ...], tuple[int, ...]]:
     """Infer square operator dims ``((d,)*k, (d,)*k)`` from a matrix dimension ``d**k``.
 
     Supports qudits: the base ``d`` is the qudit dimension (2 for qubits, 3 for qutrits, ...)
@@ -152,6 +193,109 @@ def _qudit_dims(dimension: int) -> tuple[tuple[int, ...], tuple[int, ...]]:
         raise ValueError(f"Matrix dimension {dimension} is not a prime power; cannot infer qudit dims.")
     base, exponent = decomposition
     return ((base,) * exponent, (base,) * exponent)
+
+
+def _require_qubit_dims(dims: tuple[int, ...], context: str) -> int:
+    """Assert that every subsystem is a qubit, returning the number of qubits.
+
+    The Pauli basis used by the Pauli-flavored constructors and analyses is defined for
+    two-level systems only. Rather than let a qudit fall through to an opaque array-shape
+    error, reject it here with a message that names the offending operation.
+    """
+    if any(dim != 2 for dim in dims):
+        raise ValueError(
+            f"{context} is defined for qubits only, but the instruction acts on subsystems with "
+            f"dimensions {dims}. Use a Lindbladian constructor such as "
+            "Channel.from_depolarizing_constant or Channel.from_lindbladian for qudits."
+        )
+    return len(dims)
+
+
+def _pure_dephasing_times(t1s: Sequence[float], t2s: Sequence[float]) -> list[float]:
+    r"""Convert coherence times :math:`(T_1, T_2)` to pure-dephasing times :math:`T_\varphi`.
+
+    ``quax.lindbladians.thermal_relaxation`` takes :math:`T_\varphi`, not the :math:`T_2` that
+    hardware reports. The two are related by
+
+    .. math:: \frac{1}{T_2} = \frac{1}{2 T_1} + \frac{1}{T_\varphi}
+        \quad\Longrightarrow\quad T_\varphi = \frac{1}{1/T_2 - 1/(2 T_1)}.
+
+    Note the factor of two on :math:`T_1`: :math:`T_2 = 2 T_1` means *no* pure dephasing
+    (:math:`T_\varphi = \infty`), not infinite dephasing.
+
+    :raises ValueError: If any :math:`T_1` or :math:`T_2` is non-positive, or any
+        :math:`T_2 > 2 T_1`, for which the pure-dephasing rate would be negative and unphysical.
+    """
+    tphis: list[float] = []
+    for t1, t2 in zip(t1s, t2s, strict=True):
+        if t1 <= 0.0 or t2 <= 0.0:
+            raise ValueError(f"Coherence times must be positive, got T1={t1}, T2={t2}.")
+        dephasing_rate = 1.0 / t2 - 1.0 / (2.0 * t1)
+        if dephasing_rate < 0.0:
+            raise ValueError(
+                f"T2 must not exceed 2*T1 (got T1={t1}, T2={t2}, so 2*T1={2 * t1}); the implied "
+                "pure-dephasing rate would be negative and the channel non-physical."
+            )
+        # T2 == 2*T1 exactly means no pure dephasing at all: an infinite Tphi, whose jump
+        # operator sqrt(1 / (2 Tphi)) Z vanishes.
+        tphis.append(float("inf") if dephasing_rate == 0.0 else 1.0 / dephasing_rate)
+    return tphis
+
+
+# Grid resolution used to bracket the rotation angle in :func:`_random_coherent_error_unitary`.
+# The angle is searched over [0, 2*pi] because a spectral-norm-1 generator has eigenvalues in
+# [-1, 1], so |Tr(exp(-i*theta*H))/d| completes at least one full oscillation over that range.
+_COHERENT_ERROR_ANGLE_GRID = 512
+_COHERENT_ERROR_MAX_ANGLE = 2 * np.pi
+
+
+def _random_coherent_error_unitary(
+    num_qubits: int, dimension: int, process_fidelity: float, rng: np.random.Generator
+) -> Array:
+    r"""Draw a random unitary error with exactly the requested process fidelity to the identity.
+
+    Builds a random traceless Hermitian generator :math:`H` from the non-identity Paulis,
+    normalizes it to unit spectral norm, and solves :math:`|\mathrm{Tr}(e^{-i\theta H})/d|^2 = F`
+    for the smallest positive :math:`\theta` by bracketing on a grid and refining with Brent's
+    method. Solving numerically rather than in closed form makes the achieved fidelity exact for
+    any number of qubits.
+    """
+    if process_fidelity >= 1.0:
+        return jnp.eye(dimension, dtype=complex)
+
+    pauli_matrices = qx.ensembles.PAULIS.matrix  # shape (4, 2, 2): I, X, Y, Z
+    # Skip the all-identity product: it only contributes a global phase.
+    pauli_products = list(itertools.product(pauli_matrices, repeat=num_qubits))[1:]
+    coefficients = rng.random(len(pauli_products))
+    coefficients = coefficients / np.sqrt(np.sum(np.square(coefficients)))
+
+    generator = jnp.zeros((dimension, dimension), dtype=complex)
+    for paulis, coefficient in zip(pauli_products, coefficients, strict=True):
+        generator = generator + reduce(jnp.kron, paulis) * coefficient
+    # Unit spectral norm puts the eigenvalues in [-1, 1], making the angle grid below meaningful
+    # regardless of how many qubits the gate acts on.
+    generator = generator / jnp.linalg.norm(generator, 2)
+
+    def achieved_fidelity(theta: float) -> float:
+        error_unitary = jax_expm(-1j * theta * generator)
+        return float(jnp.abs(jnp.trace(error_unitary) / dimension) ** 2)
+
+    # Walk out along the angle until the achieved fidelity crosses the target, then refine. The
+    # first crossing gives the error closest to the identity.
+    angles = np.linspace(0.0, _COHERENT_ERROR_MAX_ANGLE, _COHERENT_ERROR_ANGLE_GRID)
+    previous = 1.0
+    for low, high in zip(angles[:-1], angles[1:], strict=True):
+        current = achieved_fidelity(float(high))
+        if current <= process_fidelity <= previous:
+            # brentq returns a bare root unless full_output=True, which we do not request.
+            root = cast(float, brentq(lambda t: achieved_fidelity(t) - process_fidelity, low, high, xtol=1e-14))
+            return jnp.asarray(jax_expm(-1j * float(root) * generator))
+        previous = current
+
+    raise ValueError(
+        f"Could not reach a process fidelity of {process_fidelity} with the drawn error direction; "
+        "the requested fidelity may be unreachably low for this number of qubits."
+    )
 
 
 def get_custom_gates_from_program(program: Program) -> CustomGateMap:
@@ -176,12 +320,12 @@ def get_custom_gates_from_program(program: Program) -> CustomGateMap:
                     [[substitute(element, parameter_map) for element in row] for row in defgate.matrix],
                     dtype=complex,
                 )
-                return qx.Unitary.from_matrix(matrix, _qudit_dims(matrix.shape[0]))
+                return qx.Unitary.from_matrix(matrix, _operator_dims_from_dimension(matrix.shape[0]))
 
             custom_gates[defgate.name] = parametric_gate
         else:
             matrix = jnp.asarray(defgate.matrix, dtype=complex)
-            custom_gates[defgate.name] = qx.Unitary.from_matrix(matrix, _qudit_dims(matrix.shape[0]))
+            custom_gates[defgate.name] = qx.Unitary.from_matrix(matrix, _operator_dims_from_dimension(matrix.shape[0]))
     return custom_gates
 
 
@@ -213,7 +357,7 @@ def get_instruction_unitary(
         raise KeyError(f"Unknown gate '{name}'. Provide it via custom_gates (e.g. custom_gates={{'{name}': matrix}}).")
 
     if inst.params:
-        fixed_params = _resolve_params(inst.params)
+        fixed_params = _evaluate_parameter_designators(inst.params)
         if not callable(gate_def):
             raise ValueError(f"Gate '{name}' is not parametric but parameters were provided.")
         result = gate_def(*fixed_params)
@@ -237,7 +381,7 @@ class _ChannelBase(ABC):
 
     A gate channel attaches a CPTP ``process`` (a ``qx.SuperOp`` that *includes* the ideal
     gate) to a :class:`~pyquil.quilbase.Gate`, with fidelity metrics measured against the
-    ideal ``unitary``. Concrete subclasses supply the three attributes below; the
+    ``ideal_unitary``. Concrete subclasses supply the three attributes below; the
     ``process`` may be a stored field (:class:`SuperopChannel`) or derived from a generator
     (:class:`Channel`). Every method here depends only on those three attributes,
     so it works identically regardless of how ``process`` is produced.
@@ -249,10 +393,17 @@ class _ChannelBase(ABC):
     """
 
     # Provided by concrete subclasses (as dataclass fields or cached properties).
+    #
+    # These are declared under ``TYPE_CHECKING`` rather than as abstract properties on purpose.
+    # An abstract property here would collide with the dataclass fields on SuperopChannel: the
+    # inherited ``property`` object becomes the field's default value, and instantiation then
+    # fails with "Can't instantiate abstract class ... without an implementation for abstract
+    # method 'process'". Abstract properties would work for Channel (where ``process`` is a
+    # cached_property) but not for SuperopChannel, so the base cannot require them.
     if TYPE_CHECKING:
         inst: Gate
         process: qx.SuperOp
-        unitary: qx.Unitary
+        ideal_unitary: qx.Unitary
 
     # ──────────────────────────────────────────────
     # Serialization contract (enforced on every concrete channel)
@@ -274,62 +425,74 @@ class _ChannelBase(ABC):
         """The qubits which the channel applies to."""
         return self.inst.get_qubit_indices()
 
-    @cached_property
+    @property
     def num_qubits(self) -> int:
         """The number of qubits the channel acts on."""
         return len(self.qubits)
+
+    @property
+    def dims(self) -> tuple[int, ...]:
+        """Per-subsystem Hilbert-space dimensions, e.g. ``(2, 2)`` for a two-qubit gate."""
+        return tuple(self.ideal_unitary.dims[0])
 
     # ──────────────────────────────────────────────
     # Cached representation conversions
     # ──────────────────────────────────────────────
 
-    def as_post_gate_noise(self) -> qx.SuperOp:
-        r"""Return the noise as a superoperator applied *after* the ideal gate.
+    @cached_property
+    def error_process(self) -> qx.SuperOp:
+        r"""The error, as a superoperator applied *after* the ideal gate.
+
+        Where :attr:`process` is the *full* noisy operation (it includes the ideal gate and
+        replaces it in a circuit), this is the error alone.
 
         A noisy gate channel can be viewed either as noise applied after the ideal gate
         (*post-gate*) or before it (*pre-gate*):
 
         - **post-gate**: :math:`\mathcal{E} = \Lambda_{\text{post}} \circ \mathcal{U}`, so
-          :math:`\Lambda_{\text{post}} = \mathcal{E} \circ \mathcal{U}^\dagger` — this method.
+          :math:`\Lambda_{\text{post}} = \mathcal{E} \circ \mathcal{U}^\dagger` — this property.
         - **pre-gate**: :math:`\mathcal{E} = \mathcal{U} \circ \Lambda_{\text{pre}}`, so
           :math:`\Lambda_{\text{pre}} = \mathcal{U}^\dagger \circ \mathcal{E}`.
 
-        The two coincide only when the noise commutes with the gate; in general they are
+        The two coincide only when the error commutes with the gate; in general they are
         related by conjugation, :math:`\Lambda_{\text{post}} = \mathcal{U} \circ
         \Lambda_{\text{pre}} \circ \mathcal{U}^\dagger`, and share the same fidelity metrics.
         This channel adopts the post-gate convention throughout.
         """
-        return qx.to_superop(self.process @ self.unitary.h)
+        return qx.to_superop(self.process @ self.ideal_unitary.h)
 
     # ──────────────────────────────────────────────
     # Fidelity properties
     # ──────────────────────────────────────────────
 
     @cached_property
-    def fidelity(self) -> float:
+    def average_gate_fidelity(self) -> float:
         r"""Average gate fidelity :math:`F_{\mathrm{avg}}` of the channel relative to the ideal gate."""
-        return float(qx.process_fidelity_to_average_fidelity(self.pauli_fidelity, dims=self.unitary.dims[0]))
+        return float(qx.process_fidelity_to_average_fidelity(self.process_fidelity, dims=self.dims))
 
     @cached_property
-    def infidelity(self) -> float:
+    def average_gate_infidelity(self) -> float:
         r"""Average gate infidelity :math:`1 - F_{\mathrm{avg}}`."""
-        return 1.0 - self.fidelity
+        return 1.0 - self.average_gate_fidelity
 
     @cached_property
-    def pauli_fidelity(self) -> float:
-        """Process fidelity (entanglement fidelity) :math:`F_e` relative to the ideal gate."""
-        process, unitary = qx.promote_hilbert_space(self.process, qx.to_superop(self.unitary))
+    def process_fidelity(self) -> float:
+        """Process fidelity (entanglement fidelity) :math:`F_e` relative to the ideal gate.
+
+        Also called the Pauli fidelity. Named to match ``quax.process_fidelity``.
+        """
+        process, unitary = qx.promote_hilbert_space(self.process, qx.to_superop(self.ideal_unitary))
         return float(qx.process_fidelity(process, unitary))
 
     @cached_property
-    def pauli_infidelity(self) -> float:
+    def process_infidelity(self) -> float:
         """Process infidelity :math:`1 - F_e`."""
-        return 1.0 - self.pauli_fidelity
+        return 1.0 - self.process_fidelity
 
     @cached_property
     def stochastic_infidelity(self) -> float:
         """Stochastic (incoherent) component of the process infidelity."""
-        return float(qx.stochastic_infidelity(self.as_post_gate_noise()))
+        return float(qx.stochastic_infidelity(self.error_process))
 
     @cached_property
     def stochastic_fidelity(self) -> float:
@@ -339,7 +502,7 @@ class _ChannelBase(ABC):
     @cached_property
     def coherent_infidelity(self) -> float:
         """Coherent component of the process infidelity: :math:`e_C = e - e_S`."""
-        return self.pauli_infidelity - self.stochastic_infidelity
+        return self.process_infidelity - self.stochastic_infidelity
 
     @cached_property
     def coherent_fidelity(self) -> float:
@@ -349,39 +512,62 @@ class _ChannelBase(ABC):
     @cached_property
     def unitarity(self) -> float:
         """Unitarity of the channel."""
-        return float(qx.unitarity(self.as_post_gate_noise()))
+        return float(qx.unitarity(self.error_process))
 
     # ──────────────────────────────────────────────
     # SuperopChannel analysis methods
     # ──────────────────────────────────────────────
 
-    def _as_channel(self, process: qx.SuperOp) -> SuperopChannel:
+    def _to_superop_channel(self, process: qx.SuperOp) -> SuperopChannel:
         """Wrap a derived superoperator as a plain :class:`SuperopChannel` for this gate."""
-        return SuperopChannel(inst=self.inst, process=process, unitary=self.unitary)
+        return SuperopChannel(inst=self.inst, process=process, ideal_unitary=self.ideal_unitary)
+
+    def _unitary_error(self) -> qx.Unitary:
+        """Return the dominant coherent error as a quax ``Unitary`` on this channel's subsystems."""
+        return qx.Unitary.from_matrix(self._unitary_error_component, self.process.dims)
 
     def pauli_twirl(self) -> SuperopChannel:
-        """Return a Pauli-twirled version of this channel.
+        r"""Return a Pauli-twirled version of this channel.
 
-        Pauli twirling projects the channel onto the Pauli diagonal, eliminating
-        off-diagonal coherences in the Pauli-Liouville representation. The
-        resulting channel is a stochastic Pauli channel with the same diagonal
-        error rates.
+        Twirling is applied to the *error* (:attr:`error_process`), whose Pauli-Liouville
+        representation is projected onto its diagonal, and the ideal gate is then recomposed.
+        The result is the ideal gate followed by a stochastic Pauli channel carrying the
+        original diagonal error rates. Process fidelity is preserved exactly.
+
+        For a Clifford gate this is precisely the standard Pauli twirl of the noisy gate,
+
+        .. math:: \tilde{\mathcal{E}} = \frac{1}{4^n} \sum_k \mathcal{P}'^\dagger_k \circ
+            \mathcal{E} \circ \mathcal{P}_k, \qquad P'_k = U P_k U^\dagger
+
+        because :math:`\mathcal{U} \circ \mathcal{P}_k = \mathcal{P}'_k \circ \mathcal{U}` lets the
+        gate be pulled out of the average, and for Clifford :math:`U` the conjugated set
+        :math:`\{P'_k\}` is again the Pauli group. (Verified numerically to machine precision for
+        ``X``, ``H``, ``RX(pi/2)``, ``CZ`` and ``CNOT``.)
+
+        For a **non-Clifford** gate the two differ, since :math:`\{U P_k U^\dagger\}` is no longer
+        the Pauli group; this method is then defined as the Pauli twirl of the error, which is the
+        quantity randomized compiling actually implements.
+
+        .. note::
+            Twirling the full :attr:`process` instead would destroy the gate: zeroing the
+            off-diagonal entries of a gate's own transfer matrix does not leave the gate behind.
         """
-        ptm = qx.to_pauli_liouville(self.process)
-        # Keep only the diagonal of the PTM
+        ptm = qx.to_pauli_liouville(self.error_process)
+        # Keep only the diagonal of the error PTM, then put the ideal gate back.
         twirled_ptm_matrix = jnp.diag(jnp.diag(ptm.matrix))
-        twirled_superop = qx.to_superop(qx.PauliLiouville.from_matrix(twirled_ptm_matrix, self.process.dims))
-        return self._as_channel(twirled_superop)
+        twirled_error = qx.PauliLiouville.from_matrix(twirled_ptm_matrix, self.error_process.dims)
+        twirled_superop = qx.to_superop(qx.to_superop(twirled_error) @ qx.to_superop(self.ideal_unitary))
+        return self._to_superop_channel(twirled_superop)
 
     @cached_property
     def _unitary_error_component(self) -> Array:
-        """Extract the dominant unitary from the noise-only channel.
+        """Extract the dominant unitary from the error-only channel.
 
         Uses eigendecomposition + SVD polar decomposition to find the closest
-        unitary to the noise channel.
+        unitary to the error channel.
         """
-        choi_matrix = qx.to_choi(self.as_post_gate_noise()).matrix
-        d = 2**self.num_qubits
+        choi_matrix = qx.to_choi(self.error_process).matrix
+        d = int(np.prod(self.dims))
 
         # Dominant eigenvector of the Choi matrix
         eigenvalues, eigenvectors = jnp.linalg.eigh(choi_matrix)
@@ -392,52 +578,55 @@ class _ChannelBase(ABC):
         return u @ vh
 
     def to_coherent_channel(self) -> SuperopChannel:
-        """Isolate the coherent (unitary) component of the noise.
+        r"""Isolate the coherent (unitary) component of the error.
 
-        Extracts the dominant unitary from the noise Choi matrix via polar
-        decomposition and returns a channel consisting of that unitary error
-        composed with the ideal gate.
+        Extracts the dominant unitary :math:`U_{\mathrm{err}}` from the error Choi matrix via
+        polar decomposition and returns :math:`\mathcal{U}_{\mathrm{err}} \circ
+        \mathcal{U}_{\mathrm{gate}}`.
+
+        Together with :meth:`to_stochastic_channel` this splits the channel into its coherent
+        and stochastic parts; composing the two errors reproduces the full error.
         """
-        u_error = self._unitary_error_component
-        u_error_qx = qx.Unitary.from_matrix(u_error, self.process.dims)
-        coherent_superop = qx.to_superop(u_error_qx @ self.unitary)
-        return self._as_channel(coherent_superop)
+        coherent_superop = qx.to_superop(self._unitary_error() @ self.ideal_unitary)
+        return self._to_superop_channel(coherent_superop)
 
     def to_stochastic_channel(self) -> SuperopChannel:
-        r"""Isolate the stochastic (incoherent) component of the noise.
+        r"""Isolate the stochastic (incoherent) component of the error.
 
         The full channel decomposes as
         :math:`\mathcal{E} = \mathcal{S} \circ \mathcal{U}_{\mathrm{err}} \circ \mathcal{U}_{\mathrm{gate}}`.
         This method factors out the coherent unitary error and returns
         :math:`\mathcal{S} \circ \mathcal{U}_{\mathrm{gate}}`.
         """
-        u_error = self._unitary_error_component
-        # Get the noise-only superoperator and compose with U_err†
-        noise_superop = self.as_post_gate_noise().matrix
-        u_err_inv_superop = jnp.kron(u_error.conj(), u_error.conj().T)
-        stochastic_noise_superop = noise_superop @ u_err_inv_superop
-        # Recompose with the ideal gate
-        ideal_superop = jnp.kron(self.unitary.matrix, self.unitary.matrix.conj())
-        stochastic_superop = stochastic_noise_superop @ ideal_superop
-        return self._as_channel(qx.SuperOp.from_matrix(stochastic_superop, self.process.dims))
+        # S = Lambda_post ∘ U_err†, then recompose with the ideal gate. Composing through quax
+        # keeps the superoperator convention consistent; building the Kronecker products by hand
+        # here silently used the opposite convention and produced a non-CPTP result.
+        stochastic_superop = qx.to_superop(self.error_process @ self._unitary_error().h @ self.ideal_unitary)
+        return self._to_superop_channel(stochastic_superop)
 
     def is_pauli(self) -> bool:
-        """Check if the noise channel is a Pauli (stochastic Pauli) channel.
+        """Check if the error channel is a Pauli (stochastic Pauli) channel.
 
-        A Pauli channel has a diagonal Pauli transfer matrix (noise-only part).
+        A Pauli channel has a diagonal Pauli transfer matrix (error-only part).
         """
-        ptm = qx.to_pauli_liouville(self.as_post_gate_noise()).matrix
+        _require_qubit_dims(self.dims, "is_pauli")
+        ptm = qx.to_pauli_liouville(self.error_process).matrix
         mask = ~jnp.eye(ptm.shape[0], dtype=bool)
         return bool(jnp.allclose(ptm[mask], 0))
 
     def to_pauli_vector(self) -> Array:
-        """Convert the noise channel to a Pauli error probability vector.
+        """Project the error channel onto the Pauli basis.
 
-        Returns the vector of probabilities for each Pauli error in lexicographic
-        order (II, IX, IY, IZ, XI, XX, ...). The vector sums to 1.0.
+        Returns the coefficient of each Pauli error in lexicographic order
+        (II, IX, IY, IZ, XI, XX, ...) — equivalently, the error rates of the
+        :meth:`pauli_twirl` of this channel.
+
+        For a Pauli channel (:meth:`is_pauli`) these are genuine probabilities summing to 1.
+        For a channel with coherent error they are the magnitudes of quasi-probabilities, so
+        treat them as a twirled approximation rather than an exact error budget.
         """
-        noise_superop = self.as_post_gate_noise().matrix
-        num_qubits = self.num_qubits
+        num_qubits = _require_qubit_dims(self.dims, "to_pauli_vector")
+        noise_superop = self.error_process.matrix
         dim = noise_superop.shape[0]
 
         # Build all Pauli operators and their superoperators
@@ -459,8 +648,8 @@ class _ChannelBase(ABC):
     def plot(self, only_noise: bool = True, show_identity: bool = False) -> Figure:
         """Plot the Pauli transfer matrix of the channel.
 
-        :param only_noise: If True (default), plot the noise-only channel (the post-gate
-            noise, with the ideal gate unitary factored out; see :meth:`as_post_gate_noise`).
+        :param only_noise: If True (default), plot the error-only channel (the post-gate
+            error, with the ideal gate unitary factored out; see :attr:`error_process`).
             If False, plot the full channel including the gate unitary.
         :param show_identity: If True, include the identity component in the noise-only plot.
             If False (default), visualize the generator of the noise channel via the matrix
@@ -470,21 +659,21 @@ class _ChannelBase(ABC):
         :return: A Plotly Figure.
         """
         if only_noise:
-            channel = self.as_post_gate_noise()
+            channel = self.error_process
             if not show_identity:
                 ptm = qx.to_pauli_liouville(channel)
                 log_ptm = scipy_logm(np.asarray(ptm.matrix))
                 channel = qx.PauliLiouville.from_matrix(jnp.array(log_ptm), channel.dims)
-            title_prefix = "Noise SuperopChannel"
+            title_prefix = "Error channel"
         else:
             channel = self.process
-            title_prefix = "Full SuperopChannel"
+            title_prefix = "Full channel"
 
         fig = qx.plot(channel)
         fig.update_layout(
             title=(
                 f"{title_prefix} for {self.inst.out()}<br>"
-                f"𝜀={self.pauli_infidelity * 100:.2f}%, "
+                f"𝜀={self.process_infidelity * 100:.2f}%, "
                 f"𝜀<sub>u</sub>={self.coherent_infidelity * 100:.2f}%, "
                 f"𝜀<sub>s</sub>={self.stochastic_infidelity * 100:.2f}%"
             )
@@ -497,15 +686,15 @@ class _ChannelBase(ABC):
 
     def __str__(self) -> str:
         """Return a simplified string representation showing the gate and process fidelity."""
-        return f"<{self.inst.out()} ~ ({100 * self.pauli_fidelity:.2f}%)>"
+        return f"<{self.inst.out()} ~ ({100 * self.process_fidelity:.2f}%)>"
 
     def __eq__(self, other: object) -> bool:
         """Check equality by concrete type, instruction, and (approximate) process/unitary matrices.
 
         Two channels are equal iff they are the same concrete class, share the same instruction,
-        and have element-wise-close ``process`` and ``unitary`` matrices (via :func:`jax.numpy.allclose`).
-        The comparison is approximate rather than bit-exact so it tolerates the small floating-point
-        differences between otherwise-equivalent constructions.
+        and have element-wise-close ``process`` and ``ideal_unitary`` matrices (via
+        :func:`jax.numpy.allclose`). The comparison is approximate rather than bit-exact so it
+        tolerates the small floating-point differences between otherwise-equivalent constructions.
         """
         if type(self) is not type(other):
             return False
@@ -513,12 +702,12 @@ class _ChannelBase(ABC):
             return False
         return bool(
             jnp.allclose(self.process.matrix, other.process.matrix)
-            and jnp.allclose(self.unitary.matrix, other.unitary.matrix)
+            and jnp.allclose(self.ideal_unitary.matrix, other.ideal_unitary.matrix)
         )
 
     __hash__ = None  # type: ignore[assignment]
 
-    def __matmul__(self, other: _ChannelBase) -> _ChannelBase:
+    def __matmul__(self, other: _ChannelBase) -> SuperopChannel:
         r"""Compose two channels: ``channel_B @ channel_A``.
 
         Both channels share the same gate instruction. The composition factors
@@ -529,41 +718,38 @@ class _ChannelBase(ABC):
 
         This is the natural composition: if ``channel_A`` already includes the
         gate, applying ``channel_B`` after it should not double-count the gate.
-        This base implementation works purely with superoperators and returns a plain
-        :class:`SuperopChannel`; :class:`Channel` overrides it to compose at the Lindbladian
-        generator level (returning a :class:`Channel`) when both operands are Lindbladian-backed.
+
+        The composition is *exact* — it is carried out on superoperators — and therefore
+        returns a plain :class:`SuperopChannel` even when both operands are Lindbladian-backed:
+        the composition of two Lindbladian-generated channels is not itself the evolution of a
+        Lindbladian generator unless the two generators commute. To combine noise at the
+        generator level (which is CPTP-safe and stays a :class:`Channel`), add the channels with
+        :meth:`Channel.__add__` instead.
         """
         if not isinstance(other, _ChannelBase):
             return NotImplemented
         if self.inst != other.inst:
             raise ValueError(f"Cannot compose channels for different gates: {self.inst.out()} vs {other.inst.out()}")
         # E_B @ U† @ E_A  (factor out one gate unitary between the two channels)
-        u_dag_superop = qx.to_superop(self.unitary.h)
+        u_dag_superop = qx.to_superop(self.ideal_unitary.h)
         composed_superop = qx.to_superop(self.process @ u_dag_superop @ other.process)
-        return self._as_channel(composed_superop)
+        return self._to_superop_channel(composed_superop)
 
-    def __or__(self, other: _ChannelBase | _ResetChannelBase | MeasurementChannel) -> CycleChannel:
-        """Tensor product of two channels on disjoint qubits, producing a CycleChannel.
+    def __or__(self, other: CycleConstituent | CycleChannel) -> CycleChannel:
+        """Tensor product with another channel on disjoint qubits, producing a CycleChannel.
 
         The result represents a cycle containing both operations acting in parallel
         on disjoint qubits. The DefCircuit encodes the parallel operations as
         formal instructions.
 
-        :param other: Another gate channel, reset channel, or MeasurementChannel on disjoint qubits.
+        :param other: Another gate, reset, or measurement channel — or a
+            :class:`CycleChannel`, whose constituents are flattened in — on disjoint qubits.
         :return: A CycleChannel representing the tensor product.
         """
-        if not isinstance(other, (_ChannelBase, _ResetChannelBase, MeasurementChannel)):
-            return NotImplemented
-
-        # Validate disjoint qubits
-        self_qubits = set(self.qubits)
-        other_qubits = set(other.qubits)
-        if self_qubits & other_qubits:
-            raise ValueError(f"Cannot tensor channels with overlapping qubits: {self_qubits & other_qubits}")
-
-        return _build_cycle_channel([self, other])
+        return _tensor_into_cycle(self, other)
 
 
+@final
 @dataclass(frozen=True, eq=False)
 class SuperopChannel(_ChannelBase):
     """A noise channel that stores a superoperator directly, for a specific gate.
@@ -577,7 +763,8 @@ class SuperopChannel(_ChannelBase):
 
     The superoperator *includes* the gate unitary, so the channel replaces the gate rather than
     being applied after it, and can be converted to alternative representations (Choi, Kraus,
-    Pauli-Liouville) via ``quax``. Fidelity metrics are computed relative to ``unitary``.
+    Pauli-Liouville) via ``quax``. Fidelity metrics are computed relative to ``ideal_unitary``,
+    and the error alone is available as :attr:`~_ChannelBase.error_process`.
     """
 
     inst: Gate
@@ -586,7 +773,7 @@ class SuperopChannel(_ChannelBase):
     process: qx.SuperOp
     """The noisy process (superoperator) for the gate, including the gate unitary."""
 
-    unitary: qx.Unitary
+    ideal_unitary: qx.Unitary
     """The noiseless unitary of the gate."""
 
     # ──────────────────────────────────────────────
@@ -609,35 +796,39 @@ class SuperopChannel(_ChannelBase):
         probabilities exactly (no exponentiation).
 
         :param inst: The gate to which the channel applies.
+            The identity term is implicit: it takes the remaining probability, so passing an
+            all-identity key (``"I"``, ``"II"``, ...) is rejected.
         :param pauli_noise: Pauli error probabilities, e.g. ``{"IX": 0.01, "ZZ": 0.02}``. Must sum
             to at most 1.0; the remainder is assigned to the identity (no-error) term.
         :param custom_gates: Optional dictionary of custom gate definitions.
         :return: A SuperopChannel instance.
+        :raises ValueError: If a rate is negative, the rates sum above 1.0, a term has the wrong
+            length, or an all-identity term is supplied.
         """
         unitary = get_instruction_unitary(inst, custom_gates)
-        num_qubits = len(unitary.dims[0])
+        num_qubits = _require_qubit_dims(unitary.dims[0], "SuperopChannel.from_pauli_noise")
 
+        identity_term = "I" * num_qubits
         total_error_rate = 0.0
         for pauli, error_rate in pauli_noise.items():
             if error_rate < 0.0:
                 raise ValueError(f"Pauli term '{pauli}' has negative error rate {error_rate}.")
             if len(pauli) != num_qubits:
                 raise ValueError(f"Pauli term '{pauli}' has length {len(pauli)}, expected {num_qubits}.")
+            if pauli == identity_term:
+                raise ValueError(
+                    f"Pauli term '{pauli}' is the identity, whose probability is implicit: it receives "
+                    "whatever the given error rates leave over. Pass error terms only."
+                )
             total_error_rate += error_rate
         if total_error_rate > 1.0:
             raise ValueError(f"Pauli error rates must sum to at most 1.0, got {total_error_rate}.")
 
+        # Rates in lexicographic (I, X, Y, Z) order, with the identity taking the remainder so the
+        # resulting Kraus map is trace-preserving.
         all_pauli_terms = tuple("".join(term) for term in product("IXYZ", repeat=num_qubits))
-        pauli_error_rates: list[float] = []
-        for term in reversed(all_pauli_terms):
-            if term in pauli_noise:
-                error_rate = pauli_noise[term]
-            elif all(p == "I" for p in term):
-                error_rate = 1 - sum(pauli_error_rates)
-            else:
-                error_rate = 0
-            pauli_error_rates.append(error_rate)
-        pauli_error_rates = list(reversed(pauli_error_rates))
+        pauli_error_rates = [pauli_noise.get(term, 0.0) for term in all_pauli_terms]
+        pauli_error_rates[all_pauli_terms.index(identity_term)] = 1.0 - total_error_rate
 
         # Kraus operators are the Pauli tensor products scaled by sqrt(probability), in
         # lexicographic (I, X, Y, Z) order matching pauli_error_rates, applied after the gate.
@@ -650,7 +841,7 @@ class SuperopChannel(_ChannelBase):
         kraus_map = qx.KrausMap.from_matrix(kraus_matrices, unitary.dims)
 
         process_superop = qx.to_superop(kraus_map @ unitary)
-        return cls(inst=inst, process=process_superop, unitary=unitary)
+        return cls(inst=inst, process=process_superop, ideal_unitary=unitary)
 
     # ──────────────────────────────────────────────
     # Serialization
@@ -664,7 +855,7 @@ class SuperopChannel(_ChannelBase):
         data = {
             "inst": self.inst.out(),
             "superop": _pack_operator(self.process),
-            "unitary": _pack_operator(self.unitary),
+            "unitary": _pack_operator(self.ideal_unitary),
         }
         return json.dumps(data)
 
@@ -686,7 +877,7 @@ class SuperopChannel(_ChannelBase):
         u_data = data["unitary"]
         unitary = qx.Unitary.from_matrix(_unpack_complex_array(u_data), _unpack_dims(u_data["dims"]))
 
-        return cls(inst=inst, process=superop, unitary=unitary)
+        return cls(inst=inst, process=superop, ideal_unitary=unitary)
 
 
 class _LindbladianBacked(ABC):  # noqa: B024  (abstract mixin; its contract, `lindbladian`/`gate_time`, is supplied as dataclass fields, not @abstractmethods)
@@ -730,6 +921,7 @@ class _LindbladianBacked(ABC):  # noqa: B024  (abstract mixin; its contract, `li
         return qx.Lindbladian(hamiltonian=scaled_hamiltonian, jump_operators=scaled_jumps)
 
 
+@final
 @dataclass(frozen=True, eq=False)
 class Channel(_LindbladianBacked, _ChannelBase):
     r"""A noisy quantum gate: the ideal gate together with the noise that accompanies it.
@@ -744,8 +936,8 @@ class Channel(_LindbladianBacked, _ChannelBase):
     Build one from whatever noise data is available via the ``from_*`` constructors — an average
     or process fidelity, a depolarizing constant, T1/T2 coherence times, Pauli generator rates, a
     mixture of unitary errors, a random coherent error, or a Lindbladian directly. Once built, a
-    channel reports a full suite of fidelity and error metrics (:attr:`fidelity`,
-    :attr:`pauli_fidelity`, :attr:`coherent_infidelity`, :attr:`stochastic_infidelity`,
+    channel reports a full suite of fidelity and error metrics (:attr:`average_gate_fidelity`,
+    :attr:`process_fidelity`, :attr:`coherent_infidelity`, :attr:`stochastic_infidelity`,
     :attr:`unitarity`, ...), can be visualized with :meth:`plot`, decomposed into coherent and
     stochastic parts, Pauli-twirled, composed, and serialized.
 
@@ -755,9 +947,15 @@ class Channel(_LindbladianBacked, _ChannelBase):
       the ideal gate, sweeping noise strength in a physically meaningful way.
     - :meth:`__add__` combines the *noise* of two channels on the same gate, keeping the gate.
 
-    ``gate_time`` defaults to ``1.0`` (dimensionless). It may instead be a physical duration (e.g.
-    ``~40e-9`` s), in which case the Hamiltonian and jump operators are in physical units; the gate
-    Hamiltonian is scaled so that evolving for ``gate_time`` reproduces the ideal ``unitary``.
+    Note that ``@`` (:meth:`~_ChannelBase.__matmul__`) is different from ``+``: it is the exact
+    superoperator composition of the two noisy processes and returns a :class:`SuperopChannel`,
+    because composing two Lindbladian evolutions is not itself a Lindbladian evolution unless the
+    generators commute.
+
+    ``gate_time`` defaults to :data:`_DEFAULT_GATE_TIME` (dimensionless). It may instead be a
+    physical duration (e.g. ``~40e-9`` s), in which case the Hamiltonian and jump operators are in
+    physical units; the gate Hamiltonian is scaled so that evolving for ``gate_time`` reproduces
+    the ideal ``ideal_unitary``.
     """
 
     inst: Gate
@@ -766,16 +964,16 @@ class Channel(_LindbladianBacked, _ChannelBase):
     lindbladian: qx.Lindbladian
     """The GKSL generator for the gate, including the (scaled) gate Hamiltonian."""
 
-    unitary: qx.Unitary
+    ideal_unitary: qx.Unitary
     """The noiseless unitary of the gate."""
 
-    gate_time: float = 1.0
-    """Evolution time for ``evolve(lindbladian, gate_time)``. Default 1.0 (dimensionless)."""
+    gate_time: float = _DEFAULT_GATE_TIME
+    """Evolution time for ``evolve(lindbladian, gate_time)``. See :data:`_DEFAULT_GATE_TIME`."""
 
     @cached_property
     def gate_hamiltonian(self) -> qx.Observable:
-        """Coherent generator whose evolution over ``gate_time`` yields ``unitary``."""
-        return qx.unitary_to_hamiltonian(self.unitary) * (1.0 / self.gate_time)
+        """Coherent generator whose evolution over ``gate_time`` yields ``ideal_unitary``."""
+        return qx.unitary_to_hamiltonian(self.ideal_unitary) * (1.0 / self.gate_time)
 
     @cached_property
     def target_lindbladian(self) -> qx.Lindbladian:
@@ -784,8 +982,8 @@ class Channel(_LindbladianBacked, _ChannelBase):
         Together with :attr:`noise_lindbladian` this decomposes the full ``lindbladian`` into its
         target (gate) and noise parts: ``lindbladian == noise_lindbladian + target_lindbladian``.
         """
-        d = int(np.prod(self.unitary.dims[0]))
-        zero_jumps = qx.Operator.from_matrix(jnp.zeros((1, d, d), dtype=complex), self.unitary.dims)
+        d = int(np.prod(self.dims))
+        zero_jumps = qx.Operator.from_matrix(jnp.zeros((1, d, d), dtype=complex), self.ideal_unitary.dims)
         return qx.Lindbladian(hamiltonian=self.gate_hamiltonian, jump_operators=zero_jumps)
 
     @cached_property
@@ -804,11 +1002,30 @@ class Channel(_LindbladianBacked, _ChannelBase):
     # ──────────────────────────────────────────────
 
     @classmethod
+    def _from_noise_lindbladian(
+        cls: type[Channel],
+        inst: Gate,
+        unitary: qx.Unitary,
+        noise_lindbladian: qx.Lindbladian,
+        gate_time: float,
+    ) -> Channel:
+        """Fold an already-resolved gate unitary and a noise generator into a channel.
+
+        The shared tail of every ``from_*`` constructor. Taking the resolved ``unitary`` means the
+        gate is looked up exactly once per construction, rather than once per delegation hop.
+        """
+        gate_hamiltonian = qx.unitary_to_hamiltonian(unitary) * (1.0 / gate_time)
+        noise_hamiltonian = noise_lindbladian.hamiltonian
+        total_hamiltonian = gate_hamiltonian if noise_hamiltonian is None else noise_hamiltonian + gate_hamiltonian
+        lindbladian = qx.Lindbladian(hamiltonian=total_hamiltonian, jump_operators=noise_lindbladian.jump_operators)
+        return cls(inst=inst, lindbladian=lindbladian, ideal_unitary=unitary, gate_time=gate_time)
+
+    @classmethod
     def from_lindbladian(
         cls: type[Channel],
         inst: Gate,
         noise_lindbladian: qx.Lindbladian,
-        gate_time: float = 1.0,
+        gate_time: float = _DEFAULT_GATE_TIME,
         custom_gates: CustomGateMap | None = None,
     ) -> Channel:
         """Create a channel from a noise-only Lindbladian, folding in the gate.
@@ -816,64 +1033,85 @@ class Channel(_LindbladianBacked, _ChannelBase):
         :param inst: The gate to which the channel applies.
         :param noise_lindbladian: The noise generator (e.g. from ``qx.lindbladians``), *without*
             the gate Hamiltonian. Its rates are interpreted per unit time and evolved for ``gate_time``.
-        :param gate_time: Evolution time (default 1.0).
+        :param gate_time: Evolution time (see :data:`_DEFAULT_GATE_TIME`).
         :param custom_gates: Optional dictionary of custom gate definitions.
         :return: A Channel instance.
         """
         unitary = get_instruction_unitary(inst, custom_gates)
-        gate_hamiltonian = qx.unitary_to_hamiltonian(unitary) * (1.0 / gate_time)
-        noise_hamiltonian = noise_lindbladian.hamiltonian
-        total_hamiltonian = gate_hamiltonian if noise_hamiltonian is None else noise_hamiltonian + gate_hamiltonian
-        lindbladian = qx.Lindbladian(hamiltonian=total_hamiltonian, jump_operators=noise_lindbladian.jump_operators)
-        return cls(inst=inst, lindbladian=lindbladian, unitary=unitary, gate_time=gate_time)
+        return cls._from_noise_lindbladian(inst, unitary, noise_lindbladian, gate_time)
 
     @classmethod
     def from_gate_fidelity(
         cls: type[Channel],
         inst: Gate,
         fidelity: float,
-        gate_time: float = 1.0,
+        gate_time: float = _DEFAULT_GATE_TIME,
         custom_gates: CustomGateMap | None = None,
     ) -> Channel:
         """Create a depolarizing Lindbladian channel from an average gate fidelity."""
         unitary = get_instruction_unitary(inst, custom_gates)
-        p = qx.average_fidelity_to_depolarizing_constant(fidelity, unitary.dims[0])
-        return cls.from_depolarizing_constant(inst, p, gate_time, custom_gates)
+        p = float(qx.average_fidelity_to_depolarizing_constant(fidelity, unitary.dims[0]))
+        return cls._from_depolarizing_constant(inst, unitary, p, gate_time)
 
     @classmethod
     def from_pauli_fidelity(
         cls: type[Channel],
         inst: Gate,
         pauli_fidelity: float,
-        gate_time: float = 1.0,
+        gate_time: float = _DEFAULT_GATE_TIME,
         custom_gates: CustomGateMap | None = None,
     ) -> Channel:
         """Create a depolarizing Lindbladian channel from a process (Pauli) fidelity."""
         unitary = get_instruction_unitary(inst, custom_gates)
-        p = qx.process_fidelity_to_depolarizing_constant(pauli_fidelity, unitary.dims[0])
-        return cls.from_depolarizing_constant(inst, p, gate_time, custom_gates)
+        p = float(qx.process_fidelity_to_depolarizing_constant(pauli_fidelity, unitary.dims[0]))
+        return cls._from_depolarizing_constant(inst, unitary, p, gate_time)
+
+    @classmethod
+    def _from_depolarizing_constant(
+        cls: type[Channel],
+        inst: Gate,
+        unitary: qx.Unitary,
+        depolarizing_constant: float,
+        gate_time: float,
+    ) -> Channel:
+        """Build a depolarizing channel from an already-resolved unitary."""
+        dims = unitary.dims[0]
+        d = int(np.prod(dims))
+        if not 0.0 <= depolarizing_constant <= 1.0:
+            raise ValueError(
+                f"Depolarizing constant must lie in [0, 1], got {depolarizing_constant}. "
+                "It is the factor by which every traceless operator shrinks: 1.0 is noiseless, "
+                "0.0 is complete depolarization."
+            )
+        # Floor at the smallest positive float so p == 0 (complete depolarization) yields a large
+        # finite rate rather than log(0).
+        shrink = max(depolarizing_constant, np.finfo(float).tiny)
+        gamma_unit_time = -np.log(shrink) * (d**2 - 1) / d**2
+        noise = qx.lindbladians.depolarizing(gamma_unit_time / gate_time, dims)
+        return cls._from_noise_lindbladian(inst, unitary, noise, gate_time)
 
     @classmethod
     def from_depolarizing_constant(
         cls: type[Channel],
         inst: Gate,
         depolarizing_constant: float,
-        gate_time: float = 1.0,
+        gate_time: float = _DEFAULT_GATE_TIME,
         custom_gates: CustomGateMap | None = None,
     ) -> Channel:
         r"""Create a depolarizing Lindbladian channel from a depolarization constant.
 
-        Matches :meth:`SuperopChannel.from_depolarizing_constant`: the depolarizing constant :math:`p`
-        parameterizes :math:`\mathcal{D}_p(\rho) = p\,\rho + (1-p)\,I/d`. The rate is chosen so that
+        The depolarizing constant :math:`p` parameterizes
+        :math:`\mathcal{D}_p(\rho) = p\,\rho + (1-p)\,I/d`. The rate is chosen so that
         evolving for ``gate_time`` shrinks every traceless operator by exactly ``p``.
+
+        :param inst: The gate to which the channel applies.
+        :param depolarizing_constant: The shrink factor :math:`p \in [0, 1]`; 1.0 is noiseless.
+        :param gate_time: Evolution time (see :data:`_DEFAULT_GATE_TIME`).
+        :param custom_gates: Optional dictionary of custom gate definitions.
+        :raises ValueError: If ``depolarizing_constant`` lies outside :math:`[0, 1]`.
         """
         unitary = get_instruction_unitary(inst, custom_gates)
-        dims = unitary.dims[0]
-        d = int(np.prod(dims))
-        shrink = float(np.clip(depolarizing_constant, np.finfo(float).tiny, 1.0))
-        gamma_unit_time = -np.log(shrink) * (d**2 - 1) / d**2
-        noise = qx.lindbladians.depolarizing(gamma_unit_time / gate_time, dims)
-        return cls.from_lindbladian(inst, noise, gate_time, custom_gates)
+        return cls._from_depolarizing_constant(inst, unitary, depolarizing_constant, gate_time)
 
     @classmethod
     def from_coherence_times(
@@ -884,15 +1122,19 @@ class Channel(_LindbladianBacked, _ChannelBase):
         t2s: list[float] | None = None,
         custom_gates: CustomGateMap | None = None,
     ) -> Channel:
-        """Create a decoherence channel from T1/T2 coherence times, evolved over ``gate_duration``.
+        r"""Create a decoherence channel from T1/T2 coherence times, evolved over ``gate_duration``.
 
         The gate and thermal relaxation happen together over ``gate_duration`` (``gate_time`` is set
-        to ``gate_duration``). Physical rates come from ``qx.lindbladians.thermal_relaxation``.
+        to ``gate_duration``). Physical rates come from ``qx.lindbladians.thermal_relaxation``,
+        which takes the *pure-dephasing* time :math:`T_\varphi` rather than :math:`T_2`; the
+        conversion is :math:`T_\varphi = 1/(1/T_2 - 1/(2 T_1))` (see :func:`_pure_dephasing_times`).
 
         :param inst: The target instruction.
         :param gate_duration: The duration of the gate (used as ``gate_time``).
         :param t1s: The T1 time(s) of the qudits.
-        :param t2s: The T2 time(s) of the qudits. Default to ``2 * t1``.
+        :param t2s: The T2 time(s) of the qudits. Defaults to ``2 * t1`` (no pure dephasing).
+        :raises ValueError: If the number of T1/T2 values does not match the instruction's qudits,
+            or if any :math:`T_2 > 2 T_1`.
         """
         qubits = inst.get_qubit_indices()
         num_sys = len(qubits)
@@ -903,13 +1145,13 @@ class Channel(_LindbladianBacked, _ChannelBase):
         elif num_sys != len(t2s):
             raise ValueError(f"Expected {num_sys} T2 values for {inst.out()}, got {len(t2s)}.")
 
-        t1_array = jnp.asarray(t1s)
-        tphi_array = 1 / (1 / jnp.asarray(t2s) - 1 / t1_array)
         per_qubit = [
-            qx.lindbladians.thermal_relaxation(t1, tphi) for t1, tphi in zip(t1_array, tphi_array, strict=True)
+            qx.lindbladians.thermal_relaxation(t1, tphi)
+            for t1, tphi in zip(t1s, _pure_dephasing_times(t1s, t2s), strict=True)
         ]
         noise = reduce(lambda a, b: a | b, per_qubit)
-        return cls.from_lindbladian(inst, noise, gate_duration, custom_gates)
+        unitary = get_instruction_unitary(inst, custom_gates)
+        return cls._from_noise_lindbladian(inst, unitary, noise, gate_duration)
 
     @classmethod
     def from_pauli_generators(
@@ -929,12 +1171,13 @@ class Channel(_LindbladianBacked, _ChannelBase):
 
         :param inst: The gate to which the channel applies.
         :param pauli_generators: Pauli generator rates, e.g. ``{"IX": 0.01, "ZZ": 0.02}``.
-        :param gate_time: Evolution time (default 1.0).
+        :param gate_time: Evolution time (see :data:`_DEFAULT_GATE_TIME`).
         :param custom_gates: Optional dictionary of custom gate definitions.
         :return: A Channel instance.
+        :raises ValueError: If the gate acts on non-qubit subsystems, or a rate is negative.
         """
         unitary = get_instruction_unitary(inst, custom_gates)
-        num_qubits = len(unitary.dims[0])
+        num_qubits = _require_qubit_dims(unitary.dims[0], "Channel.from_pauli_generators")
         single_pauli_matrices = qx.ensembles.PAULIS.matrix  # (4, 2, 2): I, X, Y, Z
         pauli_index = {"I": 0, "X": 1, "Y": 2, "Z": 3}
 
@@ -947,46 +1190,62 @@ class Channel(_LindbladianBacked, _ChannelBase):
             op = reduce(jnp.kron, [single_pauli_matrices[pauli_index[p]] for p in pauli])
             jump_matrices.append(jnp.sqrt(rate) * op)
 
-        d = 2**num_qubits
+        d = int(np.prod(unitary.dims[0]))
         stacked = jnp.stack(jump_matrices) if jump_matrices else jnp.zeros((1, d, d), dtype=complex)
         jump_operators = qx.Operator.from_matrix(stacked, unitary.dims)
         noise = qx.Lindbladian(hamiltonian=None, jump_operators=jump_operators)
-        return cls.from_lindbladian(inst, noise, gate_time, custom_gates)
+        return cls._from_noise_lindbladian(inst, unitary, noise, gate_time)
 
     @classmethod
     def from_mixture(
         cls: type[Channel],
         inst: Gate,
         constituents: list[qx.Unitary],
-        probabilities: list[float],
-        gate_time: float = 1.0,
+        rates: list[float],
+        gate_time: float = _DEFAULT_GATE_TIME,
         custom_gates: CustomGateMap | None = None,
     ) -> Channel:
-        r"""Create a mixture channel from a set of unitary errors with given probabilities.
+        r"""Create a channel whose error is generated by a set of unitary jump operators.
 
-        Each error unitary ``V_i`` with probability ``p_i`` contributes a jump operator
-        ``sqrt(p_i) * V_i`` to the generator; over ``gate_time`` this is the exponentiated
-        mixture channel composed with the ideal gate.
+        Each error unitary :math:`V_i` with rate :math:`r_i` contributes a jump operator
+        :math:`\sqrt{r_i}\,V_i` to the generator, so this is the continuously-generated
+        counterpart of a mixed-unitary channel, in the same sense that
+        :meth:`from_pauli_generators` is the counterpart of
+        :meth:`SuperopChannel.from_pauli_noise`.
+
+        .. note::
+            This is *not* the one-shot mixture
+            :math:`\sum_i r_i V_i \rho V_i^\dagger + (1 - \sum_i r_i)\rho`. Exponentiating the
+            generator produces a Poissonian sum over *products* of the :math:`V_i`, so the two
+            agree only to first order in the rates. For an exact mixed-Pauli channel use
+            :meth:`SuperopChannel.from_pauli_noise`.
 
         :param inst: The gate to which the channel applies.
-        :param constituents: Unitary error operators to mix.
-        :param probabilities: Probability of each unitary error.
-        :param gate_time: Evolution time (default 1.0).
+        :param constituents: Unitary error operators.
+        :param rates: Generator rate of each unitary error, per unit time.
+        :param gate_time: Evolution time (see :data:`_DEFAULT_GATE_TIME`).
         :param custom_gates: Optional dictionary of custom gate definitions.
         :return: A Channel instance.
+        :raises ValueError: If the lengths disagree, a rate is negative, or a constituent's dims
+            do not match the gate's.
         """
         ideal = get_instruction_unitary(inst, custom_gates)
-        if len(constituents) != len(probabilities):
-            raise ValueError("The number of constituents and probabilities must match.")
-        if any(p < 0.0 for p in probabilities):
-            raise ValueError("Mixture probabilities must be non-negative.")
+        if len(constituents) != len(rates):
+            raise ValueError(f"Got {len(constituents)} constituents but {len(rates)} rates; they must match.")
+        if any(r < 0.0 for r in rates):
+            raise ValueError("Mixture rates must be non-negative.")
+        for constituent in constituents:
+            if constituent.dims != ideal.dims:
+                raise ValueError(
+                    f"Constituent unitary has dims {constituent.dims}, expected {ideal.dims} " f"to match {inst.out()}."
+                )
 
         d = int(np.prod(ideal.dims[0]))
-        jump_matrices = [jnp.sqrt(p) * v.matrix for p, v in zip(probabilities, constituents, strict=True)]
+        jump_matrices = [jnp.sqrt(r) * v.matrix for r, v in zip(rates, constituents, strict=True)]
         stacked = jnp.stack(jump_matrices) if jump_matrices else jnp.zeros((1, d, d), dtype=complex)
         jump_operators = qx.Operator.from_matrix(stacked, ideal.dims)
         noise = qx.Lindbladian(hamiltonian=None, jump_operators=jump_operators)
-        return cls.from_lindbladian(inst, noise, gate_time, custom_gates)
+        return cls._from_noise_lindbladian(inst, ideal, noise, gate_time)
 
     @classmethod
     def from_random_coherent_error(
@@ -994,49 +1253,48 @@ class Channel(_LindbladianBacked, _ChannelBase):
         inst: Gate,
         process_fidelity: float,
         rng: np.random.Generator | None = None,
-        gate_time: float = 1.0,
+        gate_time: float = _DEFAULT_GATE_TIME,
         custom_gates: CustomGateMap | None = None,
     ) -> Channel:
         r"""Create a channel with a random coherent (unitary) error at the specified process fidelity.
 
-        A random unitary close to identity is generated with the given process fidelity and composed
-        with the ideal gate; the result is a purely coherent :class:`Channel` (Hamiltonian only,
-        no jump operators).
+        A random traceless Hermitian direction :math:`H` is drawn over the non-identity Paulis and
+        normalized; the error is :math:`V(\theta) = \exp(-i\theta H)` with :math:`\theta` chosen so
+        that :math:`|\mathrm{Tr}(V)/d|^2` equals ``process_fidelity`` exactly. The smallest such
+        :math:`\theta` is taken, keeping the error as close to the identity as the target allows.
+        The result is a purely coherent :class:`Channel` (Hamiltonian only, no jump operators).
+
+        :math:`\theta` is found numerically. A closed form exists only for a single qudit, where
+        the three non-identity Paulis anticommute so that :math:`H^2 \propto I`; for multi-qubit
+        gates the eigenvalues of :math:`H` depend on the drawn direction, and the closed form
+        misses the target by roughly 1% of the infidelity.
 
         :param inst: The gate to which the channel applies.
-        :param process_fidelity: The process fidelity of the coherent error, :math:`F_e \in [0, 1]`.
+        :param process_fidelity: The process fidelity of the coherent error, :math:`F_e \in (0, 1]`.
         :param rng: NumPy random number generator for reproducibility.
-        :param gate_time: Evolution time (default 1.0).
+        :param gate_time: Evolution time (see :data:`_DEFAULT_GATE_TIME`).
         :param custom_gates: Optional dictionary of custom gate definitions.
         :return: A Channel instance.
+        :raises ValueError: If the gate acts on non-qubit subsystems, if ``process_fidelity`` lies
+            outside :math:`(0, 1]`, or if no rotation angle reaches the requested fidelity.
         """
         if rng is None:
             rng = np.random.default_rng()
 
         ideal = get_instruction_unitary(inst, custom_gates)
-        num_qubits = len(ideal.dims[0])
-        d = 2**num_qubits
+        num_qubits = _require_qubit_dims(ideal.dims[0], "Channel.from_random_coherent_error")
+        d = int(np.prod(ideal.dims[0]))
 
-        angle = jnp.arccos(2 * process_fidelity - 1) / (2 * jnp.pi)
-        id_coeff = 1 - float(angle)
-        coeffs = rng.random(4**num_qubits - 1)
-        coeffs = (1 - id_coeff) / np.sqrt(np.sum(np.square(coeffs))) * coeffs
+        if not 0.0 < process_fidelity <= 1.0:
+            raise ValueError(f"process_fidelity must lie in (0, 1], got {process_fidelity}.")
 
-        pauli_matrices = qx.ensembles.PAULIS.matrix  # shape (4, 2, 2)
-        pauli_sum = jnp.eye(d, dtype=complex) * id_coeff
-        pauli_products = list(itertools.product(pauli_matrices, repeat=num_qubits))[1:]
-        for paulis, coefficient in zip(pauli_products, coeffs, strict=False):
-            pauli_sum = pauli_sum + reduce(jnp.kron, paulis) * coefficient
-
-        error_unitary = jax_expm(-1j * jnp.pi * pauli_sum)
-        phase = jnp.exp(-1j * jnp.angle(error_unitary[0, 0]))
-        error_unitary = error_unitary * phase
+        error_unitary = _random_coherent_error_unitary(num_qubits, d, process_fidelity, rng)
 
         noisy_unitary = qx.Unitary.from_matrix(error_unitary @ ideal.matrix, ideal.dims)
         hamiltonian = qx.unitary_to_hamiltonian(noisy_unitary) * (1.0 / gate_time)
         zero_jumps = qx.Operator.from_matrix(jnp.zeros((1, d, d), dtype=complex), ideal.dims)
         lindbladian = qx.Lindbladian(hamiltonian=hamiltonian, jump_operators=zero_jumps)
-        return cls(inst=inst, lindbladian=lindbladian, unitary=ideal, gate_time=gate_time)
+        return cls(inst=inst, lindbladian=lindbladian, ideal_unitary=ideal, gate_time=gate_time)
 
     # ──────────────────────────────────────────────
     # Lindbladian-native operations
@@ -1048,38 +1306,50 @@ class Channel(_LindbladianBacked, _ChannelBase):
         ``power = 0`` yields the ideal gate, ``1`` leaves the channel unchanged, and ``> 1``
         strengthens the noise. Unlike a fractional matrix power of a superoperator, this is always
         CPTP because it acts on the generator's jump operators and coherent-noise Hamiltonian.
+
+        .. note::
+            This scales the noise; it is not the matrix power of the channel's superoperator
+            (which is not CPTP in general, and not even well defined for a channel that is not
+            infinitely divisible). Consistently with :meth:`__add__`, ``channel ** 2`` is the
+            channel with twice the noise, i.e. ``channel + channel``.
         """
         if not isinstance(power, (int, float)):
             return NotImplemented
         scaled = self._scaled_noise_generator(power, gate_hamiltonian=self.gate_hamiltonian)
         return replace(self, lindbladian=scaled)
 
-    def __matmul__(self, other: _ChannelBase) -> _ChannelBase:
-        """Compose two channels sharing the same gate.
-
-        For two Lindbladian-backed :class:`Channel`s the composition is formed at the generator
-        level: because the jump operators can be added directly, composition coincides with
-        combining the noise on the shared gate (:meth:`__add__`), yielding a :class:`Channel` that
-        stays CPTP and Lindbladian. Composing with a non-Lindbladian channel falls back to the
-        superoperator composition of :meth:`_ChannelBase.__matmul__`, which returns a plain
-        :class:`SuperopChannel`.
-        """
-        if isinstance(other, Channel):
-            return self + other
-        return super().__matmul__(other)
-
     def __add__(self, other: Channel) -> Channel:
-        """Combine the *noise* of two channels on the same gate, keeping the gate.
+        r"""Combine the *noise* of two channels on the same gate, keeping the gate.
 
         The gate Hamiltonian is factored out of each operand (via :attr:`noise_lindbladian`), the
         noise generators are summed (jump operators concatenated, coherent-noise Hamiltonians
         added), and the gate is folded back in. Adding two ``RX(pi/2)`` channels therefore yields an
-        ``RX(pi/2)`` channel whose noise is the union of the two.
+        ``RX(pi/2)`` channel whose noise is the union of the two. The result is always CPTP and
+        stays a :class:`Channel`.
+
+        This is a generator-level operation and is *not* the same as composing the two channels
+        with ``@``. Composition applies one process after the other,
+        :math:`\mathcal{E}_B \circ \mathcal{U}^\dagger \circ \mathcal{E}_A`, which equals
+        :math:`\mathrm{evolve}(L_A + L_B - H_{\mathrm{gate}}, t)` only when the two generators
+        commute. Use ``+`` to describe a gate subject to several noise mechanisms at once, and
+        ``@`` to describe one noisy operation followed by another.
+
+        Both operands must share the same ``gate_time``: jump operators carry rates *per unit
+        time*, so adding generators calibrated against different durations would silently rescale
+        one operand's noise.
+
+        :raises ValueError: If the gates or the ``gate_time`` values differ.
         """
         if not isinstance(other, Channel):
             return NotImplemented
         if self.inst != other.inst:
             raise ValueError(f"Cannot combine channels for different gates: {self.inst.out()} vs {other.inst.out()}")
+        if self.gate_time != other.gate_time:
+            raise ValueError(
+                f"Cannot combine channels with different gate times ({self.gate_time} vs {other.gate_time}): "
+                "jump operators are per-unit-time rates, so the sum would reinterpret one operand's "
+                "noise in the other's time base. Rebuild one channel at the other's gate_time first."
+            )
         combined_noise = self.noise_lindbladian + other.noise_lindbladian
         gate_hamiltonian = self.gate_hamiltonian
         combined_hamiltonian = (
@@ -1098,7 +1368,7 @@ class Channel(_LindbladianBacked, _ChannelBase):
         data = {
             "inst": self.inst.out(),
             "gate_time": self.gate_time,
-            "unitary": _pack_operator(self.unitary),
+            "unitary": _pack_operator(self.ideal_unitary),
             "hamiltonian": None if hamiltonian is None else _pack_operator(hamiltonian),
             "jump_operators": _pack_operator(self.lindbladian.jump_operators),
         }
@@ -1124,9 +1394,10 @@ class Channel(_LindbladianBacked, _ChannelBase):
         jump_data = data["jump_operators"]
         jump_operators = qx.Operator.from_matrix(_unpack_complex_array(jump_data), _unpack_dims(jump_data["dims"]))
         lindbladian = qx.Lindbladian(hamiltonian=hamiltonian, jump_operators=jump_operators)
-        return cls(inst=inst, lindbladian=lindbladian, unitary=unitary, gate_time=data["gate_time"])
+        return cls(inst=inst, lindbladian=lindbladian, ideal_unitary=unitary, gate_time=data["gate_time"])
 
 
+@final
 @dataclass(frozen=True)
 class MeasurementChannel:
     """A measurement noise channel attaches a quantum instrument to a specific measurement operation.
@@ -1144,8 +1415,7 @@ class MeasurementChannel:
     @property
     def qubits(self) -> list[int]:
         """The qubits which the measurement applies to."""
-        qubit = self.inst.qubit
-        return [qubit.index if hasattr(qubit, "index") else int(qubit)]
+        return list(self.inst.get_qubit_indices())
 
     # ──────────────────────────────────────────────
     # Constructors
@@ -1165,16 +1435,35 @@ class MeasurementChannel:
         Error is distributed only between adjacent levels: P(j+1|j) and P(j|j+1).
         Non-adjacent confusion is zero.
 
+        ``fidelity`` is the *average* over levels: for ``dim > 2`` the interior levels carry error
+        in both directions, so their individual accuracies are lower than the edge levels'.
+
         :param inst: The measurement instruction.
-        :param fidelity: The average readout fidelity.
+        :param fidelity: The average readout fidelity, in :math:`[0, 1]`.
         :param asymmetry: Value between -1 and +1. Zero is symmetric.
             Positive biases toward upward confusion P(j+1|j), negative toward downward P(j|j+1).
         :param dim: The dimension of the measured system (2 for qubits, 3 for qutrits, etc.).
         :return: A MeasurementChannel instance.
-        :raises ValueError: If ``dim < 2``.
+        :raises ValueError: If ``dim < 2``, if ``fidelity`` or ``asymmetry`` is out of range, or if
+            the two combine to a confusion matrix with a negative diagonal — which requires
+            ``dim * (1 - fidelity) * (1 + abs(asymmetry)) / (2 * (dim - 1)) <= 1``.
         """
         if dim < 2:
             raise ValueError(f"Measured system dimension must be at least 2, got dim={dim}.")
+        if not 0.0 <= fidelity <= 1.0:
+            raise ValueError(f"Readout fidelity must lie in [0, 1], got {fidelity}.")
+        if not -1.0 <= asymmetry <= 1.0:
+            raise ValueError(f"Readout asymmetry must lie in [-1, 1], got {asymmetry}.")
+
+        # The largest single off-diagonal entry is error_factor * (1 + |asymmetry|); if that
+        # exceeds 1 the corresponding diagonal entry would go negative.
+        worst_case_error = dim * (1 - fidelity) * (1 + abs(asymmetry)) / (2 * (dim - 1))
+        if worst_case_error > 1.0:
+            raise ValueError(
+                f"fidelity={fidelity} and asymmetry={asymmetry} cannot be realized for dim={dim}: "
+                f"they imply a confusion probability of {worst_case_error:.4f} between adjacent "
+                "levels. Reduce the asymmetry or raise the fidelity."
+            )
 
         # Compute per-pair error factor so that the average diagonal equals fidelity.
         # Each adjacent pair (j, j+1) contributes error_factor*(1+a) + error_factor*(1-a)
@@ -1469,21 +1758,14 @@ class MeasurementChannel:
         composed = self.process @ other.process
         return replace(self, process=composed)
 
-    def __or__(self, other: _ChannelBase | _ResetChannelBase | MeasurementChannel) -> CycleChannel:
-        """Tensor product of two channels on disjoint qubits, producing a CycleChannel.
+    def __or__(self, other: CycleConstituent | CycleChannel) -> CycleChannel:
+        """Tensor product with another channel on disjoint qubits, producing a CycleChannel.
 
-        :param other: Another gate channel, reset channel, or MeasurementChannel on disjoint qubits.
+        :param other: Another gate, reset, or measurement channel — or a
+            :class:`CycleChannel`, whose constituents are flattened in — on disjoint qubits.
         :return: A CycleChannel representing the tensor product.
         """
-        if not isinstance(other, (_ChannelBase, _ResetChannelBase, MeasurementChannel)):
-            return NotImplemented
-
-        self_qubits = set(self.qubits)
-        other_qubits = set(other.qubits)
-        if self_qubits & other_qubits:
-            raise ValueError(f"Cannot tensor channels with overlapping qubits: {self_qubits & other_qubits}")
-
-        return _build_cycle_channel([self, other])
+        return _tensor_into_cycle(self, other)
 
 
 class _ResetChannelBase(ABC):
@@ -1496,6 +1778,8 @@ class _ResetChannelBase(ABC):
     :class:`ResetChannel`.
     """
 
+    # Declared under TYPE_CHECKING rather than as abstract properties for the same reason as in
+    # :class:`_ChannelBase` — an abstract property collides with the subclass dataclass field.
     if TYPE_CHECKING:
         inst: ResetQubit
         process: qx.SuperOp
@@ -1519,10 +1803,8 @@ class _ResetChannelBase(ABC):
     @property
     def qubits(self) -> list[int]:
         """The qubit(s) that the reset applies to."""
-        qubit = self.inst.qubit
-        if qubit is None:
-            return []
-        return [qubit.index if hasattr(qubit, "index") else int(qubit)]
+        indices = self.inst.get_qubit_indices()
+        return [] if indices is None else list(indices)
 
     @cached_property
     def _ideal_reset(self) -> qx.SuperOp:
@@ -1530,15 +1812,20 @@ class _ResetChannelBase(ABC):
         return qx.gates.RESET(dim=self.process.dims[0][0])
 
     @cached_property
-    def fidelity(self) -> float:
-        r"""Process fidelity of the reset channel relative to the ideal reset :math:`F_e \in [0, 1]`."""
+    def process_fidelity(self) -> float:
+        r"""Process fidelity of the reset channel relative to the ideal reset :math:`F_e \in [0, 1]`.
+
+        Named to match ``quax.process_fidelity`` — and, deliberately, *not* ``fidelity``: on gate
+        channels that name means the average gate fidelity, which is a different quantity.
+        """
         return float(qx.process_fidelity(self.process, self._ideal_reset))
 
-    def as_post_gate_noise(self) -> qx.SuperOp:
-        r"""Return the noise as a superoperator applied *after* the ideal reset.
+    @cached_property
+    def error_process(self) -> qx.SuperOp:
+        r"""The error, as a superoperator applied *after* the ideal reset.
 
         The full channel factors as :math:`\mathcal{E} = \mathcal{N} \circ \mathcal{R}`, where
-        :math:`\mathcal{R}` is the ideal reset and :math:`\mathcal{N}` the post-reset noise.
+        :math:`\mathcal{R}` is the ideal reset and :math:`\mathcal{N}` the post-reset error.
         The ideal reset is not invertible, so :math:`\mathcal{N}` is recovered with its
         Moore-Penrose pseudo-inverse, :math:`\mathcal{N} = \mathcal{E} \circ \mathcal{R}^{+}`.
         This is exact for channels built as noise-after-reset (e.g.
@@ -1553,21 +1840,23 @@ class _ResetChannelBase(ABC):
     def plot(self, only_noise: bool = False) -> Figure:
         """Plot the Pauli transfer matrix of the reset channel.
 
-        :param only_noise: If True, plot the post-reset noise (see :meth:`as_post_gate_noise`)
+        :param only_noise: If True, plot the post-reset error (see :attr:`error_process`)
             instead of the full process. Defaults to False (the full channel).
         :return: A Plotly Figure.
         """
-        channel = self.as_post_gate_noise() if only_noise else self.process
-        title_prefix = "Reset noise" if only_noise else "Reset channel"
+        channel = self.error_process if only_noise else self.process
+        title_prefix = "Reset error" if only_noise else "Reset channel"
         fig = qx.plot(channel)
         qubit_str = str(self.qubits[0]) if self.qubits else "?"
-        fig.update_layout(title=(f"{title_prefix} RESET {qubit_str}<br><sub>F_χ={self.fidelity * 100:.2f}%</sub>"))
+        fig.update_layout(
+            title=(f"{title_prefix} RESET {qubit_str}<br><sub>F_χ={self.process_fidelity * 100:.2f}%</sub>")
+        )
         return fig
 
     def __str__(self) -> str:
         """Return a simplified string representation."""
         qubit_str = str(self.qubits[0]) if self.qubits else "?"
-        return f"<RESET({self.fidelity:.2f}) {qubit_str}>"
+        return f"<RESET({self.process_fidelity:.2f}) {qubit_str}>"
 
     def __eq__(self, other: object) -> bool:
         """Check equality by concrete type, instruction, and (approximate) process matrix.
@@ -1585,23 +1874,17 @@ class _ResetChannelBase(ABC):
 
     __hash__ = None  # type: ignore[assignment]
 
-    def __or__(self, other: _ChannelBase | _ResetChannelBase | MeasurementChannel) -> CycleChannel:
+    def __or__(self, other: CycleConstituent | CycleChannel) -> CycleChannel:
         """Tensor product with another channel on disjoint qubits, producing a CycleChannel.
 
-        :param other: Another gate channel, reset channel, or MeasurementChannel on disjoint qubits.
+        :param other: Another gate, reset, or measurement channel — or a
+            :class:`CycleChannel`, whose constituents are flattened in — on disjoint qubits.
         :return: A CycleChannel representing the tensor product.
         """
-        if not isinstance(other, (_ChannelBase, _ResetChannelBase, MeasurementChannel)):
-            return NotImplemented
-
-        self_qubits = set(self.qubits)
-        other_qubits = set(other.qubits)
-        if self_qubits & other_qubits:
-            raise ValueError(f"Cannot tensor channels with overlapping qubits: {self_qubits & other_qubits}")
-
-        return _build_cycle_channel([self, other])
+        return _tensor_into_cycle(self, other)
 
 
+@final
 @dataclass(frozen=True, eq=False)
 class SuperopResetChannel(_ResetChannelBase):
     """A reset noise channel attaches a superoperator to a specific reset operation.
@@ -1627,24 +1910,43 @@ class SuperopResetChannel(_ResetChannelBase):
         fidelity: float,
         dim: int = 2,
     ) -> SuperopResetChannel:
-        r"""Create a SuperopResetChannel with depolarizing noise scaled to the given process fidelity.
+        r"""Create a SuperopResetChannel whose :attr:`~_ResetChannelBase.process_fidelity` is ``fidelity``.
 
         The ideal reset maps every state to :math:`|0\rangle\langle 0|`; noise is a depolarizing
         channel applied *after* it, so the process is ``depolarizing @ RESET`` — every state is
-        reset and then shrunk toward the maximally-mixed state by a factor ``fidelity``.
+        reset and then shrunk toward the maximally-mixed state.
+
+        The depolarizing shrink factor is *not* the resulting fidelity. Because the ideal reset is
+        rank one, the process fidelity of ``depolarizing_p @ RESET`` against ``RESET`` is
+        :math:`F = (1 + (d - 1) p) / d`, so the shrink factor is obtained by inverting that:
+        :math:`p = (d F - 1) / (d - 1)`. The channel therefore reports back exactly the
+        ``fidelity`` requested here.
 
         :param inst: The reset instruction.
-        :param fidelity: Process fidelity of the reset channel, :math:`F \in [0, 1]`.
-            1.0 yields an ideal reset; values below 1 introduce depolarizing noise.
+        :param fidelity: Process fidelity of the reset channel, :math:`F \in [1/d, 1]`.
+            1.0 yields an ideal reset; values below 1 introduce depolarizing noise. The floor is
+            :math:`1/d` because a fully depolarizing reset still has that much overlap with the
+            ideal one.
         :param dim: Hilbert-space dimension (2 for qubits).
         :return: A SuperopResetChannel instance.
+        :raises ValueError: If ``dim < 2`` or ``fidelity`` lies outside :math:`[1/d, 1]`.
         """
         if not isinstance(inst, ResetQubit):
             raise TypeError("SuperopResetChannel only supports targeted ResetQubit instructions.")
+        if dim < 2:
+            raise ValueError(f"Reset dimension must be at least 2, got dim={dim}.")
+        minimum_fidelity = 1.0 / dim
+        if not minimum_fidelity <= fidelity <= 1.0:
+            raise ValueError(
+                f"Reset process fidelity must lie in [{minimum_fidelity}, 1] for dim={dim}, got {fidelity}. "
+                f"A fully depolarized reset already has process fidelity {minimum_fidelity}."
+            )
 
-        # Depolarizing rate whose evolution shrinks every traceless operator by exactly ``fidelity``.
+        # Invert F = (1 + (d - 1) p) / d to get the depolarizing shrink factor, then pick the rate
+        # whose evolution shrinks every traceless operator by exactly that factor.
+        depolarizing_constant = (dim * fidelity - 1.0) / (dim - 1.0)
         d2 = dim * dim
-        shrink = float(np.clip(fidelity, np.finfo(float).tiny, 1.0))
+        shrink = max(depolarizing_constant, np.finfo(float).tiny)
         gamma = -np.log(shrink) * (d2 - 1) / d2
         depol = qx.channels.depolarizing(gamma, (dim,))
         noisy_superop = qx.to_superop(depol @ qx.gates.RESET(dim=dim))
@@ -1683,6 +1985,7 @@ class SuperopResetChannel(_ResetChannelBase):
         return cls(inst=inst, process=process)
 
 
+@final
 @dataclass(frozen=True, eq=False)
 class ResetChannel(_LindbladianBacked, _ResetChannelBase):
     """A reset channel modeled as finite-time relaxation toward the ground state.
@@ -1700,15 +2003,15 @@ class ResetChannel(_LindbladianBacked, _ResetChannelBase):
     lindbladian: qx.Lindbladian
     """The dissipative generator whose evolution over ``gate_time`` relaxes toward the ground state."""
 
-    gate_time: float = 1.0
-    """Evolution time for ``evolve(lindbladian, gate_time)``. Default 1.0 (dimensionless)."""
+    gate_time: float = _DEFAULT_GATE_TIME
+    """Evolution time for ``evolve(lindbladian, gate_time)``. See :data:`_DEFAULT_GATE_TIME`."""
 
     @classmethod
     def from_lindbladian(
         cls: type[ResetChannel],
         inst: ResetQubit,
         lindbladian: qx.Lindbladian,
-        gate_time: float = 1.0,
+        gate_time: float = _DEFAULT_GATE_TIME,
     ) -> ResetChannel:
         """Create a reset channel directly from a dissipative relaxation generator."""
         return cls(inst=inst, lindbladian=lindbladian, gate_time=gate_time)
@@ -1718,7 +2021,7 @@ class ResetChannel(_LindbladianBacked, _ResetChannelBase):
         cls: type[ResetChannel],
         inst: ResetQubit,
         gamma: float,
-        gate_time: float = 1.0,
+        gate_time: float = _DEFAULT_GATE_TIME,
         dim: int = 2,
     ) -> ResetChannel:
         """Create a reset channel from an amplitude-damping (decay-to-ground) generator.
@@ -1736,9 +2039,16 @@ class ResetChannel(_LindbladianBacked, _ResetChannelBase):
         t1: float,
         t2: float | None = None,
     ) -> ResetChannel:
-        """Create a reset channel from T1/T2 relaxation over ``duration`` (used as ``gate_time``)."""
+        """Create a reset channel from T1/T2 relaxation over ``duration`` (used as ``gate_time``).
+
+        :param inst: The targeted reset instruction.
+        :param duration: How long the reset is allowed to relax (used as ``gate_time``).
+        :param t1: The T1 relaxation time.
+        :param t2: The T2 coherence time. Defaults to ``2 * t1`` (no pure dephasing). Must not
+            exceed ``2 * t1``; see :func:`_pure_dephasing_times`.
+        """
         t2_value = 2 * t1 if t2 is None else t2
-        tphi = 1 / (1 / t2_value - 1 / t1)
+        (tphi,) = _pure_dephasing_times([t1], [t2_value])
         return cls.from_lindbladian(inst, qx.lindbladians.thermal_relaxation(t1, tphi), duration)
 
     def __pow__(self, power: float) -> ResetChannel:
@@ -1778,10 +2088,11 @@ class ResetChannel(_LindbladianBacked, _ResetChannelBase):
         return cls(inst=inst, lindbladian=lindbladian, gate_time=data["gate_time"])
 
 
-# A single operation within a cycle: a gate channel, a reset channel, or a measurement channel.
-CycleConstituent = _ChannelBase | _ResetChannelBase | MeasurementChannel
+CycleConstituent: TypeAlias = _ChannelBase | _ResetChannelBase | MeasurementChannel
+"""A single operation within a cycle: a gate channel, a reset channel, or a measurement channel."""
 
 
+@final
 @dataclass(frozen=True)
 class CycleChannel:
     """A cycle noise channel attaches superoperators to a specific cycle.
@@ -1804,23 +2115,23 @@ class CycleChannel:
 
         Downstream consumers (the resolver, the stim converter) use only ``channels`` and
         ignore ``defcircuit``; a missing channel would silently drop that operation's noise.
-        Operations are matched by identity (name, params, concrete qubits), independent of
-        the DefCircuit's formal-argument naming.
+        Operations are matched by instruction equality (name, params, concrete qubits),
+        independent of the DefCircuit's formal-argument naming.
         """
         if len(self.expanded_instructions) != len(self.channels):
             raise ValueError(
                 "CycleChannel is incomplete: every instruction in the cycle's DefCircuit "
                 "body must have a corresponding channel. "
-                f"\nDefCircuit body: {self.expanded_instructions}"
-                f"\nChannels:        {self.channels}"
+                f"\nDefCircuit body: {[str(i) for i in self.expanded_instructions]}"
+                f"\nChannels:        {[str(c.inst) for c in self.channels]}"
             )
         for instruction, channel in zip(self.expanded_instructions, self.channels, strict=True):
-            if str(instruction) != str(channel.inst):
+            if instruction != channel.inst:
                 raise ValueError(
-                    "CycleChannel is incomplete: every instruction in the cycle's DefCircuit "
-                    "body must have a corresponding channel. "
+                    "CycleChannel is inconsistent: each instruction in the cycle's DefCircuit "
+                    "body must match its corresponding channel's instruction. "
                     f"\nDefCircuit body: {instruction}"
-                    f"\nChannels:        {channel.inst}"
+                    f"\nChannel:         {channel.inst}"
                 )
 
     # ──────────────────────────────────────────────
@@ -1828,21 +2139,42 @@ class CycleChannel:
     # ──────────────────────────────────────────────
 
     @cached_property
-    def expanded_instructions(self) -> list[Gate | Measurement | ResetQubit]:
-        """Return the expanded instructions of the defcircuit."""
-        qarg_to_qubit = dict(zip(self.defcircuit.qubit_variables, self.inst.get_qubit_indices(), strict=False))
+    def expanded_instructions(self) -> tuple[Gate | Measurement | ResetQubit, ...]:
+        """The defcircuit's body with its formal arguments substituted for concrete qubits.
+
+        Returns a tuple rather than a list: this is a cached property on a frozen dataclass, so a
+        mutable result would let a caller corrupt the cache.
+        """
+        formal_arguments = self.defcircuit.qubit_variables
+        cycle_qubits = self.inst.get_qubit_indices()
+        if len(formal_arguments) != len(cycle_qubits):
+            raise ValueError(
+                f"Cycle instruction {self.inst.out()} supplies {len(cycle_qubits)} qubit(s) but "
+                f"DEFCIRCUIT {self.defcircuit.name} declares {len(formal_arguments)} formal "
+                f"argument(s) ({[str(a) for a in formal_arguments]})."
+            )
+        qarg_to_qubit = dict(zip(formal_arguments, cycle_qubits, strict=True))
+
+        def resolve(qubit: Any) -> int:
+            if qubit not in qarg_to_qubit:
+                raise ValueError(
+                    f"DEFCIRCUIT {self.defcircuit.name} body references {qubit}, which is not one "
+                    f"of its formal arguments ({[str(a) for a in formal_arguments]})."
+                )
+            return qarg_to_qubit[qubit]
+
         instructions: list[Gate | Measurement | ResetQubit] = []
         for inst in self.defcircuit.instructions:
             match inst:
                 case Measurement():
-                    instructions.append(Measurement(qubit=qarg_to_qubit[inst.qubit], classical_reg=inst.classical_reg))  # type: ignore[index]
+                    instructions.append(Measurement(qubit=resolve(inst.qubit), classical_reg=inst.classical_reg))
                 case ResetQubit():
-                    instructions.append(ResetQubit(qarg_to_qubit[inst.qubit]))  # type: ignore[index]
+                    instructions.append(ResetQubit(resolve(inst.qubit)))
                 case Gate():
-                    instructions.append(Gate(inst.name, inst.params, [qarg_to_qubit[q] for q in inst.qubits]))  # type: ignore[index]
+                    instructions.append(Gate(inst.name, inst.params, [resolve(q) for q in inst.qubits]))
                 case _:
                     raise TypeError(f"Unsupported instruction type in defcircuit: {type(inst).__name__}")
-        return instructions
+        return tuple(instructions)
 
     @cached_property
     def operator(self) -> tuple[qx.SuperOp | qx.QuantumInstrument, ...]:
@@ -1854,41 +2186,57 @@ class CycleChannel:
         """All qubits in the cycle, derived from the instruction."""
         return self.inst.get_qubit_indices()
 
+    @property
+    def _gate_channels(self) -> tuple[_ChannelBase, ...]:
+        """The gate channels in the cycle; the only constituents carrying a gate fidelity."""
+        return tuple(ch for ch in self.channels if isinstance(ch, _ChannelBase))
+
     @cached_property
-    def pauli_fidelity(self) -> float:
+    def process_fidelity(self) -> float:
         """Product of process (Pauli) fidelities over all gate channels in the cycle.
 
-        Reset and measurement channels do not contribute a gate fidelity and are skipped.
-        For near-ideal noise the product approximation is exact since constituent
-        channels act on disjoint subsystems.
+        The product is *exact*: process fidelity is multiplicative over a tensor product, and the
+        constituent channels act on disjoint subsystems by construction.
+
+        .. warning::
+            Reset and measurement channels carry no gate fidelity and are skipped entirely, so a
+            cycle made only of measurements reports 1.0 here however noisy its readout is. Read
+            readout quality off the constituent :class:`MeasurementChannel` objects
+            (:attr:`~MeasurementChannel.classification_fidelity` and friends) instead.
         """
         f = 1.0
-        for ch in self.channels:
-            if isinstance(ch, _ChannelBase):
-                f *= ch.pauli_fidelity
+        for ch in self._gate_channels:
+            f *= ch.process_fidelity
         return f
 
     @cached_property
-    def fidelity(self) -> float:
-        """Product of average gate fidelities over all gate channels in the cycle.
+    def average_gate_fidelity(self) -> float:
+        """Average gate fidelity of the cycle's gate channels, taken as a whole.
 
-        Reset and measurement channels do not contribute a gate fidelity and are skipped.
+        Unlike the process fidelity, average gate fidelity is *not* multiplicative over a tensor
+        product: the process-to-average conversion depends on the total dimension. So this converts
+        once, from the exact :attr:`process_fidelity` product, using the combined dimensions of
+        every gate channel in the cycle — rather than multiplying the constituents' average
+        fidelities, which would overstate the result.
+
+        The same caveat as :attr:`process_fidelity` applies: reset and measurement channels are
+        skipped.
         """
-        f = 1.0
-        for ch in self.channels:
-            if isinstance(ch, _ChannelBase):
-                f *= ch.fidelity
-        return f
+        gate_channels = self._gate_channels
+        if not gate_channels:
+            return 1.0
+        dims = tuple(dim for ch in gate_channels for dim in ch.dims)
+        return float(qx.process_fidelity_to_average_fidelity(self.process_fidelity, dims=dims))
 
     @cached_property
-    def infidelity(self) -> float:
-        """``1 - fidelity``."""
-        return 1.0 - self.fidelity
+    def average_gate_infidelity(self) -> float:
+        """``1 - average_gate_fidelity``."""
+        return 1.0 - self.average_gate_fidelity
 
     @cached_property
-    def pauli_infidelity(self) -> float:
-        """``1 - pauli_fidelity``."""
-        return 1.0 - self.pauli_fidelity
+    def process_infidelity(self) -> float:
+        """``1 - process_fidelity``."""
+        return 1.0 - self.process_fidelity
 
     # ──────────────────────────────────────────────
     # Serialization
@@ -1897,22 +2245,22 @@ class CycleChannel:
     def to_json(self) -> str:
         """Serialize CycleChannel to a JSON string.
 
+        The cycle instruction and its ``DEFCIRCUIT`` are written out alongside the constituent
+        channels, so a cycle built elsewhere (with its own name, formal arguments, or body
+        ordering) survives a round trip rather than being rebuilt as a generic ``CYCLE``.
+
         :return: JSON string representation.
         """
-        ch_data = []
-        for ch in self.channels:
-            ch_data.append({"type": type(ch).__name__, "data": ch.to_json()})
         data = {
-            "channels": ch_data,
+            "inst": self.inst.out(),
+            "defcircuit": self.defcircuit.out(),
+            "channels": [{"type": type(ch).__name__, "data": ch.to_json()} for ch in self.channels],
         }
         return json.dumps(data)
 
     @classmethod
     def from_json(cls: type[CycleChannel], json_str: str) -> CycleChannel:
         """Deserialize a CycleChannel from a JSON string.
-
-        The ``inst`` and ``defcircuit`` fields are reconstructed from the constituent
-        channels, consistent with how :func:`_build_cycle_channel` builds them.
 
         :param json_str: JSON string as produced by :meth:`to_json`.
         :return: CycleChannel instance.
@@ -1928,7 +2276,16 @@ class CycleChannel:
         constituent_channels: list[CycleConstituent] = [
             _type_map[ch_data["type"]].from_json(ch_data["data"]) for ch_data in data["channels"]
         ]
-        return _build_cycle_channel(constituent_channels)
+
+        # Older payloads carried only the constituents; rebuild the generic cycle for those.
+        if "defcircuit" not in data or "inst" not in data:
+            return _build_cycle_channel(constituent_channels)
+
+        inst = _parse_quil_instruction(data["inst"])
+        if not isinstance(inst, Gate):
+            raise TypeError(f"CycleChannel JSON must contain a gate instruction, got {type(inst).__name__}.")
+        defcircuit = _parse_defcircuit(data["defcircuit"])
+        return cls(inst=inst, defcircuit=defcircuit, channels=tuple(constituent_channels))
 
     # ──────────────────────────────────────────────
     # Dunder methods
@@ -1936,17 +2293,27 @@ class CycleChannel:
 
     def __str__(self) -> str:
         """Return a simplified string representation showing the gate and process fidelity."""
-        return f"<{self.inst.out()} ~ ({100 * self.pauli_fidelity:.2f}%)>"
+        return f"<{self.inst.out()} ~ ({100 * self.process_fidelity:.2f}%)>"
 
     def __eq__(self, other: object) -> bool:
-        """Check equality based on instruction and constituent channels."""
+        """Check equality by cycle instruction, DefCircuit, and constituent channels."""
         if not isinstance(other, CycleChannel):
             return False
-        if self.inst != other.inst:
-            return False
-        return self.channels == other.channels
+        return self.inst == other.inst and self.defcircuit == other.defcircuit and self.channels == other.channels
 
     __hash__ = None  # type: ignore[assignment]
+
+    def __or__(self, other: CycleConstituent | CycleChannel) -> CycleChannel:
+        """Tensor another channel into this cycle, producing a wider CycleChannel.
+
+        Lets cycles be built up left to right (``a | b | c``). A :class:`CycleChannel` operand has
+        its constituents flattened in, so the result is always a flat cycle.
+
+        :param other: Another gate, reset, or measurement channel, or another CycleChannel, on
+            qubits disjoint from this cycle's.
+        :return: A CycleChannel containing every constituent operation.
+        """
+        return _tensor_into_cycle(self, other)
 
 
 def _channel_to_formal_inst(channel: CycleConstituent) -> Gate | Measurement | ResetQubit:
@@ -1987,3 +2354,36 @@ def _build_cycle_channel(
     )
     inst = Gate(name=cycle_name, params=[], qubits=all_qubits)
     return CycleChannel(inst=inst, defcircuit=defcircuit, channels=tuple(channels))
+
+
+def _tensor_into_cycle(
+    left: CycleConstituent | CycleChannel,
+    right: CycleConstituent | CycleChannel,
+) -> CycleChannel:
+    """Tensor two channels on disjoint qubits into a single flat :class:`CycleChannel`.
+
+    Shared by every ``__or__`` implementation so that ``|`` is closed over cycles: either operand
+    may itself be a :class:`CycleChannel`, in which case its constituents are flattened in and
+    ``a | b | c`` builds one three-operation cycle rather than failing on the second ``|``.
+    """
+    if not isinstance(left, (_ChannelBase, _ResetChannelBase, MeasurementChannel, CycleChannel)):
+        return NotImplemented
+    if not isinstance(right, (_ChannelBase, _ResetChannelBase, MeasurementChannel, CycleChannel)):
+        return NotImplemented
+
+    overlap = set(left.qubits) & set(right.qubits)
+    if overlap:
+        raise ValueError(f"Cannot tensor channels with overlapping qubits: {overlap}")
+
+    def constituents(channel: CycleConstituent | CycleChannel) -> list[CycleConstituent]:
+        return list(channel.channels) if isinstance(channel, CycleChannel) else [channel]
+
+    return _build_cycle_channel(constituents(left) + constituents(right))
+
+
+def _parse_defcircuit(quil_str: str) -> DefCircuit:
+    """Parse a ``DEFCIRCUIT`` block back into a pyquil :class:`~pyquil.quilbase.DefCircuit`."""
+    rs_inst = RSInstruction.parse(quil_str)
+    if not rs_inst.is_circuit_definition():
+        raise ValueError(f"Expected a DEFCIRCUIT definition, got: {quil_str}")
+    return DefCircuit._from_rs_circuit_definition(rs_inst.to_circuit_definition())

--- a/pyquil/noise/_channels.py
+++ b/pyquil/noise/_channels.py
@@ -27,7 +27,7 @@ import itertools
 import json
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from functools import cached_property, reduce
 from itertools import product
@@ -42,7 +42,7 @@ from quil.expression import Expression as QuilExpression
 from quil.instructions import Instruction as RSInstruction
 from scipy.linalg import logm as scipy_logm
 
-from pyquil.quilatom import Expression, FormalArgument, MemoryReference, Parameter, substitute
+from pyquil.quilatom import Expression, FormalArgument, MemoryReference, Parameter, ParameterDesignator, substitute
 from pyquil.quilbase import DefCircuit, DefGate, Gate, Measurement, Reset, ResetQubit, _integer_base_and_exponent
 
 if TYPE_CHECKING:
@@ -54,11 +54,6 @@ logger = logging.getLogger(__name__)
 
 # Type alias for the custom-gate lookup map used throughout the SuperopChannel constructors.
 CustomGateMap = dict[str, qx.Unitary | Callable[..., qx.Unitary]]
-
-
-# A gate parameter that :func:`_resolve_params` can reduce to a concrete float. The ``complex``
-# arm covers concrete numbers (``int``/``float``/``complex`` via the typing numeric tower).
-ResolvableParam = Parameter | Expression | QuilExpression | complex
 
 
 def _parse_quil_instruction(quil_str: str) -> Gate | Measurement | Reset:
@@ -113,7 +108,7 @@ def _pack_operator(operator: qx.SuperOp | qx.Unitary | qx.Choi | qx.Observable |
     return data
 
 
-def _resolve_params(params: list[ResolvableParam]) -> list[float]:
+def _resolve_params(params: Sequence[ParameterDesignator]) -> list[float]:
     """Resolve gate parameters to concrete float values.
 
     Gate parameters are expected to be real. If a parameter evaluates to a complex number with a
@@ -218,7 +213,7 @@ def get_instruction_unitary(
         raise KeyError(f"Unknown gate '{name}'. Provide it via custom_gates (e.g. custom_gates={{'{name}': matrix}}).")
 
     if inst.params:
-        fixed_params = _resolve_params(list(inst.params))
+        fixed_params = _resolve_params(inst.params)
         if not callable(gate_def):
             raise ValueError(f"Gate '{name}' is not parametric but parameters were provided.")
         result = gate_def(*fixed_params)
@@ -289,7 +284,7 @@ class _ChannelBase(ABC):
     # ──────────────────────────────────────────────
 
     def as_post_gate_noise(self) -> qx.SuperOp:
-        r"""The noise as a superoperator applied *after* the ideal gate.
+        r"""Return the noise as a superoperator applied *after* the ideal gate.
 
         A noisy gate channel can be viewed either as noise applied after the ideal gate
         (*post-gate*) or before it (*pre-gate*):
@@ -514,11 +509,11 @@ class _ChannelBase(ABC):
         """
         if type(self) is not type(other):
             return False
-        if self.inst != other.inst:  # type: ignore[attr-defined]
+        if self.inst != other.inst:
             return False
         return bool(
-            jnp.allclose(self.process.matrix, other.process.matrix)  # type: ignore[attr-defined]
-            and jnp.allclose(self.unitary.matrix, other.unitary.matrix)  # type: ignore[attr-defined]
+            jnp.allclose(self.process.matrix, other.process.matrix)
+            and jnp.allclose(self.unitary.matrix, other.unitary.matrix)
         )
 
     __hash__ = None  # type: ignore[assignment]
@@ -1540,7 +1535,7 @@ class _ResetChannelBase(ABC):
         return float(qx.process_fidelity(self.process, self._ideal_reset))
 
     def as_post_gate_noise(self) -> qx.SuperOp:
-        r"""The noise as a superoperator applied *after* the ideal reset.
+        r"""Return the noise as a superoperator applied *after* the ideal reset.
 
         The full channel factors as :math:`\mathcal{E} = \mathcal{N} \circ \mathcal{R}`, where
         :math:`\mathcal{R}` is the ideal reset and :math:`\mathcal{N}` the post-reset noise.
@@ -1584,9 +1579,9 @@ class _ResetChannelBase(ABC):
         """
         if type(self) is not type(other):
             return False
-        if self.inst != other.inst:  # type: ignore[attr-defined]
+        if self.inst != other.inst:
             return False
-        return bool(jnp.allclose(self.process.matrix, other.process.matrix))  # type: ignore[attr-defined]
+        return bool(jnp.allclose(self.process.matrix, other.process.matrix))
 
     __hash__ = None  # type: ignore[assignment]
 

--- a/pyquil/noise/_legacy_noise.py
+++ b/pyquil/noise/_legacy_noise.py
@@ -123,8 +123,8 @@ _NoiseModel = namedtuple("_NoiseModel", ["gates", "assignment_probs"])
 
 @deprecated(
     version="4.17.0",
-    reason="Use the quax-based noise model in pyquil.noise._noise_model instead. "
-    "This class will be removed in the next major version of pyquil.",
+    reason="Use the quax-based noise model, which will become the public API in the next major "
+    "version of pyquil. This class will be removed at that time.",
 )
 class NoiseModel(_NoiseModel):
     """Encapsulate the QPU noise model containing information about the noisy gates.

--- a/pyquil/noise/_legacy_noise.py
+++ b/pyquil/noise/_legacy_noise.py
@@ -21,7 +21,6 @@ from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 import numpy as np
-from deprecated import deprecated
 
 from pyquil.external.rpcq import CompilerISA
 from pyquil.gates import MEASURE, RX, I
@@ -42,8 +41,10 @@ _KrausModel = namedtuple("_KrausModel", ["gate", "params", "targets", "kraus_ops
 class KrausModel(_KrausModel):
     """Encapsulate a single gate's noise model.
 
-    .. deprecated::
-        Use :class:`pyquil.noise.Channel` for quax-based noise modeling.
+    .. note::
+        This is the original Kraus-map noise model, used by the QVM. A quax-backed replacement
+        lives in ``pyquil.noise._channels``; it is not yet part of the public API, so this class
+        remains the supported way to describe QVM noise and is not deprecated.
 
     :ivar str gate: The name of the gate.
     :ivar Sequence[float] params: Optional parameters for the gate.
@@ -121,13 +122,16 @@ class KrausModel(_KrausModel):
 _NoiseModel = namedtuple("_NoiseModel", ["gates", "assignment_probs"])
 
 
-@deprecated(
-    version="4.17.0",
-    reason="Use the quax-based noise model, which will become the public API in the next major "
-    "version of pyquil. This class will be removed at that time.",
-)
 class NoiseModel(_NoiseModel):
     """Encapsulate the QPU noise model containing information about the noisy gates.
+
+    .. note::
+        This is the original Kraus-map noise model, used by the QVM and by
+        :func:`~pyquil.api.get_qc`. A quax-backed replacement lives in
+        ``pyquil.noise._channels`` / ``pyquil.noise._noise_model``; until that becomes public,
+        this class is the supported way to describe QVM noise. It is therefore not deprecated —
+        marking it so would warn users of ``get_qc(..., noisy=True)`` about pyQuil's own internal
+        use of it, with no importable alternative to move to.
 
     :ivar Sequence[KrausModel] gates: The tomographic estimates of all gates.
     :ivar dict[int,np.array] assignment_probs: The single qubit readout assignment

--- a/pyquil/noise/_legacy_noise.py
+++ b/pyquil/noise/_legacy_noise.py
@@ -21,6 +21,7 @@ from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 import numpy as np
+from deprecated import deprecated
 
 from pyquil.external.rpcq import CompilerISA
 from pyquil.gates import MEASURE, RX, I
@@ -40,6 +41,9 @@ _KrausModel = namedtuple("_KrausModel", ["gate", "params", "targets", "kraus_ops
 
 class KrausModel(_KrausModel):
     """Encapsulate a single gate's noise model.
+
+    .. deprecated::
+        Use :class:`pyquil.noise.Channel` for quax-based noise modeling.
 
     :ivar str gate: The name of the gate.
     :ivar Sequence[float] params: Optional parameters for the gate.
@@ -117,6 +121,11 @@ class KrausModel(_KrausModel):
 _NoiseModel = namedtuple("_NoiseModel", ["gates", "assignment_probs"])
 
 
+@deprecated(
+    version="4.17.0",
+    reason="Use the quax-based noise model in pyquil.noise._noise_model instead. "
+    "This class will be removed in the next major version of pyquil.",
+)
 class NoiseModel(_NoiseModel):
     """Encapsulate the QPU noise model containing information about the noisy gates.
 

--- a/pyquil/noise/_noise_model.py
+++ b/pyquil/noise/_noise_model.py
@@ -30,17 +30,20 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
-from functools import reduce
-from operator import mul
+from dataclasses import dataclass, field
+from functools import lru_cache
 from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Protocol,
+    TypeAlias,
     overload,
     runtime_checkable,
 )
+
+from deprecated import deprecated
 
 from pyquil.external.rpcq import CompilerISA
 from pyquil.noise._channels import (
@@ -51,11 +54,12 @@ from pyquil.noise._channels import (
     SuperopChannel,
     SuperopResetChannel,
     _ChannelBase,
-    _ResetChannelBase,
 )
 from pyquil.quilbase import Gate, Measurement, ResetQubit
 
 if TYPE_CHECKING:
+    from qcs_sdk.qpu.isa import InstructionSetArchitecture
+
     from pyquil import Program
     from pyquil.paulis import PauliSum, PauliTerm
 
@@ -65,9 +69,13 @@ logger = logging.getLogger(__name__)
 # Protocol
 # ──────────────────────────────────────────────────────────
 
-# Channel union type returned by get_channel
-ChannelType = SuperopChannel | Channel | MeasurementChannel | SuperopResetChannel | ResetChannel | CycleChannel
-NoiseInstruction = Gate | Measurement | ResetQubit
+ChannelType: TypeAlias = (
+    SuperopChannel | Channel | MeasurementChannel | SuperopResetChannel | ResetChannel | CycleChannel
+)
+"""Any noise channel that :meth:`NoiseModelLike.get_channel` may return."""
+
+NoiseInstruction: TypeAlias = Gate | Measurement | ResetQubit
+"""Any instruction a noise channel may be attached to."""
 
 
 @runtime_checkable
@@ -80,6 +88,11 @@ class NoiseModelLike(Protocol):
     consumers.
 
     The standard concrete implementation is :class:`NoiseModel`.
+
+    .. note::
+        This protocol is ``runtime_checkable``, so ``isinstance`` checks only verify that a
+        ``get_channel`` *attribute* exists — not that its signature matches. Do not rely on
+        ``isinstance`` to validate a candidate noise model.
     """
 
     @overload
@@ -112,26 +125,26 @@ class NoiseModel:
     or other channel iterable.
     """
 
-    channels: Mapping[NoiseInstruction, ChannelType]
-    """Immutable mapping from instruction to its noise channel."""
+    channels: Mapping[NoiseInstruction, ChannelType] = field(default_factory=dict)
+    """Immutable mapping from instruction to its noise channel.
 
-    def __init__(
-        self,
-        channels: Mapping[NoiseInstruction, ChannelType] | None = None,
-    ) -> None:
-        if channels is None:
-            channels = {}
+    Wrapped in a :class:`types.MappingProxyType` by ``__post_init__``, so the mapping passed in
+    cannot be mutated through the model afterwards. (``MappingProxyType`` is used in preference to
+    a third-party frozen-dict type to keep pyQuil's dependency surface unchanged.)
+    """
+
+    def __post_init__(self) -> None:
+        """Validate that every key matches its channel's instruction, and freeze the mapping."""
+        channels = self.channels
         if not isinstance(channels, Mapping):
             raise TypeError("NoiseModel channels must be a mapping. Use NoiseModel.from_channels(...) for iterables.")
 
-        channel_map: dict[NoiseInstruction, ChannelType] = {}
         for inst, channel in channels.items():
             if channel.inst != inst:
                 raise ValueError(
                     f"NoiseModel channel key {inst!r} does not match channel instruction {channel.inst!r}."
                 )
-            channel_map[inst] = channel
-        object.__setattr__(self, "channels", MappingProxyType(channel_map))
+        object.__setattr__(self, "channels", MappingProxyType(dict(channels)))
 
     def __getstate__(self) -> dict[str, dict[NoiseInstruction, ChannelType]]:
         # ``channels`` is a MappingProxyType (unpicklable); serialize it as a plain dict.
@@ -177,12 +190,39 @@ class NoiseModel:
         return cls(channels=channel_map)
 
     @classmethod
-    def from_isa(cls: type[NoiseModel], compiler_isa: CompilerISA) -> NoiseModel:
-        """Create a noise model from an instruction set architecture.
+    def from_isa(cls: type[NoiseModel], isa: InstructionSetArchitecture) -> NoiseModel:
+        """Create a noise model from a QCS ``InstructionSetArchitecture``.
+
+        This is the preferred ISA entry point: it takes the ``qcs_sdk`` ISA returned by
+        :func:`qcs_sdk.qpu.isa.get_instruction_set_architecture`, rather than the legacy
+        rpcq-derived :class:`~pyquil.external.rpcq.CompilerISA`.
+
+        :param isa: The QCS API ``InstructionSetArchitecture``.
+        :return: A NoiseModel with channels according to the ISA's fidelities.
+
+        .. seealso:: :meth:`from_compiler_isa` for the channel-construction details and caveats.
+        """
+        from pyquil.quantum_processor.transformers import qcs_isa_to_compiler_isa
+
+        return cls.from_compiler_isa(qcs_isa_to_compiler_isa(isa))
+
+    @classmethod
+    @deprecated(
+        version="4.17.0",
+        reason="pyquil.external.rpcq (and CompilerISA) will be removed in pyQuil v5. "
+        "Use NoiseModel.from_isa with a qcs_sdk InstructionSetArchitecture instead.",
+    )
+    def from_compiler_isa(cls: type[NoiseModel], compiler_isa: CompilerISA) -> NoiseModel:
+        """Create a noise model from an rpcq-derived compiler ISA.
 
         Gate fidelities are converted to depolarizing channels and measurement
-        errors are symmetric. Only gates with concrete numeric parameters are
-        included.
+        errors are symmetric. Only gates with concrete numeric parameters and a
+        fidelity below 1.0 are included.
+
+        .. deprecated:: 4.17.0
+            :class:`~pyquil.external.rpcq.CompilerISA` is part of the rpcq layer slated for
+            removal in pyQuil v5. Use :meth:`from_isa` with a ``qcs_sdk``
+            ``InstructionSetArchitecture``.
 
         .. note::
             Two-qubit gate channels are keyed by the ISA edge's operand order
@@ -210,11 +250,12 @@ class NoiseModel:
 
                     if gate_name is None:
                         continue
-                    # Skip gates with non-numeric parameters
-                    if not all(isinstance(p, (float, int, complex)) for p in params):
+                    # Skip gates with non-numeric parameters. ``complex`` is excluded
+                    # deliberately: gate parameters must be real, and float(complex) raises.
+                    if not all(isinstance(p, (float, int)) for p in params):
                         continue
 
-                    numeric_params: list[float] = [float(p) for p in params if isinstance(p, (float, int, complex))]
+                    numeric_params: list[float] = [float(p) for p in params if isinstance(p, (float, int))]
                     inst = Gate(name=gate_name, params=numeric_params, qubits=qubits)
                     if fidelity is not None and fidelity < 1.0:
                         channels[inst] = Channel.from_gate_fidelity(inst=inst, fidelity=fidelity)
@@ -236,6 +277,10 @@ class NoiseModel:
                         # MeasureInfo for the same qubit may carry a usable fidelity.
                         continue
                     seen_measure_qubits.add(qubit_idx)
+                    # Matching the gate branch, a perfect readout gets no channel at all rather
+                    # than an identity one.
+                    if fidelity >= 1.0:
+                        continue
                     m_inst = Measurement(qubit=QuilQubit(qubit_idx), classical_reg=None)
                     channels[m_inst] = MeasurementChannel.from_readout_fidelity(inst=m_inst, fidelity=fidelity)
 
@@ -249,10 +294,10 @@ class NoiseModel:
 
                     if gate_name is None:
                         continue
-                    if not all(isinstance(p, (float, int, complex)) for p in params):
+                    if not all(isinstance(p, (float, int)) for p in params):
                         continue
 
-                    numeric_params = [float(p) for p in params if isinstance(p, (float, int, complex))]
+                    numeric_params = [float(p) for p in params if isinstance(p, (float, int))]
                     inst = Gate(name=gate_name, params=numeric_params, qubits=qubits)
                     if fidelity is not None and fidelity < 1.0:
                         channels[inst] = Channel.from_gate_fidelity(inst=inst, fidelity=fidelity)
@@ -268,14 +313,10 @@ class NoiseModel:
 
         :return: JSON string representation.
         """
-        channel_data = []
-        for ch in self.channels.values():
-            # Match by base class so every gate channel (SuperopChannel, Channel) and reset
-            # channel (SuperopResetChannel, ResetChannel) is covered, plus measurement and cycle.
-            if isinstance(ch, (_ChannelBase, _ResetChannelBase, MeasurementChannel, CycleChannel)):
-                channel_data.append({"type": type(ch).__name__, "data": ch.to_json()})
-            else:
-                logger.warning(f"Skipping serialization of {type(ch).__name__} (not yet supported).")
+        # Every member of ChannelType derives from _ChannelBase or _ResetChannelBase, or is a
+        # MeasurementChannel or CycleChannel — all of which implement to_json — so there is no
+        # unsupported case to skip here.
+        channel_data = [{"type": type(ch).__name__, "data": ch.to_json()} for ch in self.channels.values()]
         return json.dumps({"channels": channel_data})
 
     @classmethod
@@ -363,11 +404,11 @@ class NoiseModel:
 class DepolarizingNoiseModel:
     r"""A noise model that applies uniform depolarizing noise to every gate.
 
-    For any ``Gate`` instruction, returns a :class:`SuperopChannel` with the specified
+    For any ``Gate`` instruction, returns a :class:`Channel` with the specified
     depolarizing constant.  Measurements and resets are treated as ideal.
 
     :param depolarizing_constant: The depolarization constant :math:`p` where
-        :math:`\\mathcal{D}_p(\\rho) = p \\, \\rho + (1-p) \\, I/d`.
+        :math:`\mathcal{D}_p(\rho) = p \, \rho + (1-p) \, I/d`.
         A value of 1.0 means no noise; 0.0 means full depolarization.
     """
 
@@ -385,8 +426,20 @@ class DepolarizingNoiseModel:
     def get_channel(self, inst: Gate | Measurement | ResetQubit) -> ChannelType | None:
         """Return a depolarizing channel for gates; ``None`` for measurements/resets."""
         if isinstance(inst, Gate):
-            return Channel.from_depolarizing_constant(inst, self.depolarizing_constant)
+            return _depolarizing_channel(inst, self.depolarizing_constant)
         return None
+
+
+@lru_cache(maxsize=1024)
+def _depolarizing_channel(inst: Gate, depolarizing_constant: float) -> Channel:
+    """Build (and memoize) the depolarizing channel for one gate.
+
+    :class:`DepolarizingNoiseModel` synthesizes channels on demand, and a resolver walking a
+    program will ask for the same handful of gates thousands of times. Building the channel
+    involves resolving the gate unitary and deriving its Hamiltonian, so the results are cached
+    on the (hashable) instruction and constant.
+    """
+    return Channel.from_depolarizing_constant(inst, depolarizing_constant)
 
 
 # ──────────────────────────────────────────────────────────
@@ -397,8 +450,12 @@ class DepolarizingNoiseModel:
 def estimate_program_fidelity(program: Program, noise_model: NoiseModelLike) -> float:
     """Estimate the program fidelity for a given noise model.
 
-    Works by multiplying the gate process fidelities together. Readout noise
-    is not considered.
+    Works by multiplying the gate process fidelities together.
+
+    .. note::
+        Readout and reset noise are **not** considered: measurement and reset channels are
+        skipped, as is the readout portion of any :class:`~pyquil.noise._channels.CycleChannel`.
+        The result describes the coherent part of the program only.
 
     :param program: The program of interest.
     :param noise_model: A noise model.
@@ -411,9 +468,9 @@ def estimate_program_fidelity(program: Program, noise_model: NoiseModelLike) -> 
             # Gate channels (SuperopChannel, Channel) and cycle channels both expose a
             # process (Pauli) fidelity; treat all gate-based channels the same.
             if isinstance(channel, (_ChannelBase, CycleChannel)):
-                gate_fidelities.append(channel.pauli_fidelity)
+                gate_fidelities.append(channel.process_fidelity)
 
-    return reduce(mul, gate_fidelities)
+    return math.prod(gate_fidelities)
 
 
 def _light_cone_program(program: Program, qubits: list[int]) -> Program:

--- a/pyquil/noise/_noise_model.py
+++ b/pyquil/noise/_noise_model.py
@@ -43,7 +43,14 @@ from typing import (
 )
 
 from pyquil.external.rpcq import CompilerISA
-from pyquil.noise._channels import Channel, CycleChannel, MeasurementChannel, ResetChannel
+from pyquil.noise._channels import (
+    Channel,
+    CycleChannel,
+    MeasurementChannel,
+    ResetChannel,
+    SuperopChannel,
+    SuperopResetChannel,
+)
 from pyquil.quilbase import Gate, Measurement, ResetQubit
 
 if TYPE_CHECKING:
@@ -57,7 +64,7 @@ logger = logging.getLogger(__name__)
 # ──────────────────────────────────────────────────────────
 
 # Channel union type returned by get_channel
-ChannelType = Channel | MeasurementChannel | ResetChannel | CycleChannel
+ChannelType = SuperopChannel | Channel | MeasurementChannel | SuperopResetChannel | ResetChannel | CycleChannel
 NoiseInstruction = Gate | Measurement | ResetQubit
 
 
@@ -74,13 +81,13 @@ class NoiseModelLike(Protocol):
     """
 
     @overload
-    def get_channel(self, inst: Gate) -> Channel | CycleChannel | None: ...
+    def get_channel(self, inst: Gate) -> SuperopChannel | Channel | CycleChannel | None: ...
 
     @overload
     def get_channel(self, inst: Measurement) -> MeasurementChannel | None: ...
 
     @overload
-    def get_channel(self, inst: ResetQubit) -> ResetChannel | None: ...
+    def get_channel(self, inst: ResetQubit) -> SuperopResetChannel | ResetChannel | None: ...
 
     def get_channel(self, inst: Gate | Measurement | ResetQubit) -> ChannelType | None:
         """Retrieve the noise channel for a specific instruction.
@@ -132,17 +139,15 @@ class NoiseModel:
         object.__setattr__(self, "channels", MappingProxyType(dict(state["channels"])))
 
     @overload
-    def get_channel(self, inst: Gate) -> Channel | CycleChannel | None: ...
+    def get_channel(self, inst: Gate) -> SuperopChannel | Channel | CycleChannel | None: ...
 
     @overload
     def get_channel(self, inst: Measurement) -> MeasurementChannel | None: ...
 
     @overload
-    def get_channel(self, inst: ResetQubit) -> ResetChannel | None: ...
+    def get_channel(self, inst: ResetQubit) -> SuperopResetChannel | ResetChannel | None: ...
 
-    def get_channel(
-        self, inst: Gate | Measurement | ResetQubit
-    ) -> Channel | MeasurementChannel | ResetChannel | CycleChannel | None:
+    def get_channel(self, inst: Gate | Measurement | ResetQubit) -> ChannelType | None:
         """Retrieve the noise channel associated with a specific instruction.
 
         :param inst: The instruction (gate, measurement, or reset) for which to retrieve the noise channel.
@@ -263,7 +268,10 @@ class NoiseModel:
         """
         channel_data = []
         for ch in self.channels.values():
-            if isinstance(ch, (Channel, MeasurementChannel, ResetChannel, CycleChannel)):
+            if isinstance(
+                ch,
+                (SuperopChannel, Channel, MeasurementChannel, SuperopResetChannel, ResetChannel, CycleChannel),
+            ):
                 channel_data.append({"type": type(ch).__name__, "data": ch.to_json()})
             else:
                 logger.warning(f"Skipping serialization of {type(ch).__name__} (not yet supported).")
@@ -278,12 +286,14 @@ class NoiseModel:
         """
         data = json.loads(json_str)
         _type_map = {
+            "SuperopChannel": SuperopChannel,
             "Channel": Channel,
             "MeasurementChannel": MeasurementChannel,
+            "SuperopResetChannel": SuperopResetChannel,
             "ResetChannel": ResetChannel,
             "CycleChannel": CycleChannel,
         }
-        channels: list[Channel | MeasurementChannel | ResetChannel | CycleChannel] = []
+        channels: list[ChannelType] = []
         for ch_data in data["channels"]:
             ch_cls = _type_map.get(ch_data["type"])
             if ch_cls is None:
@@ -352,7 +362,7 @@ class NoiseModel:
 class DepolarizingNoiseModel:
     r"""A noise model that applies uniform depolarizing noise to every gate.
 
-    For any ``Gate`` instruction, returns a :class:`Channel` with the specified
+    For any ``Gate`` instruction, returns a :class:`SuperopChannel` with the specified
     depolarizing constant.  Measurements and resets are treated as ideal.
 
     :param depolarizing_constant: The depolarization constant :math:`p` where
@@ -363,13 +373,13 @@ class DepolarizingNoiseModel:
     depolarizing_constant: float
 
     @overload
-    def get_channel(self, inst: Gate) -> Channel | CycleChannel | None: ...
+    def get_channel(self, inst: Gate) -> SuperopChannel | Channel | CycleChannel | None: ...
 
     @overload
     def get_channel(self, inst: Measurement) -> MeasurementChannel | None: ...
 
     @overload
-    def get_channel(self, inst: ResetQubit) -> ResetChannel | None: ...
+    def get_channel(self, inst: ResetQubit) -> SuperopResetChannel | ResetChannel | None: ...
 
     def get_channel(self, inst: Gate | Measurement | ResetQubit) -> ChannelType | None:
         """Return a depolarizing channel for gates; ``None`` for measurements/resets."""
@@ -397,7 +407,7 @@ def estimate_program_fidelity(program: Program, noise_model: NoiseModelLike) -> 
     for inst in program.instructions:
         if isinstance(inst, Gate):
             channel = noise_model.get_channel(inst)
-            if isinstance(channel, (Channel, CycleChannel)):
+            if isinstance(channel, (SuperopChannel, CycleChannel)):
                 gate_fidelities.append(channel.pauli_fidelity)
 
     return reduce(mul, gate_fidelities)

--- a/pyquil/noise/_noise_model.py
+++ b/pyquil/noise/_noise_model.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright 2016-2026 Rigetti Computing
+# Copyright 2026 Rigetti Computing
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -23,8 +23,6 @@ This module defines:
   collects per-instruction noise channels.
 - ``DepolarizingNoiseModel``: A convenience implementation that returns a
   depolarizing channel for any gate.
-- ``CompositeNoiseModel``: Chains multiple noise models, returning the first
-  non-None channel.
 - Program-level fidelity estimation utilities.
 """
 
@@ -32,7 +30,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from functools import reduce
 from operator import mul
@@ -377,39 +375,6 @@ class DepolarizingNoiseModel:
         """Return a depolarizing channel for gates; ``None`` for measurements/resets."""
         if isinstance(inst, Gate):
             return Channel.from_depolarizing_constant(inst, self.depolarizing_constant)
-        return None
-
-
-@dataclass(frozen=True)
-class CompositeNoiseModel:
-    """A noise model that chains multiple models, returning the first non-None channel.
-
-    Models are queried in order. The first model that returns a non-None channel
-    for a given instruction wins.
-
-    :param models: Sequence of noise models to query in priority order.
-    """
-
-    models: tuple[NoiseModelLike, ...]
-
-    def __init__(self, models: Sequence[NoiseModelLike]) -> None:
-        object.__setattr__(self, "models", tuple(models))
-
-    @overload
-    def get_channel(self, inst: Gate) -> Channel | CycleChannel | None: ...
-
-    @overload
-    def get_channel(self, inst: Measurement) -> MeasurementChannel | None: ...
-
-    @overload
-    def get_channel(self, inst: ResetQubit) -> ResetChannel | None: ...
-
-    def get_channel(self, inst: Gate | Measurement | ResetQubit) -> ChannelType | None:
-        """Query each model in order, returning the first non-None result."""
-        for model in self.models:
-            channel = model.get_channel(inst)
-            if channel is not None:
-                return channel
         return None
 
 

--- a/pyquil/noise/_noise_model.py
+++ b/pyquil/noise/_noise_model.py
@@ -50,6 +50,8 @@ from pyquil.noise._channels import (
     ResetChannel,
     SuperopChannel,
     SuperopResetChannel,
+    _ChannelBase,
+    _ResetChannelBase,
 )
 from pyquil.quilbase import Gate, Measurement, ResetQubit
 
@@ -268,10 +270,9 @@ class NoiseModel:
         """
         channel_data = []
         for ch in self.channels.values():
-            if isinstance(
-                ch,
-                (SuperopChannel, Channel, MeasurementChannel, SuperopResetChannel, ResetChannel, CycleChannel),
-            ):
+            # Match by base class so every gate channel (SuperopChannel, Channel) and reset
+            # channel (SuperopResetChannel, ResetChannel) is covered, plus measurement and cycle.
+            if isinstance(ch, (_ChannelBase, _ResetChannelBase, MeasurementChannel, CycleChannel)):
                 channel_data.append({"type": type(ch).__name__, "data": ch.to_json()})
             else:
                 logger.warning(f"Skipping serialization of {type(ch).__name__} (not yet supported).")
@@ -407,7 +408,9 @@ def estimate_program_fidelity(program: Program, noise_model: NoiseModelLike) -> 
     for inst in program.instructions:
         if isinstance(inst, Gate):
             channel = noise_model.get_channel(inst)
-            if isinstance(channel, (SuperopChannel, CycleChannel)):
+            # Gate channels (SuperopChannel, Channel) and cycle channels both expose a
+            # process (Pauli) fidelity; treat all gate-based channels the same.
+            if isinstance(channel, (_ChannelBase, CycleChannel)):
                 gate_fidelities.append(channel.pauli_fidelity)
 
     return reduce(mul, gate_fidelities)

--- a/pyquil/noise/_noise_model.py
+++ b/pyquil/noise/_noise_model.py
@@ -1,0 +1,489 @@
+##############################################################################
+# Copyright 2016-2026 Rigetti Computing
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+##############################################################################
+"""Noise model container and program-level fidelity estimation.
+
+This module defines:
+
+- ``NoiseModelLike``: A ``typing.Protocol`` defining the interface that all noise
+  models must satisfy (a single ``get_channel`` method).
+- ``NoiseModel``: The primary concrete implementation — a frozen dataclass that
+  collects per-instruction noise channels.
+- ``DepolarizingNoiseModel``: A convenience implementation that returns a
+  depolarizing channel for any gate.
+- ``CompositeNoiseModel``: Chains multiple noise models, returning the first
+  non-None channel.
+- Program-level fidelity estimation utilities.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from functools import reduce
+from operator import mul
+from types import MappingProxyType
+from typing import (
+    TYPE_CHECKING,
+    Protocol,
+    overload,
+    runtime_checkable,
+)
+
+from pyquil.external.rpcq import CompilerISA
+from pyquil.noise._channels import Channel, CycleChannel, MeasurementChannel, ResetChannel
+from pyquil.quilbase import Gate, Measurement, ResetQubit
+
+if TYPE_CHECKING:
+    from pyquil import Program
+    from pyquil.paulis import PauliSum, PauliTerm
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────
+# Protocol
+# ──────────────────────────────────────────────────────────
+
+# Channel union type returned by get_channel
+ChannelType = Channel | MeasurementChannel | ResetChannel | CycleChannel
+NoiseInstruction = Gate | Measurement | ResetQubit
+
+
+@runtime_checkable
+class NoiseModelLike(Protocol):
+    """Protocol defining the noise model interface.
+
+    Any object that implements ``get_channel`` with the correct signature can be
+    used wherever a noise model is expected. This enables alternative noise model
+    strategies (depolarizing, dynamic, crosstalk-aware) without modifying
+    consumers.
+
+    The standard concrete implementation is :class:`NoiseModel`.
+    """
+
+    @overload
+    def get_channel(self, inst: Gate) -> Channel | CycleChannel | None: ...
+
+    @overload
+    def get_channel(self, inst: Measurement) -> MeasurementChannel | None: ...
+
+    @overload
+    def get_channel(self, inst: ResetQubit) -> ResetChannel | None: ...
+
+    def get_channel(self, inst: Gate | Measurement | ResetQubit) -> ChannelType | None:
+        """Retrieve the noise channel for a specific instruction.
+
+        :param inst: A gate, measurement, or reset instruction.
+        :return: The associated noise channel, or ``None`` if the instruction
+            should be treated as ideal (noiseless).
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class NoiseModel:
+    """A noise model collects all the noise channels for a given quantum program.
+
+    This includes gate channels, measurement channels, reset channels, and cycle channels.
+
+    The constructor accepts a mapping from instruction to channel. Use
+    :meth:`from_channels` when constructing from a list, tuple, set, generator,
+    or other channel iterable.
+    """
+
+    channels: Mapping[NoiseInstruction, ChannelType]
+    """Immutable mapping from instruction to its noise channel."""
+
+    def __init__(
+        self,
+        channels: Mapping[NoiseInstruction, ChannelType] | None = None,
+    ) -> None:
+        if channels is None:
+            channels = {}
+        if not isinstance(channels, Mapping):
+            raise TypeError("NoiseModel channels must be a mapping. Use NoiseModel.from_channels(...) for iterables.")
+
+        channel_map: dict[NoiseInstruction, ChannelType] = {}
+        for inst, channel in channels.items():
+            if channel.inst != inst:
+                raise ValueError(
+                    f"NoiseModel channel key {inst!r} does not match channel instruction {channel.inst!r}."
+                )
+            channel_map[inst] = channel
+        object.__setattr__(self, "channels", MappingProxyType(channel_map))
+
+    def __getstate__(self) -> dict[str, dict[NoiseInstruction, ChannelType]]:
+        # ``channels`` is a MappingProxyType (unpicklable); serialize it as a plain dict.
+        return {"channels": dict(self.channels)}
+
+    def __setstate__(self, state: Mapping[str, Mapping[NoiseInstruction, ChannelType]]) -> None:
+        object.__setattr__(self, "channels", MappingProxyType(dict(state["channels"])))
+
+    @overload
+    def get_channel(self, inst: Gate) -> Channel | CycleChannel | None: ...
+
+    @overload
+    def get_channel(self, inst: Measurement) -> MeasurementChannel | None: ...
+
+    @overload
+    def get_channel(self, inst: ResetQubit) -> ResetChannel | None: ...
+
+    def get_channel(
+        self, inst: Gate | Measurement | ResetQubit
+    ) -> Channel | MeasurementChannel | ResetChannel | CycleChannel | None:
+        """Retrieve the noise channel associated with a specific instruction.
+
+        :param inst: The instruction (gate, measurement, or reset) for which to retrieve the noise channel.
+        :return: The noise channel associated with the instruction, or None if no channel is found.
+        """
+        return self.channels.get(inst)
+
+    # ──────────────────────────────────────────────
+    # Constructors
+    # ──────────────────────────────────────────────
+
+    @classmethod
+    def from_channels(cls: type[NoiseModel], channels: Iterable[ChannelType] = ()) -> NoiseModel:
+        """Create a noise model from an iterable of channels.
+
+        :param channels: Noise channels to include in the model.
+        :return: A NoiseModel keyed by each channel's instruction.
+        :raises ValueError: If more than one channel targets the same instruction.
+        """
+        channel_map: dict[NoiseInstruction, ChannelType] = {}
+        for channel in channels:
+            if channel.inst in channel_map:
+                raise ValueError(f"Duplicate noise channel for instruction {channel.inst!r}.")
+            channel_map[channel.inst] = channel
+        return cls(channels=channel_map)
+
+    @classmethod
+    def from_isa(cls: type[NoiseModel], compiler_isa: CompilerISA) -> NoiseModel:
+        """Create a noise model from an instruction set architecture.
+
+        Gate fidelities are converted to depolarizing channels and measurement
+        errors are symmetric. Only gates with concrete numeric parameters are
+        included.
+
+        .. note::
+            Two-qubit gate channels are keyed by the ISA edge's operand order
+            (e.g. ``CZ 0 1``). A program that issues the gate with the operands
+            reversed (``CZ 1 0``) will not match this channel, even for symmetric
+            gates. Issue gates in the ISA operand order, or build channels
+            explicitly for both orderings.
+
+        :param compiler_isa: The compiler ISA.
+        :return: A NoiseModel with channels according to the provided fidelities.
+        """
+        from pyquil.external.rpcq import GateInfo, MeasureInfo
+        from pyquil.quilatom import Qubit as QuilQubit
+
+        channels: dict[NoiseInstruction, ChannelType] = {}
+        seen_measure_qubits: set[int] = set()
+
+        for qubit_label, qubit in compiler_isa.qubits.items():
+            for op_info in qubit.gates:
+                if isinstance(op_info, GateInfo):
+                    qubits = [int(qubit_label)]
+                    gate_name = op_info.operator
+                    fidelity = op_info.fidelity
+                    params = op_info.parameters
+
+                    if gate_name is None:
+                        continue
+                    # Skip gates with non-numeric parameters
+                    if not all(isinstance(p, (float, int, complex)) for p in params):
+                        continue
+
+                    numeric_params: list[float] = [float(p) for p in params if isinstance(p, (float, int, complex))]
+                    inst = Gate(name=gate_name, params=numeric_params, qubits=qubits)
+                    if fidelity is not None and fidelity < 1.0:
+                        channels[inst] = Channel.from_gate_fidelity(inst=inst, fidelity=fidelity)
+
+                elif isinstance(op_info, MeasureInfo):
+                    if op_info.qubit is None:
+                        continue
+                    # Use qubit_label from the enclosing section when qubit is a wildcard
+                    qubit_str = op_info.qubit if op_info.qubit != "_" else qubit_label
+                    try:
+                        qubit_idx = int(qubit_str)
+                    except (ValueError, TypeError):
+                        continue
+                    fidelity = op_info.fidelity
+                    if qubit_idx in seen_measure_qubits:
+                        continue
+                    if fidelity is None:
+                        # Don't mark the qubit seen on a fidelity-less entry; a later
+                        # MeasureInfo for the same qubit may carry a usable fidelity.
+                        continue
+                    seen_measure_qubits.add(qubit_idx)
+                    m_inst = Measurement(qubit=QuilQubit(qubit_idx), classical_reg=None)
+                    channels[m_inst] = MeasurementChannel.from_readout_fidelity(inst=m_inst, fidelity=fidelity)
+
+        for edge_label, edge in compiler_isa.edges.items():
+            for op_info in edge.gates:
+                if isinstance(op_info, GateInfo):
+                    qubits = [int(q) for q in edge_label.split("-")]
+                    gate_name = op_info.operator
+                    fidelity = op_info.fidelity
+                    params = op_info.parameters
+
+                    if gate_name is None:
+                        continue
+                    if not all(isinstance(p, (float, int, complex)) for p in params):
+                        continue
+
+                    numeric_params = [float(p) for p in params if isinstance(p, (float, int, complex))]
+                    inst = Gate(name=gate_name, params=numeric_params, qubits=qubits)
+                    if fidelity is not None and fidelity < 1.0:
+                        channels[inst] = Channel.from_gate_fidelity(inst=inst, fidelity=fidelity)
+
+        return cls(channels=channels)
+
+    # ──────────────────────────────────────────────
+    # Serialization
+    # ──────────────────────────────────────────────
+
+    def to_json(self) -> str:
+        """Serialize NoiseModel to a JSON string.
+
+        :return: JSON string representation.
+        """
+        channel_data = []
+        for ch in self.channels.values():
+            if isinstance(ch, (Channel, MeasurementChannel, ResetChannel, CycleChannel)):
+                channel_data.append({"type": type(ch).__name__, "data": ch.to_json()})
+            else:
+                logger.warning(f"Skipping serialization of {type(ch).__name__} (not yet supported).")
+        return json.dumps({"channels": channel_data})
+
+    @classmethod
+    def from_json(cls: type[NoiseModel], json_str: str) -> NoiseModel:
+        """Deserialize a NoiseModel from a JSON string.
+
+        :param json_str: JSON string as produced by :meth:`to_json`.
+        :return: NoiseModel instance.
+        """
+        data = json.loads(json_str)
+        _type_map = {
+            "Channel": Channel,
+            "MeasurementChannel": MeasurementChannel,
+            "ResetChannel": ResetChannel,
+            "CycleChannel": CycleChannel,
+        }
+        channels: list[Channel | MeasurementChannel | ResetChannel | CycleChannel] = []
+        for ch_data in data["channels"]:
+            ch_cls = _type_map.get(ch_data["type"])
+            if ch_cls is None:
+                raise ValueError(f"Unknown channel type: {ch_data['type']}")
+            channels.append(ch_cls.from_json(ch_data["data"]))  # type: ignore[attr-defined]
+        return cls.from_channels(channels)
+
+    # ──────────────────────────────────────────────
+    # Dunder methods
+    # ──────────────────────────────────────────────
+
+    def __eq__(self, other: object) -> bool:
+        """Check if two NoiseModels contain equivalent channel maps."""
+        if not isinstance(other, NoiseModel):
+            return False
+        return dict(self.channels) == dict(other.channels)
+
+    # Unhashable: its channels hold jax arrays and are themselves unhashable, and an
+    # ``id``-based hash would be inconsistent with the value-based ``__eq__``.
+    __hash__ = None  # type: ignore[assignment]
+
+    def __add__(self, other: NoiseModel) -> NoiseModel:
+        """Combine two NoiseModels into their disjoint union.
+
+        The two models must not both define a channel for the same instruction.
+        Addition is a union of channels, not a composition: overlapping channels are
+        a conflict, not an "addition". Compose channels explicitly
+        (``channel_a @ channel_b``) if that is what you intend.
+
+        :raises ValueError: If both models define a channel for the same instruction.
+        """
+        if not isinstance(other, NoiseModel):
+            return NotImplemented
+
+        overlap = set(self.channels) & set(other.channels)
+        if overlap:
+            insts = ", ".join(repr(inst) for inst in overlap)
+            raise ValueError(
+                f"Cannot add NoiseModels: both define a channel for the same instruction(s): {insts}. "
+                "Addition is a disjoint union; compose the channels explicitly if that is intended."
+            )
+
+        return NoiseModel(channels={**self.channels, **other.channels})
+
+    def with_channels(self, channels: Iterable[ChannelType]) -> NoiseModel:
+        """Return a new model with additional channels.
+
+        :param channels: New channels to add.
+        :return: A NoiseModel containing the existing and new channels.
+        :raises ValueError: If a new channel targets an instruction already in the model.
+        """
+        combined = dict(self.channels)
+        for channel in channels:
+            if channel.inst in combined:
+                raise ValueError(f"Duplicate noise channel for instruction {channel.inst!r}.")
+            combined[channel.inst] = channel
+        return NoiseModel(channels=combined)
+
+
+# ──────────────────────────────────────────────────────────
+# Convenience NoiseModelLike implementations
+# ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class DepolarizingNoiseModel:
+    r"""A noise model that applies uniform depolarizing noise to every gate.
+
+    For any ``Gate`` instruction, returns a :class:`Channel` with the specified
+    depolarizing constant.  Measurements and resets are treated as ideal.
+
+    :param depolarizing_constant: The depolarization constant :math:`p` where
+        :math:`\\mathcal{D}_p(\\rho) = p \\, \\rho + (1-p) \\, I/d`.
+        A value of 1.0 means no noise; 0.0 means full depolarization.
+    """
+
+    depolarizing_constant: float
+
+    @overload
+    def get_channel(self, inst: Gate) -> Channel | CycleChannel | None: ...
+
+    @overload
+    def get_channel(self, inst: Measurement) -> MeasurementChannel | None: ...
+
+    @overload
+    def get_channel(self, inst: ResetQubit) -> ResetChannel | None: ...
+
+    def get_channel(self, inst: Gate | Measurement | ResetQubit) -> ChannelType | None:
+        """Return a depolarizing channel for gates; ``None`` for measurements/resets."""
+        if isinstance(inst, Gate):
+            return Channel.from_depolarizing_constant(inst, self.depolarizing_constant)
+        return None
+
+
+@dataclass(frozen=True)
+class CompositeNoiseModel:
+    """A noise model that chains multiple models, returning the first non-None channel.
+
+    Models are queried in order. The first model that returns a non-None channel
+    for a given instruction wins.
+
+    :param models: Sequence of noise models to query in priority order.
+    """
+
+    models: tuple[NoiseModelLike, ...]
+
+    def __init__(self, models: Sequence[NoiseModelLike]) -> None:
+        object.__setattr__(self, "models", tuple(models))
+
+    @overload
+    def get_channel(self, inst: Gate) -> Channel | CycleChannel | None: ...
+
+    @overload
+    def get_channel(self, inst: Measurement) -> MeasurementChannel | None: ...
+
+    @overload
+    def get_channel(self, inst: ResetQubit) -> ResetChannel | None: ...
+
+    def get_channel(self, inst: Gate | Measurement | ResetQubit) -> ChannelType | None:
+        """Query each model in order, returning the first non-None result."""
+        for model in self.models:
+            channel = model.get_channel(inst)
+            if channel is not None:
+                return channel
+        return None
+
+
+# ──────────────────────────────────────────────────────────
+# Program-level fidelity estimation
+# ──────────────────────────────────────────────────────────
+
+
+def estimate_program_fidelity(program: Program, noise_model: NoiseModelLike) -> float:
+    """Estimate the program fidelity for a given noise model.
+
+    Works by multiplying the gate process fidelities together. Readout noise
+    is not considered.
+
+    :param program: The program of interest.
+    :param noise_model: A noise model.
+    :return: The estimated process fidelity.
+    """
+    gate_fidelities = [1.0]
+    for inst in program.instructions:
+        if isinstance(inst, Gate):
+            channel = noise_model.get_channel(inst)
+            if isinstance(channel, (Channel, CycleChannel)):
+                gate_fidelities.append(channel.pauli_fidelity)
+
+    return reduce(mul, gate_fidelities)
+
+
+def _light_cone_program(program: Program, qubits: list[int]) -> Program:
+    """Return a sub-program containing only gates in the backward light cone of *qubits*.
+
+    Walks backward through the program's gate instructions. Any gate that
+    acts on a qubit currently in the light-cone set is included, and all of
+    its qubits are added to the set (because earlier gates on those qubits
+    are now causally relevant).
+    """
+    from pyquil import Program as _Program
+
+    gate_instructions = [inst for inst in program.instructions if isinstance(inst, Gate)]
+    relevant_qubits = set(qubits)
+    included: list[Gate] = []
+    for inst in reversed(gate_instructions):
+        inst_qubits = {q.index for q in inst.qubits}  # type: ignore[union-attr]
+        if inst_qubits & relevant_qubits:
+            included.append(inst)
+            relevant_qubits |= inst_qubits
+    reduced = _Program()
+    for inst in reversed(included):
+        reduced += inst
+    return reduced
+
+
+def estimate_program_observable_fidelity(
+    program: Program,
+    noise_model: NoiseModelLike,
+    observable: PauliSum | PauliTerm,
+) -> float:
+    """Estimate program fidelity restricted to the backward light cone of *observable*.
+
+    Reduces the program to only the gates causally connected to the
+    observable qubits, then multiplies gate process fidelities together.
+    Readout noise is not considered.
+
+    :param program: The program of interest.
+    :param noise_model: A noise model.
+    :param observable: A ``PauliTerm`` or ``PauliSum`` whose qubits define
+        the light cone.
+    :return: The estimated process fidelity for the light-cone-reduced program.
+    """
+    from pyquil.paulis import PauliSum, PauliTerm
+
+    if isinstance(observable, PauliTerm):
+        observable = PauliSum(terms=[observable])
+
+    qubits = [int(q) for term in observable.terms for q, _ in term.operations_as_set()]  # type: ignore[arg-type]
+    reduced_program = _light_cone_program(program, qubits)
+    return estimate_program_fidelity(reduced_program, noise_model)

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -61,7 +61,6 @@ import math
 import quil.expression as quil_rs_expr
 import quil.instructions as quil_rs
 
-
 # Primes used to peel perfect powers apart in :func:`_integer_base_and_exponent`. An exponent
 # whose prime factors all lie in this list is fully reducible; matrix dimensions never approach
 # ``2 ** 61``, so this covers every realistic qudit decomposition.

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -132,12 +132,18 @@ def _integer_base_and_exponent(n: int) -> tuple[int, int] | None:
     return base, exponent
 
 
-def _is_perfect_power(n: int) -> bool:
+def _is_prime_power(n: int) -> bool:
     """Check if n is a prime power (p^k for prime p, k >= 1).
 
     This ensures the matrix dimension can be interpreted as k qudits of
     dimension p.  Composite non-prime-power dimensions like 6 = 2*3 are
     ambiguous and rejected.
+
+    .. note::
+        Prime-power dimensions are always read with the *prime* as the qudit dimension, so a
+        4x4 matrix describes two qubits, never one ququart, and a 16x16 matrix describes four
+        qubits, never two ququarts. Non-prime qudit dimensions need the dimensions to be stated
+        explicitly rather than inferred from the matrix size.
     """
     return _integer_base_and_exponent(n) is not None
 
@@ -788,9 +794,10 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
         else:
             raise TypeError("Matrix argument must be a list or NumPy array/matrix")
 
-        if not _is_perfect_power(rows):
+        if not _is_prime_power(rows):
             raise ValueError(
-                f"Dimension of matrix must be a perfect power of an integer (e.g. 2, 3, 4, 8, 9, ...), got {rows}"
+                f"Dimension of matrix must be a power of a prime qudit dimension "
+                f"(e.g. 2, 3, 4, 5, 8, 9, 16, 27, ...), got {rows}"
             )
 
         if not contains_parameters:
@@ -818,7 +825,9 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
     def num_args(self) -> int:
         """Get the number of qudit arguments the gate takes.
 
-        For a matrix of dimension d^k with d a prime qudit dimension, returns k.
+        For a matrix of dimension d^k with d a prime qudit dimension, returns k. So a 4x4 matrix
+        takes two qubit arguments (not one ququart) and a 9x9 matrix takes two qutrit arguments;
+        see :func:`_is_prime_power`.
 
         :raises ValueError: If the matrix dimension is not a prime power (see
             :func:`_integer_base_and_exponent`).
@@ -826,7 +835,10 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
         rows = len(self.matrix)
         decomposition = _integer_base_and_exponent(rows)
         if decomposition is None:
-            raise ValueError(f"Matrix dimension must be a prime power (e.g. 2, 3, 4, 8, 9, ...), got {rows}.")
+            raise ValueError(
+                f"Matrix dimension must be a power of a prime qudit dimension "
+                f"(e.g. 2, 3, 4, 5, 8, 9, 16, 27, ...), got {rows}."
+            )
         return decomposition[1]
 
     @property
@@ -885,8 +897,21 @@ class DefPermutationGate(DefGate):
         quil_rs.GateDefinition.specification.__set__(self, specification)  # type: ignore[attr-defined]
 
     def num_args(self) -> int:
-        """Get the number of arguments the gate takes."""
-        return int(np.log2(len(self.permutation)))
+        """Get the number of qudit arguments the gate takes.
+
+        A permutation of length d^k permutes the basis states of k qudits of dimension d, so this
+        returns k on the same prime-power reading as :meth:`DefGate.num_args`.
+
+        :raises ValueError: If the permutation length is not a prime power.
+        """
+        levels = len(self.permutation)
+        decomposition = _integer_base_and_exponent(levels)
+        if decomposition is None:
+            raise ValueError(
+                f"Permutation length must be a power of a prime qudit dimension "
+                f"(e.g. 2, 3, 4, 5, 8, 9, 16, 27, ...), got {levels}."
+            )
+        return decomposition[1]
 
     def __str__(self) -> str:
         return super().to_quil_or_debug()

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -62,30 +62,73 @@ import quil.expression as quil_rs_expr
 import quil.instructions as quil_rs
 
 
+# Primes used to peel perfect powers apart in :func:`_integer_base_and_exponent`. An exponent
+# whose prime factors all lie in this list is fully reducible; matrix dimensions never approach
+# ``2 ** 61``, so this covers every realistic qudit decomposition.
+_SMALL_PRIMES = (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61)
+
+
+def _int_n_root(x: int, n: int) -> int:
+    """Return the integer ``n``-th root of ``x`` (the largest ``m`` with ``m ** n <= x``).
+
+    Uses integer binary search, so it is exact for arbitrarily large ``x`` without the
+    numerical instability of a floating-point ``x ** (1 / n)``. Runs in ``O(log x)``.
+    """
+    low, high = 1, x
+    while low <= high:
+        mid = (low + high) // 2
+        mid_pow_n = mid**n
+        if mid_pow_n == x:
+            return mid
+        elif mid_pow_n < x:
+            low = mid + 1
+        else:
+            high = mid - 1
+    return low - 1
+
+
+def _is_prime(n: int) -> bool:
+    """Return whether ``n`` is prime, via trial division seeded by :data:`_SMALL_PRIMES`."""
+    if n < 2:
+        return False
+    for p in _SMALL_PRIMES:
+        if n == p:
+            return True
+        if n % p == 0:
+            return False
+    for d in range(_SMALL_PRIMES[-1] + 2, math.isqrt(n) + 1, 2):
+        if n % d == 0:
+            return False
+    return True
+
+
 def _integer_base_and_exponent(n: int) -> tuple[int, int] | None:
     """Decompose n as ``base ** exponent`` for a prime ``base``.
 
-    Returns the smallest prime factor ``d`` and the exponent ``k`` such that
-    ``n == d ** k``, or ``None`` if ``n`` is not a prime power. This is the
-    natural qudit decomposition: a matrix dimension ``d ** k`` describes ``k``
-    qudits of dimension ``d``. Composite non-prime-power dimensions like
-    ``6 = 2 * 3`` are ambiguous and rejected (``None``).
+    Returns the prime ``d`` and the exponent ``k`` such that ``n == d ** k``, or ``None`` if
+    ``n`` is not a prime power. This is the natural qudit decomposition: a matrix dimension
+    ``d ** k`` describes ``k`` qudits of dimension ``d``. Composite non-prime-power dimensions
+    like ``6 = 2 * 3`` are ambiguous and rejected (``None``).
+
+    Runs in ``O(log^2 n)`` by repeatedly extracting exact integer prime-th roots (see
+    :func:`_int_n_root`), rather than trial-dividing up to ``sqrt(n)``.
     """
     if n < 2:
         return None
-    # Find the smallest prime factor; it is the qudit dimension (base).
-    base = n
-    for p in range(2, int(math.isqrt(n)) + 1):
-        if n % p == 0:
-            base = p
+
+    # Peel off prime-th roots: whenever the current base is a perfect p-th power, replace it
+    # with its p-th root and fold p into the exponent. What remains is the primitive base b
+    # (with maximal exponent k) such that n == b ** k. Once b < 2 ** p no larger prime can
+    # reduce it further, so we stop.
+    base, exponent = n, 1
+    for p in _SMALL_PRIMES:
+        while (root := _int_n_root(base, p)) >= 2 and root**p == base:
+            base, exponent = root, exponent * p
+        if root < 2:
             break
-    # Check that n is a power of this base and count the exponent.
-    exponent = 0
-    val = 1
-    while val < n:
-        val *= base
-        exponent += 1
-    if val != n:
+
+    # n is a prime power exactly when its primitive base is prime.
+    if not _is_prime(base):
         return None
     return base, exponent
 
@@ -776,12 +819,15 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
     def num_args(self) -> int:
         """Get the number of qudit arguments the gate takes.
 
-        For a matrix of dimension d^k, returns k where d is the smallest
-        integer base >= 2 such that rows = d^k.
+        For a matrix of dimension d^k with d a prime qudit dimension, returns k.
+
+        :raises ValueError: If the matrix dimension is not a prime power (see
+            :func:`_integer_base_and_exponent`).
         """
-        decomposition = _integer_base_and_exponent(len(self.matrix))
+        rows = len(self.matrix)
+        decomposition = _integer_base_and_exponent(rows)
         if decomposition is None:
-            return 0
+            raise ValueError(f"Matrix dimension must be a prime power (e.g. 2, 3, 4, 8, 9, ...), got {rows}.")
         return decomposition[1]
 
     @property

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -56,8 +56,35 @@ from pyquil.quilatom import (
 if TYPE_CHECKING:  # avoids circular import
     from pyquil.paulis import PauliSum
 
+import math
+
 import quil.expression as quil_rs_expr
 import quil.instructions as quil_rs
+
+
+def _is_perfect_power(n: int) -> bool:
+    """Check if n is a prime power (p^k for prime p, k >= 1).
+
+    This ensures the matrix dimension can be interpreted as k qudits of
+    dimension p.  Composite non-prime-power dimensions like 6 = 2*3 are
+    ambiguous and rejected.
+    """
+    if n < 2:
+        return False
+    # Find the smallest prime factor.
+    factor = 0
+    for p in range(2, int(math.isqrt(n)) + 1):
+        if n % p == 0:
+            factor = p
+            break
+    if factor == 0:
+        # n is prime → n = n^1, valid single-qudit dimension.
+        return True
+    # Check that n is a power of this smallest prime factor.
+    val = factor
+    while val < n:
+        val *= factor
+    return val == n
 
 
 class _InstructionMeta(abc.ABCMeta):
@@ -706,8 +733,10 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
         else:
             raise TypeError("Matrix argument must be a list or NumPy array/matrix")
 
-        if 0 != rows & (rows - 1):
-            raise ValueError(f"Dimension of matrix must be a power of 2, got {rows}")
+        if not _is_perfect_power(rows):
+            raise ValueError(
+                f"Dimension of matrix must be a perfect power of an integer (e.g. 2, 3, 4, 8, 9, ...), got {rows}"
+            )
 
         if not contains_parameters:
             np_matrix = np.asarray(matrix)
@@ -732,9 +761,19 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
             return lambda *qubits: Gate(name=self.name, params=[], qubits=list(map(unpack_qubit, qubits)))
 
     def num_args(self) -> int:
-        """Get the number of qubit arguments the gate takes."""
+        """Get the number of qudit arguments the gate takes.
+
+        For a matrix of dimension d^k, returns k where d is the smallest
+        integer base >= 2 such that rows = d^k.
+        """
         rows = len(self.matrix)
-        return int(np.log2(rows))
+        if rows < 2:
+            return 0
+        for base in range(2, rows + 1):
+            k = int(round(math.log(rows, base)))
+            if base**k == rows:
+                return k
+        return 1
 
     @property
     def matrix(self) -> np.ndarray:

--- a/pyquil/quilbase.py
+++ b/pyquil/quilbase.py
@@ -62,6 +62,34 @@ import quil.expression as quil_rs_expr
 import quil.instructions as quil_rs
 
 
+def _integer_base_and_exponent(n: int) -> tuple[int, int] | None:
+    """Decompose n as ``base ** exponent`` for a prime ``base``.
+
+    Returns the smallest prime factor ``d`` and the exponent ``k`` such that
+    ``n == d ** k``, or ``None`` if ``n`` is not a prime power. This is the
+    natural qudit decomposition: a matrix dimension ``d ** k`` describes ``k``
+    qudits of dimension ``d``. Composite non-prime-power dimensions like
+    ``6 = 2 * 3`` are ambiguous and rejected (``None``).
+    """
+    if n < 2:
+        return None
+    # Find the smallest prime factor; it is the qudit dimension (base).
+    base = n
+    for p in range(2, int(math.isqrt(n)) + 1):
+        if n % p == 0:
+            base = p
+            break
+    # Check that n is a power of this base and count the exponent.
+    exponent = 0
+    val = 1
+    while val < n:
+        val *= base
+        exponent += 1
+    if val != n:
+        return None
+    return base, exponent
+
+
 def _is_perfect_power(n: int) -> bool:
     """Check if n is a prime power (p^k for prime p, k >= 1).
 
@@ -69,22 +97,7 @@ def _is_perfect_power(n: int) -> bool:
     dimension p.  Composite non-prime-power dimensions like 6 = 2*3 are
     ambiguous and rejected.
     """
-    if n < 2:
-        return False
-    # Find the smallest prime factor.
-    factor = 0
-    for p in range(2, int(math.isqrt(n)) + 1):
-        if n % p == 0:
-            factor = p
-            break
-    if factor == 0:
-        # n is prime → n = n^1, valid single-qudit dimension.
-        return True
-    # Check that n is a power of this smallest prime factor.
-    val = factor
-    while val < n:
-        val *= factor
-    return val == n
+    return _integer_base_and_exponent(n) is not None
 
 
 class _InstructionMeta(abc.ABCMeta):
@@ -766,14 +779,10 @@ class DefGate(quil_rs.GateDefinition, AbstractInstruction):
         For a matrix of dimension d^k, returns k where d is the smallest
         integer base >= 2 such that rows = d^k.
         """
-        rows = len(self.matrix)
-        if rows < 2:
+        decomposition = _integer_base_and_exponent(len(self.matrix))
+        if decomposition is None:
             return 0
-        for base in range(2, rows + 1):
-            k = int(round(math.log(rows, base)))
-            if base**k == rows:
-                return k
-        return 1
+        return decomposition[1]
 
     @property
     def matrix(self) -> np.ndarray:

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,6 +1,10 @@
 import os
 from typing import Any, Dict
 
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
 import numpy as np
 import pytest
 from qcs_sdk import QCSClient

--- a/test/unit/test_noise.py
+++ b/test/unit/test_noise.py
@@ -1,3 +1,7 @@
+# TODO(pyquil-5.0): Remove this file. These tests exercise the legacy KrausModel/NoiseModel
+# API in pyquil.noise, which is superseded by pyquil.noise._channels / pyquil.noise._noise_model.
+# Equivalent coverage lives in test_noise_model.py.
+
 from collections import OrderedDict
 
 import numpy as np

--- a/test/unit/test_noise_model.py
+++ b/test/unit/test_noise_model.py
@@ -100,10 +100,10 @@ class TestChannel:
         assert ch.stochastic_fidelity + ch.stochastic_infidelity == pytest.approx(1.0)
         assert ch.coherent_fidelity + ch.coherent_infidelity == pytest.approx(1.0)
 
-    def test_noise_process(self):
-        """noise_process factors out the ideal gate unitary."""
+    def test_as_post_gate_noise(self):
+        """as_post_gate_noise factors out the ideal gate unitary."""
         ch = Channel.from_depolarizing_constant(inst=RX(np.pi / 4, 0), depolarizing_constant=0.99)
-        noise = ch.noise_process
+        noise = ch.as_post_gate_noise()
         assert isinstance(noise, qx.SuperOp)
 
     def test_is_pauli(self):
@@ -125,7 +125,7 @@ class TestChannel:
     def test_pauli_vector_sums_to_one(self):
         """Pauli error probability vector should sum to 1."""
         ch = Channel.from_depolarizing_constant(inst=X(0), depolarizing_constant=0.97)
-        pv = ch.pauli_vector
+        pv = ch.to_pauli_vector()
         assert float(jnp.sum(pv)) == pytest.approx(1.0, abs=1e-8)
 
     def test_perfect_channel(self):
@@ -152,9 +152,9 @@ class TestChannel:
         """
         pauli_generators = {"IX": 0.01, "XI": 0.005, "ZZ": 0.02}
         ch = Channel.from_pauli_generators(inst=CNOT(0, 1), pauli_generators=pauli_generators)
-        pv = np.asarray(ch.pauli_vector)
+        pv = np.asarray(ch.to_pauli_vector())
         assert pv.size == 16
-        assert float(jnp.sum(ch.pauli_vector)) == pytest.approx(1.0, abs=1e-3)
+        assert float(jnp.sum(ch.to_pauli_vector())) == pytest.approx(1.0, abs=1e-3)
         terms = [a + b for a in "IXYZ" for b in "IXYZ"]
         rates = dict(zip(terms, pv, strict=True))
         # Identity keeps the dominant weight; each specified error term is populated.
@@ -169,7 +169,7 @@ class TestChannel:
         pauli_noise = {"IX": 0.01, "XI": 0.005, "ZZ": 0.02}
         ch = SuperopChannel.from_pauli_noise(inst=CNOT(0, 1), pauli_noise=pauli_noise)
         assert isinstance(ch, SuperopChannel)
-        pv = np.asarray(ch.pauli_vector)
+        pv = np.asarray(ch.to_pauli_vector())
         assert pv.size == 16
         assert float(jnp.sum(pv)) == pytest.approx(1.0, abs=1e-6)
         terms = [a + b for a in "IXYZ" for b in "IXYZ"]
@@ -195,14 +195,14 @@ class TestChannel:
         )
         target_unitary = qx.Unitary.from_matrix(qutrit_x, ((3,), (3,)))
         channel = SuperopChannel(
-            inst=Gate("TX", [], [0]), process=qx.to_superop(target_unitary), target_unitary=target_unitary
+            inst=Gate("TX", [], [0]), process=qx.to_superop(target_unitary), unitary=target_unitary
         )
 
         restored = SuperopChannel.from_json(channel.to_json())
 
         assert restored.inst == channel.inst
         assert restored.process.dims == ((3,), (3,))
-        assert restored.target_unitary.dims == ((3,), (3,))
+        assert restored.unitary.dims == ((3,), (3,))
         assert jnp.allclose(restored.process.matrix, channel.process.matrix)
 
 
@@ -688,7 +688,7 @@ class TestChannelGeneratorOps:
         assert (ch**1.0).pauli_infidelity == pytest.approx(ch.pauli_infidelity, abs=1e-6)
         assert (ch**2.0).pauli_infidelity == pytest.approx(2 * ch.pauli_infidelity, rel=1e-2)
         assert isinstance(ch**2.0, Channel)
-        assert jnp.allclose((ch**2.0).target_unitary.matrix, ch.target_unitary.matrix)
+        assert jnp.allclose((ch**2.0).unitary.matrix, ch.unitary.matrix)
 
     def test_add_combines_noise_on_same_gate(self):
         """Adding two channels on the same gate keeps the gate and combines the noise."""
@@ -697,7 +697,7 @@ class TestChannelGeneratorOps:
         combined = a + b
         assert isinstance(combined, Channel)
         assert combined.pauli_infidelity > a.pauli_infidelity
-        assert jnp.allclose(combined.target_unitary.matrix, a.target_unitary.matrix)
+        assert jnp.allclose(combined.unitary.matrix, a.unitary.matrix)
 
     def test_add_rejects_different_gates(self):
         a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)

--- a/test/unit/test_noise_model.py
+++ b/test/unit/test_noise_model.py
@@ -27,6 +27,8 @@ from pyquil.noise._channels import (
     MeasurementChannel,
     ResetChannel,
     _build_cycle_channel,
+    _resolve_params,
+    get_custom_gates_from_program,
     get_instruction_unitary,
 )
 from pyquil.noise._noise_model import NoiseModel
@@ -148,16 +150,6 @@ class TestChannel:
         for term, rate in pauli_noise.items():
             assert rates[term] == pytest.approx(rate, abs=1e-3)
         assert rates["II"] == pytest.approx(1.0 - sum(pauli_noise.values()), abs=1e-3)
-
-    def test_pow_scales_noise(self):
-        """Channel ** power scales the noise while preserving the gate."""
-        ch = Channel.from_depolarizing_constant(inst=RX(np.pi / 2, 0), depolarizing_constant=0.99)
-        assert (ch**0.0).pauli_infidelity == pytest.approx(0.0, abs=1e-3)
-        assert (ch**1.0).pauli_infidelity == pytest.approx(ch.pauli_infidelity, abs=1e-3)
-        assert (ch**2.0).pauli_infidelity > ch.pauli_infidelity
-        # The ideal gate is preserved.
-        assert (ch**2.0).qubits == ch.qubits
-        assert jnp.allclose((ch**2.0).target_unitary.matrix, ch.target_unitary.matrix)
 
     def test_json_roundtrip_preserves_qutrit_dims(self):
         """Channel JSON includes explicit dims for non-qubit operators."""
@@ -463,6 +455,30 @@ class TestGetInstructionUnitary:
         u = get_instruction_unitary(inst, custom_gates={"MY_GATE": qx.Unitary.from_matrix(custom_matrix, ((2,), (2,)))})
         assert isinstance(u, qx.Unitary)
         assert np.allclose(np.asarray(u.matrix), custom_matrix)
+
+    def test_get_custom_gates_from_program_qutrit(self):
+        """get_custom_gates_from_program infers qudit (base, exponent) dims, not just qubit dims."""
+        qutrit_x = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]], dtype=complex)
+        program = Program()
+        program.defgate("QUTRIT_X", qutrit_x)
+
+        custom_gates = get_custom_gates_from_program(program)
+        unitary = custom_gates["QUTRIT_X"]
+        assert isinstance(unitary, qx.Unitary)
+        # A single qutrit: dims are ((3,), (3,)), not the qubit-only ((2, 2), (2, 2)).
+        assert unitary.dims == ((3,), (3,))
+        assert np.allclose(np.asarray(unitary.matrix), qutrit_x)
+
+    def test_resolve_params_real(self):
+        """_resolve_params returns concrete floats for real parameters."""
+        assert _resolve_params([1.5, 2]) == [1.5, 2.0]
+
+    def test_resolve_params_warns_on_imaginary(self, caplog):
+        """A non-negligible imaginary part is dropped with a warning, keeping the real part."""
+        with caplog.at_level("WARNING"):
+            resolved = _resolve_params([1.5 + 0.3j])
+        assert resolved == [1.5]
+        assert "imaginary part" in caplog.text
 
 
 # ──────────────────────────────────────────────────────────

--- a/test/unit/test_noise_model.py
+++ b/test/unit/test_noise_model.py
@@ -14,12 +14,12 @@
 
 """Unit tests for the quax-based noise model (Channel, MeasurementChannel, ResetChannel, NoiseModel)."""
 
+import pickle
 from dataclasses import replace
 
 import jax.numpy as jnp
 import numpy as np
 import pytest
-import pickle
 import quax as qx
 
 from pyquil.external.rpcq import CompilerISA
@@ -33,7 +33,8 @@ from pyquil.noise._channels import (
     SuperopResetChannel,
     _build_cycle_channel,
     _ChannelBase,
-    _resolve_params,
+    _evaluate_parameter_designators,
+    _operator_dims_from_dimension,
     get_custom_gates_from_program,
     get_instruction_unitary,
 )
@@ -53,36 +54,36 @@ class TestChannel:
         inst = RX(np.pi / 4, 0)
         ch = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
         assert isinstance(ch.process, qx.SuperOp)
-        expected_fidelity = qx.depolarizing_constant_to_average_fidelity(0.98, num_qubits=1)
-        np.testing.assert_allclose(ch.fidelity, expected_fidelity, rtol=1e-4)
+        expected_fidelity = qx.depolarizing_constant_to_average_fidelity(0.98, dims=(2,))
+        np.testing.assert_allclose(ch.average_gate_fidelity, expected_fidelity, rtol=1e-4)
 
     def test_from_gate_fidelity(self):
         """Channel.from_gate_fidelity produces correct fidelity."""
         inst = RX(np.pi / 2, 0)
         ch = Channel.from_gate_fidelity(inst=inst, fidelity=0.99)
-        assert abs(ch.fidelity - 0.99) < 0.001
+        assert abs(ch.average_gate_fidelity - 0.99) < 0.001
 
     def test_from_pauli_fidelity(self):
         """Channel.from_pauli_fidelity produces a valid channel."""
         inst = X(0)
         ch = Channel.from_pauli_fidelity(inst=inst, pauli_fidelity=0.97)
         assert isinstance(ch.process, qx.SuperOp)
-        assert ch.pauli_fidelity == pytest.approx(0.97, abs=0.001)
+        assert ch.process_fidelity == pytest.approx(0.97, abs=0.001)
 
     def test_from_pauli_generators(self):
         """Channel.from_pauli_generators produces a valid Pauli-dissipation channel."""
         inst = RX(0.5, 0)
         ch = Channel.from_pauli_generators(inst=inst, pauli_generators={"X": 0.01, "Z": 0.02})
         assert isinstance(ch.process, qx.SuperOp)
-        assert ch.fidelity < 1.0
+        assert ch.average_gate_fidelity < 1.0
 
     def test_from_coherence_times(self):
         """Channel.from_coherence_times produces a valid decoherence channel."""
         inst = RX(np.pi / 4, 0)
         ch = Channel.from_coherence_times(inst=inst, gate_duration=40e-9, t1s=[30e-6], t2s=[20e-6])
         assert isinstance(ch.process, qx.SuperOp)
-        assert ch.fidelity < 1.0
-        assert ch.fidelity > 0.99  # short gate relative to T1/T2
+        assert ch.average_gate_fidelity < 1.0
+        assert ch.average_gate_fidelity > 0.99  # short gate relative to T1/T2
 
     def test_qubits(self):
         """SuperopChannel.qubits reflects the instruction's qubits."""
@@ -97,15 +98,15 @@ class TestChannel:
     def test_fidelity_properties(self):
         """Fidelity, infidelity, pauli_fidelity, pauli_infidelity are consistent."""
         ch = Channel.from_gate_fidelity(inst=RX(0.3, 0), fidelity=0.98)
-        assert ch.fidelity + ch.infidelity == pytest.approx(1.0)
-        assert ch.pauli_fidelity + ch.pauli_infidelity == pytest.approx(1.0)
+        assert ch.average_gate_fidelity + ch.average_gate_infidelity == pytest.approx(1.0)
+        assert ch.process_fidelity + ch.process_infidelity == pytest.approx(1.0)
         assert ch.stochastic_fidelity + ch.stochastic_infidelity == pytest.approx(1.0)
         assert ch.coherent_fidelity + ch.coherent_infidelity == pytest.approx(1.0)
 
-    def test_as_post_gate_noise(self):
-        """as_post_gate_noise factors out the ideal gate unitary."""
+    def test_error_process(self):
+        """error_process factors out the ideal gate unitary."""
         ch = Channel.from_depolarizing_constant(inst=RX(np.pi / 4, 0), depolarizing_constant=0.99)
-        noise = ch.as_post_gate_noise()
+        noise = ch.error_process
         assert isinstance(noise, qx.SuperOp)
 
     def test_is_pauli(self):
@@ -133,7 +134,34 @@ class TestChannel:
     def test_perfect_channel(self):
         """A depolarizing constant of 1.0 should give fidelity 1.0."""
         ch = Channel.from_depolarizing_constant(inst=RX(np.pi, 0), depolarizing_constant=1.0)
-        assert ch.fidelity == pytest.approx(1.0, abs=1e-6)
+        assert ch.average_gate_fidelity == pytest.approx(1.0, abs=1e-6)
+
+    @pytest.mark.parametrize("depolarizing_constant", [-0.5, 1.5])
+    def test_from_depolarizing_constant_rejects_out_of_range(self, depolarizing_constant):
+        """An out-of-range shrink factor is a caller error, not something to clip silently.
+
+        Regression guard: values were clipped into [tiny, 1], so ``p = -0.5`` quietly produced a
+        channel with fidelity 0.25 and ``p = 1.5`` a noiseless one.
+        """
+        with pytest.raises(ValueError, match=r"must lie in \[0, 1\]"):
+            Channel.from_depolarizing_constant(X(0), depolarizing_constant=depolarizing_constant)
+
+    @pytest.mark.parametrize("depolarizing_constant", [1.0, 0.99, 0.5, 0.0])
+    def test_from_depolarizing_constant_shrinks_by_exactly_p(self, depolarizing_constant):
+        """The error PTM's traceless diagonal must equal the requested shrink factor."""
+        ch = Channel.from_depolarizing_constant(X(0), depolarizing_constant=depolarizing_constant)
+        ptm = np.asarray(qx.to_pauli_liouville(ch.error_process).matrix).real
+        np.testing.assert_allclose(np.diag(ptm), [1.0] + [depolarizing_constant] * 3, atol=1e-9)
+
+    def test_gate_time_scales_the_noise(self):
+        """Rates are per unit time, so a longer gate at fixed rates accumulates more noise."""
+        short = Channel.from_pauli_generators(RX(np.pi / 2, 0), {"Z": 0.01}, gate_time=1.0)
+        long = Channel.from_pauli_generators(RX(np.pi / 2, 0), {"Z": 0.01}, gate_time=10.0)
+        assert long.process_fidelity < short.process_fidelity
+        # The gate itself is unchanged: the Hamiltonian is rescaled to reproduce it either way.
+        for ch in (short, long):
+            ideal = replace(ch, lindbladian=ch.target_lindbladian)
+            assert ideal.process_infidelity == pytest.approx(0.0, abs=1e-6)
 
     def test_from_pauli_generators_rejects_negative_rate(self):
         """Pauli generator rates must be non-negative (they are Lindbladian rates, not probs)."""
@@ -197,14 +225,14 @@ class TestChannel:
         )
         target_unitary = qx.Unitary.from_matrix(qutrit_x, ((3,), (3,)))
         channel = SuperopChannel(
-            inst=Gate("TX", [], [0]), process=qx.to_superop(target_unitary), unitary=target_unitary
+            inst=Gate("TX", [], [0]), process=qx.to_superop(target_unitary), ideal_unitary=target_unitary
         )
 
         restored = SuperopChannel.from_json(channel.to_json())
 
         assert restored.inst == channel.inst
         assert restored.process.dims == ((3,), (3,))
-        assert restored.unitary.dims == ((3,), (3,))
+        assert restored.ideal_unitary.dims == ((3,), (3,))
         assert jnp.allclose(restored.process.matrix, channel.process.matrix)
 
 
@@ -216,34 +244,53 @@ class TestChannel:
 class TestMeasurementChannel:
     def test_from_readout_fidelity(self):
         """MeasurementChannel.from_readout_fidelity produces a valid quantum instrument."""
-        # Use the pyquil MEASURE gate to get qubit
-        prog = Program(MEASURE(0, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        meas_inst = MEASURE(0, None)
         ch = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.95)
         assert isinstance(ch.process, qx.QuantumInstrument)
 
     def test_from_readout_fidelity_with_asymmetry(self):
         """MeasurementChannel with asymmetry produces asymmetric confusion."""
-        prog = Program(MEASURE(0, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        meas_inst = MEASURE(0, None)
         ch = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.95, asymmetry=0.5)
         assert isinstance(ch.process, qx.QuantumInstrument)
 
     def test_qubits(self):
         """MeasurementChannel.qubits returns the correct qubit."""
-        prog = Program(MEASURE(5, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        meas_inst = MEASURE(5, None)
         ch = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.99)
         assert ch.qubits == [5]
 
-    def test_from_binary_discriminator_qubit_is_faithful_readout(self):
-        """Regression: dim=2/threshold=1 is a real qubit readout, not an always-0 collapse.
+    @pytest.mark.parametrize("dim", [2, 3, 4])
+    def test_from_readout_fidelity_average_diagonal_is_the_fidelity(self, dim):
+        """``fidelity`` is the average over levels of P(outcome j | prepared j)."""
+        ch = MeasurementChannel.from_readout_fidelity(inst=MEASURE(0, None), fidelity=0.9, dim=dim)
+        confusion = np.asarray(ch.confusion_matrix)
+        assert np.diag(confusion).mean() == pytest.approx(0.9, abs=1e-9)
+        np.testing.assert_allclose(confusion.sum(axis=0), np.ones(dim), atol=1e-9)
 
-        The previous implementation mapped both |0> and |1> to outcome 0 for a qubit,
-        silently erasing all measurement information.
+    @pytest.mark.parametrize(
+        ("kwargs", "match"),
+        [
+            ({"fidelity": 0.9, "dim": 1}, "at least 2"),
+            ({"fidelity": 1.5}, r"fidelity must lie in \[0, 1\]"),
+            ({"fidelity": -0.2}, r"fidelity must lie in \[0, 1\]"),
+            ({"fidelity": 0.9, "asymmetry": 3.0}, r"asymmetry must lie in \[-1, 1\]"),
+            ({"fidelity": 0.4, "asymmetry": 1.0}, "cannot be realized"),
+        ],
+        ids=["dim", "fidelity-high", "fidelity-low", "asymmetry", "joint-constraint"],
+    )
+    def test_from_readout_fidelity_validates_its_arguments(self, kwargs, match):
+        """Bad arguments get a message naming the parameter, not a downstream quax complaint."""
+        with pytest.raises(ValueError, match=match):
+            MeasurementChannel.from_readout_fidelity(inst=MEASURE(0, None), **kwargs)
+
+    def test_from_binary_discriminator_qubit_is_faithful_readout(self):
+        """dim=2/threshold=1 must be a faithful qubit readout: |0> -> 0 and |1> -> 1.
+
+        The failure mode this guards against is a discriminator that maps every level to outcome
+        0, which erases all measurement information while still looking like a valid instrument.
         """
-        prog = Program(MEASURE(0, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        meas_inst = MEASURE(0, None)
         ch = MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=2, threshold=1)
         cm = np.asarray(ch.confusion_matrix)
         assert cm.shape == (2, 2)  # two reachable outcomes
@@ -251,8 +298,7 @@ class TestMeasurementChannel:
 
     def test_from_binary_discriminator_qutrit_split(self):
         """dim=3 splits into exactly two outcomes at the threshold."""
-        prog = Program(MEASURE(0, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        meas_inst = MEASURE(0, None)
         # threshold=2: {0,1} -> 0, {2} -> 1 (flag leakage only)
         cm2 = np.asarray(
             MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=3, threshold=2).confusion_matrix
@@ -266,8 +312,7 @@ class TestMeasurementChannel:
 
     def test_from_binary_discriminator_fidelity_degrades(self):
         """Sub-unit fidelity stays column-stochastic and keeps both outcomes reachable."""
-        prog = Program(MEASURE(0, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        meas_inst = MEASURE(0, None)
         cm = np.asarray(
             MeasurementChannel.from_binary_discriminator(
                 inst=meas_inst, dim=2, threshold=1, fidelity=0.9
@@ -279,15 +324,13 @@ class TestMeasurementChannel:
 
     def test_from_binary_discriminator_rejects_bad_threshold(self):
         """threshold must satisfy 1 <= threshold < dim."""
-        prog = Program(MEASURE(0, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        meas_inst = MEASURE(0, None)
         with pytest.raises(ValueError, match="threshold"):
             MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=2, threshold=2)
 
     def test_json_roundtrip_preserves_qutrit_dims(self):
         """MeasurementChannel JSON includes explicit dims for non-qubit instruments."""
-        prog = Program(MEASURE(0, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        meas_inst = MEASURE(0, None)
         channel = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.95, dim=3)
 
         restored = MeasurementChannel.from_json(channel.to_json())
@@ -331,8 +374,7 @@ class TestNoiseModel:
         """
 
         gate = RX(np.pi / 4, 0)
-        prog = Program(MEASURE(0, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        meas_inst = MEASURE(0, None)
         nm = NoiseModel.from_channels(
             [
                 Channel.from_depolarizing_constant(inst=gate, depolarizing_constant=0.98),
@@ -479,16 +521,18 @@ class TestGetInstructionUnitary:
         assert unitary.dims == ((3,), (3,))
         assert np.allclose(np.asarray(unitary.matrix), qutrit_x)
 
-    def test_resolve_params_real(self):
-        """_resolve_params returns concrete floats for real parameters."""
-        assert _resolve_params([1.5, 2]) == [1.5, 2.0]
+    def test_evaluate_parameter_designators_real(self):
+        """_evaluate_parameter_designators returns concrete floats for real parameters."""
+        assert _evaluate_parameter_designators([1.5, 2]) == [1.5, 2.0]
 
-    def test_resolve_params_warns_on_imaginary(self, caplog):
-        """A non-negligible imaginary part is dropped with a warning, keeping the real part."""
-        with caplog.at_level("WARNING"):
-            resolved = _resolve_params([1.5 + 0.3j])
-        assert resolved == [1.5]
-        assert "imaginary part" in caplog.text
+    def test_evaluate_parameter_designators_rejects_imaginary(self):
+        """A non-negligible imaginary part is a caller error, not something to truncate silently."""
+        with pytest.raises(ValueError, match="imaginary part"):
+            _evaluate_parameter_designators([1.5 + 0.3j])
+
+    def test_evaluate_parameter_designators_tolerates_numerical_imaginary(self):
+        """A round-off-scale imaginary part is dropped without complaint."""
+        assert _evaluate_parameter_designators([1.5 + 1e-18j]) == [1.5]
 
 
 # ──────────────────────────────────────────────────────────
@@ -509,7 +553,26 @@ class TestSuperopResetChannel:
         ch_perfect = SuperopResetChannel.from_reset_fidelity(inst=inst, fidelity=1.0)
         ch_noisy = SuperopResetChannel.from_reset_fidelity(inst=inst, fidelity=0.95)
         assert isinstance(ch_noisy.process, qx.SuperOp)
-        assert ch_noisy.fidelity < ch_perfect.fidelity
+        assert ch_noisy.process_fidelity < ch_perfect.process_fidelity
+
+    @pytest.mark.parametrize("dim", [2, 3, 4])
+    @pytest.mark.parametrize("fidelity", [1.0, 0.99, 0.9, 0.75, 0.5001])
+    def test_from_reset_fidelity_is_the_resulting_fidelity(self, dim, fidelity):
+        """The requested fidelity must be the fidelity the channel reports back.
+
+        Regression guard: the argument used to be applied directly as a depolarizing shrink
+        factor, so ``from_reset_fidelity(0.9).process_fidelity`` came out as 0.95. The ideal reset
+        is rank one, giving F = (1 + (d - 1) p) / d rather than F = p.
+        """
+        ch = SuperopResetChannel.from_reset_fidelity(inst=ResetQubit(0), fidelity=fidelity, dim=dim)
+        assert ch.process_fidelity == pytest.approx(fidelity, abs=1e-9)
+
+    def test_from_reset_fidelity_rejects_out_of_range(self):
+        """A fully depolarized reset already has process fidelity 1/d; below that is unreachable."""
+        with pytest.raises(ValueError, match="must lie in"):
+            SuperopResetChannel.from_reset_fidelity(inst=ResetQubit(0), fidelity=0.4)
+        with pytest.raises(ValueError, match="must lie in"):
+            SuperopResetChannel.from_reset_fidelity(inst=ResetQubit(0), fidelity=1.5)
 
     def test_qubits(self):
         """SuperopResetChannel.qubits returns the correct qubit."""
@@ -574,9 +637,9 @@ class TestChannelAnalysis:
     def test_from_mixture(self):
         """from_mixture builds a noisy channel from unitary errors with probabilities."""
         z = qx.Unitary.from_matrix(jnp.array([[1, 0], [0, -1]], dtype=complex), ((2,), (2,)))
-        ch = Channel.from_mixture(X(0), constituents=[z], probabilities=[0.1])
+        ch = Channel.from_mixture(X(0), constituents=[z], rates=[0.1])
         assert isinstance(ch.process, qx.SuperOp)
-        assert ch.pauli_infidelity > 0.0
+        assert ch.process_infidelity > 0.0
 
     def test_coherent_and_stochastic_decomposition(self):
         """to_coherent_channel / to_stochastic_channel split the noise into components."""
@@ -589,11 +652,93 @@ class TestChannelAnalysis:
         assert np.isfinite(ch.coherent_infidelity)
         assert np.isfinite(ch.stochastic_infidelity)
 
+    def test_stochastic_channel_is_cptp_and_matches_stochastic_fidelity(self):
+        """The stochastic component must be a physical channel carrying the stochastic fidelity.
+
+        Regression guard: the decomposition previously built its superoperators with hand-rolled
+        Kronecker products in the wrong convention, yielding a non-CP, non-trace-preserving
+        channel whose fidelity bore no relation to ``stochastic_fidelity``.
+        """
+        ch = Channel.from_random_coherent_error(
+            RX(np.pi / 2, 0), process_fidelity=0.99, rng=np.random.default_rng(7)
+        ) + Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.995)
+        stochastic = ch.to_stochastic_channel()
+
+        # Completely positive: the Choi matrix is positive semi-definite.
+        choi_eigenvalues = np.linalg.eigvalsh(np.asarray(qx.to_choi(stochastic.process).matrix))
+        assert choi_eigenvalues.min() > -1e-9
+
+        # Trace preserving: the first row of the Pauli transfer matrix is (1, 0, ..., 0).
+        ptm = np.asarray(qx.to_pauli_liouville(stochastic.process).matrix)
+        np.testing.assert_allclose(ptm[0].real, [1.0, 0.0, 0.0, 0.0], atol=1e-9)
+
+        # The stochastic part carries exactly the channel's stochastic fidelity.
+        assert stochastic.process_fidelity == pytest.approx(ch.stochastic_fidelity, abs=1e-5)
+
+    def test_coherent_channel_matches_coherent_fidelity_and_is_unitary(self):
+        """The coherent component is a unitary channel carrying the coherent fidelity."""
+        ch = Channel.from_random_coherent_error(
+            RX(np.pi / 2, 0), process_fidelity=0.99, rng=np.random.default_rng(7)
+        ) + Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.995)
+        coherent = ch.to_coherent_channel()
+        assert coherent.unitarity == pytest.approx(1.0, abs=1e-6)
+        assert coherent.process_fidelity == pytest.approx(ch.coherent_fidelity, abs=1e-3)
+
     def test_pauli_twirl_is_pauli(self):
         """Twirling a coherent-error channel yields a stochastic Pauli channel."""
         ch = Channel.from_random_coherent_error(X(0), process_fidelity=0.95, rng=np.random.default_rng(1))
         twirled = ch.pauli_twirl()
         assert twirled.is_pauli()
+
+    @pytest.mark.parametrize("gate", [X(0), RX(np.pi / 2, 0), CNOT(0, 1)], ids=lambda g: g.out())
+    def test_pauli_twirl_preserves_the_gate(self, gate):
+        """Twirling must randomize the error and leave the gate intact.
+
+        Regression guard: the twirl used to be applied to the full process, gate included, which
+        for any gate whose transfer matrix is not already diagonal (e.g. ``RX(pi/2)``) deleted the
+        gate itself and roughly halved the process fidelity.
+        """
+        ch = Channel.from_random_coherent_error(
+            gate, process_fidelity=0.97, rng=np.random.default_rng(3)
+        ) + Channel.from_depolarizing_constant(gate, 0.99)
+        twirled = ch.pauli_twirl()
+
+        # The error is now a stochastic Pauli channel...
+        assert twirled.is_pauli()
+        # ...the gate survives...
+        assert jnp.allclose(twirled.ideal_unitary.matrix, ch.ideal_unitary.matrix)
+        # ...and twirling preserves process fidelity (to PTM round-trip precision). The bug this
+        # guards against moved the fidelity by ~0.5, so this bound is far tighter than needed.
+        assert twirled.process_fidelity == pytest.approx(ch.process_fidelity, abs=1e-7)
+
+    def test_pauli_twirl_matches_explicit_clifford_twirl(self):
+        """For a Clifford gate, twirling the error equals the textbook twirl of the whole channel.
+
+        The textbook Pauli twirl of a noisy gate is
+        ``(1/4^n) sum_k S(P'_k)^dag @ E @ S(P_k)`` with ``P'_k = U P_k U^dag``. Because
+        ``U P_k = P'_k U``, the gate factors out of the average, and for Clifford ``U`` the
+        conjugated set ``{P'_k}`` is again the Pauli group -- so the two agree exactly.
+        """
+        gate = RX(np.pi / 2, 0)
+        ch = Channel.from_random_coherent_error(
+            gate, process_fidelity=0.97, rng=np.random.default_rng(4)
+        ) + Channel.from_depolarizing_constant(gate, 0.99)
+
+        unitary = np.asarray(ch.ideal_unitary.matrix)
+        process = np.asarray(ch.process.matrix)
+        paulis = np.asarray(qx.ensembles.PAULIS.matrix)
+
+        def superop(matrix: np.ndarray) -> np.ndarray:
+            # quax's SuperOp convention is kron(conj(U), U).
+            return np.kron(matrix.conj(), matrix)
+
+        explicit = np.zeros_like(process)
+        for pauli in paulis:
+            conjugated = unitary @ pauli @ unitary.conj().T
+            explicit += superop(conjugated).conj().T @ process @ superop(pauli)
+        explicit /= len(paulis)
+
+        assert jnp.allclose(ch.pauli_twirl().process.matrix, jnp.asarray(explicit), atol=1e-12)
 
 
 # ──────────────────────────────────────────────────────────
@@ -642,15 +787,51 @@ class TestFromIsa:
         )
 
     def test_builds_gate_and_edge_channels(self):
-        nm = NoiseModel.from_isa(self._isa())
+        nm = NoiseModel.from_compiler_isa(self._isa())
         assert isinstance(nm.get_channel(Gate("RX", [1.5707963267948966], [0])), Channel)
         assert isinstance(nm.get_channel(Gate("CZ", [], [0, 1])), Channel)
 
     def test_measurement_dedup_prefers_real_fidelity(self):
         """A None-fidelity measure entry must not block a later usable one (dedup ordering)."""
-        nm = NoiseModel.from_isa(self._isa())
+        nm = NoiseModel.from_compiler_isa(self._isa())
         channel = nm.get_channel(Measurement(qubit=Qubit(0), classical_reg=None))
         assert isinstance(channel, MeasurementChannel)
+
+    def test_perfect_fidelities_get_no_channel(self):
+        """A fidelity of 1.0 means ideal, for readout as well as for gates."""
+        isa = CompilerISA.parse_obj(
+            {
+                "1Q": {
+                    "0": {
+                        "id": 0,
+                        "gates": [
+                            {
+                                "operator_type": "gate",
+                                "operator": "RX",
+                                "parameters": [1.5707963267948966],
+                                "arguments": ["_"],
+                                "fidelity": 1.0,
+                            },
+                            {"operator_type": "measure", "qubit": "0", "fidelity": 1.0},
+                        ],
+                    }
+                },
+                "2Q": {},
+            }
+        )
+        nm = NoiseModel.from_compiler_isa(isa)
+        assert nm.get_channel(Gate("RX", [1.5707963267948966], [0])) is None
+        assert nm.get_channel(Measurement(qubit=Qubit(0), classical_reg=None)) is None
+
+    def test_from_isa_accepts_a_qcs_instruction_set_architecture(self, qcs_aspen8_isa):
+        """The preferred entry point takes the qcs_sdk ISA, not the rpcq CompilerISA."""
+        nm = NoiseModel.from_isa(qcs_aspen8_isa)
+        assert len(nm.channels) > 0
+        assert all(isinstance(ch, (Channel, MeasurementChannel)) for ch in nm.channels.values())
+
+    def test_from_isa_matches_from_compiler_isa(self, qcs_aspen8_isa, aspen8_compiler_isa):
+        """Both ISA entry points describe the same device, so they must agree."""
+        assert NoiseModel.from_isa(qcs_aspen8_isa) == NoiseModel.from_compiler_isa(aspen8_compiler_isa)
 
 
 class TestCycleChannel:
@@ -697,6 +878,107 @@ class TestCycleChannel:
         cycle = gate | reset
         assert CycleChannel.from_json(cycle.to_json()) == cycle
 
+    def test_json_roundtrip_preserves_externally_built_defcircuit(self):
+        """A cycle built elsewhere keeps its own name, formal arguments, and body ordering.
+
+        Regression guard: serialization used to write only the constituent channels, so
+        deserialization rebuilt every cycle as a generic ``CYCLE`` on sorted qubits, silently
+        discarding a DEFCIRCUIT constructed by a caller.
+        """
+        qa, qb = FormalArgument("a"), FormalArgument("b")
+        defcircuit = DefCircuit("SYNDROME_ROUND", [], [qa, qb], [RZ(0.2, qb), RX(0.1, qa)])
+        cycle_inst = Gate("SYNDROME_ROUND", [], [Qubit(5), Qubit(3)])
+        channels = (
+            Channel.from_depolarizing_constant(RZ(0.2, 3), depolarizing_constant=0.99),
+            Channel.from_depolarizing_constant(RX(0.1, 5), depolarizing_constant=0.98),
+        )
+        cycle = CycleChannel(inst=cycle_inst, defcircuit=defcircuit, channels=channels)
+
+        restored = CycleChannel.from_json(cycle.to_json())
+
+        assert restored.inst == cycle_inst
+        assert restored.defcircuit == defcircuit
+        assert restored.defcircuit.name == "SYNDROME_ROUND"
+        assert restored.qubits == [5, 3]
+        assert restored == cycle
+
+    def test_or_chains_into_a_flat_three_operation_cycle(self):
+        """``a | b | c`` must build one three-operation cycle.
+
+        Regression guard: ``a | b`` returns a CycleChannel, which had no ``__or__``, so the second
+        ``|`` raised TypeError and wider cycles were reachable only through a private helper.
+        """
+        a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        b = Channel.from_depolarizing_constant(RX(np.pi / 2, 1), 0.99)
+        c = MeasurementChannel.from_readout_fidelity(MEASURE(2, None), fidelity=0.98)
+
+        cycle = a | b | c
+        assert isinstance(cycle, CycleChannel)
+        assert cycle.channels == (a, b, c)
+        assert sorted(cycle.qubits) == [0, 1, 2]
+
+        # Cycles compose from either side, and stay flat.
+        from_cycle_on_the_right = a | (b | c)
+        assert from_cycle_on_the_right.channels == (a, b, c)
+
+    def test_or_rejects_overlapping_qubits_when_chaining(self):
+        a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        b = Channel.from_depolarizing_constant(RX(np.pi / 2, 1), 0.99)
+        c = Channel.from_depolarizing_constant(RX(np.pi / 2, 1), 0.98)
+        with pytest.raises(ValueError, match="overlapping qubits"):
+            _ = a | b | c
+
+    def test_process_fidelity_is_the_exact_product(self):
+        """Process fidelity is multiplicative over the disjoint constituents."""
+        a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        b = Channel.from_depolarizing_constant(RX(np.pi / 2, 1), 0.99)
+        cycle = a | b
+        assert cycle.process_fidelity == pytest.approx(a.process_fidelity * b.process_fidelity)
+        assert cycle.process_infidelity == pytest.approx(1.0 - cycle.process_fidelity)
+
+    def test_average_gate_fidelity_converts_once_over_the_full_dimension(self):
+        """Average gate fidelity is not multiplicative, so it must be converted once at the end.
+
+        Regression guard: the cycle used to multiply its constituents' average gate fidelities,
+        which overstates the result because the process-to-average conversion depends on the total
+        Hilbert-space dimension.
+        """
+        a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        b = Channel.from_depolarizing_constant(RX(np.pi / 2, 1), 0.99)
+        cycle = a | b
+
+        expected = float(qx.process_fidelity_to_average_fidelity(cycle.process_fidelity, dims=(2, 2)))
+        assert cycle.average_gate_fidelity == pytest.approx(expected)
+        assert cycle.average_gate_infidelity == pytest.approx(1.0 - expected)
+
+        # The naive product of averages is a different (larger) number.
+        naive_product = a.average_gate_fidelity * b.average_gate_fidelity
+        assert naive_product > cycle.average_gate_fidelity
+        assert not np.isclose(naive_product, cycle.average_gate_fidelity, atol=1e-6)
+
+    def test_fidelities_ignore_measurement_only_cycles(self):
+        """Documented (and surprising) behavior: readout noise carries no gate fidelity."""
+        m0 = MeasurementChannel.from_readout_fidelity(MEASURE(0, None), fidelity=0.9)
+        m1 = MeasurementChannel.from_readout_fidelity(MEASURE(1, None), fidelity=0.9)
+        cycle = m0 | m1
+        assert cycle.process_fidelity == 1.0
+        assert cycle.average_gate_fidelity == 1.0
+
+    def test_expanded_instructions_is_an_immutable_tuple(self):
+        """A cached property on a frozen dataclass must not hand out a mutable list."""
+        a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        b = Channel.from_depolarizing_constant(RX(np.pi / 2, 1), 0.99)
+        assert isinstance((a | b).expanded_instructions, tuple)
+
+    def test_arity_mismatch_reports_clearly(self):
+        """A cycle gate whose arity disagrees with its DEFCIRCUIT gets a real error message."""
+        q0, q1 = FormalArgument("q0"), FormalArgument("q1")
+        defcircuit = DefCircuit("CYCLE", [], [q0, q1], [RX(0.1, q0), RZ(0.2, q1)])
+        cycle_inst = Gate("CYCLE", [], [Qubit(0)])  # one qubit, two formal arguments
+        channels = (Channel.from_depolarizing_constant(RX(0.1, 0), depolarizing_constant=0.99),)
+        with pytest.raises(ValueError, match="formal argument"):
+            _ = CycleChannel(inst=cycle_inst, defcircuit=defcircuit, channels=channels)
+
 
 # ──────────────────────────────────────────────────────────
 # Channel tests
@@ -714,16 +996,16 @@ class TestChannelGeneratorOps:
         """A depolarizing Channel matches the equivalent superoperator SuperopChannel."""
         lind = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
         superop = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
-        assert lind.pauli_fidelity == pytest.approx(superop.pauli_fidelity, abs=1e-6)
+        assert lind.process_fidelity == pytest.approx(superop.process_fidelity, abs=1e-6)
 
     def test_pow_scales_noise_and_keeps_gate(self):
         """** scales the noise while preserving the ideal gate; result stays a Channel."""
         ch = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
-        assert (ch**0.0).pauli_infidelity == pytest.approx(0.0, abs=1e-6)
-        assert (ch**1.0).pauli_infidelity == pytest.approx(ch.pauli_infidelity, abs=1e-6)
-        assert (ch**2.0).pauli_infidelity == pytest.approx(2 * ch.pauli_infidelity, rel=1e-2)
+        assert (ch**0.0).process_infidelity == pytest.approx(0.0, abs=1e-6)
+        assert (ch**1.0).process_infidelity == pytest.approx(ch.process_infidelity, abs=1e-6)
+        assert (ch**2.0).process_infidelity == pytest.approx(2 * ch.process_infidelity, rel=1e-2)
         assert isinstance(ch**2.0, Channel)
-        assert jnp.allclose((ch**2.0).unitary.matrix, ch.unitary.matrix)
+        assert jnp.allclose((ch**2.0).ideal_unitary.matrix, ch.ideal_unitary.matrix)
 
     def test_add_combines_noise_on_same_gate(self):
         """Adding two channels on the same gate keeps the gate and combines the noise."""
@@ -731,8 +1013,8 @@ class TestChannelGeneratorOps:
         b = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.98)
         combined = a + b
         assert isinstance(combined, Channel)
-        assert combined.pauli_infidelity > a.pauli_infidelity
-        assert jnp.allclose(combined.unitary.matrix, a.unitary.matrix)
+        assert combined.process_infidelity > a.process_infidelity
+        assert jnp.allclose(combined.ideal_unitary.matrix, a.ideal_unitary.matrix)
 
     def test_add_rejects_different_gates(self):
         a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
@@ -750,22 +1032,62 @@ class TestChannelGeneratorOps:
         superop = ch.pauli_twirl()
         assert isinstance(ch @ superop, SuperopChannel) and not isinstance(ch @ superop, Channel)
 
-    def test_matmul_of_lindbladian_channels_stays_a_channel(self):
-        """Composing two Lindbladian channels combines the jump operators, staying a Channel."""
+    def test_matmul_is_exact_superoperator_composition(self):
+        """``@`` composes the processes exactly, so it returns a SuperopChannel, not a Channel."""
         a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
         b = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.98)
         composed = a @ b
-        assert isinstance(composed, Channel)
-        # Composition combines the noise (same as adding on a shared gate) and keeps the gate.
-        assert composed == a + b
-        assert composed.pauli_infidelity > a.pauli_infidelity
-        assert jnp.allclose(composed.unitary.matrix, a.unitary.matrix)
+
+        # Not a Channel: composing two Lindbladian evolutions is not itself one.
+        assert isinstance(composed, SuperopChannel)
+        assert not isinstance(composed, Channel)
+
+        expected = qx.to_superop(a.process @ qx.to_superop(a.ideal_unitary.h) @ b.process)
+        assert jnp.allclose(composed.process.matrix, expected.matrix)
+        assert composed.process_infidelity > a.process_infidelity
+        assert jnp.allclose(composed.ideal_unitary.matrix, a.ideal_unitary.matrix)
+
+    def test_matmul_differs_from_add_for_noncommuting_generators(self):
+        """``@`` (exact composition) and ``+`` (generator sum) agree only when generators commute.
+
+        Regression guard: ``@`` used to be implemented as ``+``, which silently substituted a
+        first-order approximation for the composition.
+        """
+        gate = RX(np.pi / 2, 0)
+        a = Channel.from_pauli_generators(gate, {"Y": 0.9})
+        b = Channel.from_pauli_generators(gate, {"Z": 0.7})
+
+        composed = a @ b
+        summed = a + b
+        assert not jnp.allclose(composed.process.matrix, summed.process.matrix)
+
+        # ...and they do agree when the noise commutes with the gate and with itself.
+        commuting_a = Channel.from_pauli_generators(gate, {"X": 0.9})
+        commuting_b = Channel.from_pauli_generators(gate, {"X": 0.7})
+        assert jnp.allclose(
+            (commuting_a @ commuting_b).process.matrix,
+            (commuting_a + commuting_b).process.matrix,
+        )
 
     def test_matmul_rejects_different_gates(self):
         a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
         b = Channel.from_depolarizing_constant(RY(np.pi / 2, 1), 0.99)
         with pytest.raises(ValueError, match="different gates"):
             _ = a @ b
+
+    def test_add_rejects_different_gate_times(self):
+        """Jump operators are per-unit-time rates, so mismatched gate times cannot be summed."""
+        a = Channel.from_pauli_generators(RX(np.pi / 2, 0), {"X": 0.01}, gate_time=1.0)
+        b = Channel.from_pauli_generators(RX(np.pi / 2, 0), {"X": 0.01}, gate_time=100.0)
+        with pytest.raises(ValueError, match="different gate times"):
+            _ = a + b
+
+    def test_pow_equals_repeated_addition(self):
+        """``ch ** 2`` scales the noise, matching ``ch + ch``."""
+        ch = Channel.from_pauli_generators(RX(np.pi / 2, 0), {"X": 0.02, "Z": 0.01})
+        assert jnp.allclose((ch**2.0).process.matrix, (ch + ch).process.matrix)
+        # power 0 recovers the ideal gate
+        assert (ch**0.0).process_infidelity == pytest.approx(0.0, abs=1e-6)
 
     def test_noise_and_target_lindbladians_decompose_the_generator(self):
         """`lindbladian` splits into `noise_lindbladian + target_lindbladian`."""
@@ -774,17 +1096,69 @@ class TestChannelGeneratorOps:
         assert jnp.allclose(recombined.matrix, ch.lindbladian.matrix)
         # The target alone (zero dissipation) reproduces the ideal gate.
         target_only = replace(ch, lindbladian=ch.target_lindbladian)
-        assert target_only.pauli_infidelity == pytest.approx(0.0, abs=1e-6)
+        assert target_only.process_infidelity == pytest.approx(0.0, abs=1e-6)
 
     def test_coherence_times(self):
         """A short gate relative to T1/T2 gives high fidelity."""
         ch = Channel.from_coherence_times(RX(np.pi / 2, 0), gate_duration=40e-9, t1s=[30e-6], t2s=[20e-6])
         assert isinstance(ch.process, qx.SuperOp)
-        assert ch.fidelity > 0.99
+        assert ch.average_gate_fidelity > 0.99
 
     def test_json_roundtrip(self):
         ch = Channel.from_depolarizing_constant(RX(0.3, 0), 0.97)
         assert Channel.from_json(ch.to_json()) == ch
+
+
+class TestCoherenceTimes:
+    """T1/T2 -> Tphi conversion, which uses 1/T2 = 1/(2*T1) + 1/Tphi."""
+
+    @pytest.mark.parametrize("t2_over_t1", [0.5, 1.0, 1.5, 2.0])
+    def test_physical_t2_range_gives_a_cptp_channel(self, t2_over_t1):
+        """Every physical T2 (up to and including 2*T1) must produce a valid channel.
+
+        Regression guard: the Tphi conversion used to omit the factor of two on T1, so any
+        T1 < T2 <= 2*T1 -- which is the entire realistic range -- produced a negative pure-dephasing
+        time, NaN fidelities, and a LinAlgError from the unitarity computation.
+        """
+        t1 = 20e-6
+        ch = Channel.from_coherence_times(RX(np.pi / 2, 0), 40e-9, t1s=[t1], t2s=[t2_over_t1 * t1])
+
+        assert np.isfinite(ch.process_fidelity)
+        assert ch.process_fidelity > 0.99  # 40 ns gate against a 20 us T1
+        assert np.isfinite(ch.unitarity)
+        choi_eigenvalues = np.linalg.eigvalsh(np.asarray(qx.to_choi(ch.process).matrix))
+        assert choi_eigenvalues.min() > -1e-9
+
+    def test_default_t2_is_twice_t1(self):
+        """Omitting T2 means no pure dephasing, i.e. the same channel as T2 == 2*T1."""
+        t1 = 20e-6
+        default = Channel.from_coherence_times(RX(np.pi / 2, 0), 40e-9, t1s=[t1])
+        explicit = Channel.from_coherence_times(RX(np.pi / 2, 0), 40e-9, t1s=[t1], t2s=[2 * t1])
+        assert jnp.allclose(default.process.matrix, explicit.process.matrix)
+        assert np.isfinite(default.process_fidelity)
+
+    def test_more_dephasing_lowers_fidelity(self):
+        """Shorter T2 at fixed T1 means more pure dephasing and a worse gate."""
+        t1 = 20e-6
+        dephasing = Channel.from_coherence_times(RX(np.pi / 2, 0), 40e-9, t1s=[t1], t2s=[0.5 * t1])
+        relaxation_only = Channel.from_coherence_times(RX(np.pi / 2, 0), 40e-9, t1s=[t1], t2s=[2 * t1])
+        assert dephasing.process_fidelity < relaxation_only.process_fidelity
+
+    def test_rejects_t2_above_twice_t1(self):
+        """T2 > 2*T1 implies a negative dephasing rate and is unphysical."""
+        with pytest.raises(ValueError, match="T2 must not exceed"):
+            Channel.from_coherence_times(RX(np.pi / 2, 0), 40e-9, t1s=[20e-6], t2s=[41e-6])
+
+    def test_rejects_non_positive_times(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            Channel.from_coherence_times(RX(np.pi / 2, 0), 40e-9, t1s=[20e-6], t2s=[0.0])
+
+    def test_reset_channel_shares_the_conversion(self):
+        """ResetChannel.from_coherence_times has the same default and the same guard."""
+        reset = ResetChannel.from_coherence_times(ResetQubit(0), duration=1.0, t1=2.0)
+        assert np.isfinite(reset.process_fidelity)
+        with pytest.raises(ValueError, match="T2 must not exceed"):
+            ResetChannel.from_coherence_times(ResetQubit(0), duration=1.0, t1=2.0, t2=5.0)
 
 
 # ──────────────────────────────────────────────────────────
@@ -797,12 +1171,12 @@ class TestResetChannel:
         weak = ResetChannel.from_amplitude_damping(ResetQubit(0), gamma=0.5)
         strong = ResetChannel.from_amplitude_damping(ResetQubit(0), gamma=5.0)
         assert isinstance(weak.process, qx.SuperOp)
-        assert strong.fidelity > weak.fidelity
+        assert strong.process_fidelity > weak.process_fidelity
 
     def test_pow_scales_relaxation(self):
         ch = ResetChannel.from_amplitude_damping(ResetQubit(0), gamma=0.5)
         assert isinstance(ch**2.0, ResetChannel)
-        assert (ch**2.0).fidelity > ch.fidelity
+        assert (ch**2.0).process_fidelity > ch.process_fidelity
 
     def test_rejects_global_reset(self):
         from pyquil.quilbase import Reset
@@ -813,3 +1187,133 @@ class TestResetChannel:
     def test_json_roundtrip(self):
         ch = ResetChannel.from_coherence_times(ResetQubit(0), duration=1.0, t1=2.0, t2=1.5)
         assert ResetChannel.from_json(ch.to_json()) == ch
+
+
+# ──────────────────────────────────────────────────────────
+# Qudit support boundaries
+# ──────────────────────────────────────────────────────────
+
+
+class TestQuditSupport:
+    """The Pauli basis is a qubit-only construct; qudits must get a real error, not a shape crash."""
+
+    QUTRIT_X = np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]], dtype=complex)
+
+    @pytest.fixture
+    def qutrit_gate(self):
+        gate = Gate("QUTRIT_X", [], [0])
+        custom_gates = {
+            "QUTRIT_X": qx.Unitary.from_matrix(jnp.asarray(self.QUTRIT_X), _operator_dims_from_dimension(3))
+        }
+        return gate, custom_gates
+
+    def test_lindbladian_constructors_support_qutrits(self, qutrit_gate):
+        """The generator-based path is dimension-agnostic and must keep working."""
+        gate, custom_gates = qutrit_gate
+        ch = Channel.from_depolarizing_constant(gate, 0.99, custom_gates=custom_gates)
+        assert ch.dims == (3,)
+
+        # The contract is the shrink factor, not the fidelity: for d = 3 a shrink of 0.99 gives
+        # a process fidelity of (1 + (d^2 - 1) * p) / d^2 = 0.991111...
+        expected = float(qx.process_fidelity_to_depolarizing_constant(ch.process_fidelity, (3,)))
+        assert expected == pytest.approx(0.99, abs=1e-6)
+        assert Channel.from_json(ch.to_json()) == ch
+
+    def test_pauli_constructors_reject_qutrits_with_a_clear_message(self, qutrit_gate):
+        """Regression guard: these used to fail with raw JAX reshape errors."""
+        gate, custom_gates = qutrit_gate
+        with pytest.raises(ValueError, match="qubits only"):
+            Channel.from_pauli_generators(gate, {"X": 0.01}, custom_gates=custom_gates)
+        with pytest.raises(ValueError, match="qubits only"):
+            SuperopChannel.from_pauli_noise(gate, {"X": 0.01}, custom_gates=custom_gates)
+        with pytest.raises(ValueError, match="qubits only"):
+            Channel.from_random_coherent_error(gate, 0.99, custom_gates=custom_gates)
+
+    def test_pauli_analyses_reject_qutrits_with_a_clear_message(self, qutrit_gate):
+        """``is_pauli`` in particular used to return a meaningless answer rather than raising."""
+        gate, custom_gates = qutrit_gate
+        ch = Channel.from_depolarizing_constant(gate, 0.99, custom_gates=custom_gates)
+        with pytest.raises(ValueError, match="qubits only"):
+            ch.is_pauli()
+        with pytest.raises(ValueError, match="qubits only"):
+            ch.to_pauli_vector()
+
+    def test_error_message_names_the_operation_and_the_dims(self, qutrit_gate):
+        gate, custom_gates = qutrit_gate
+        with pytest.raises(ValueError, match=r"from_pauli_generators.*\(3,\)"):
+            Channel.from_pauli_generators(gate, {"X": 0.01}, custom_gates=custom_gates)
+
+
+# ──────────────────────────────────────────────────────────
+# Random coherent error
+# ──────────────────────────────────────────────────────────
+
+
+class TestRandomCoherentError:
+    @pytest.mark.parametrize("gate", [X(0), RX(np.pi / 2, 0), CNOT(0, 1)], ids=lambda g: g.out())
+    @pytest.mark.parametrize("requested", [0.999, 0.99, 0.9, 0.5])
+    def test_achieves_the_requested_process_fidelity(self, gate, requested):
+        """The angle is solved numerically, so multi-qubit gates hit the target exactly too.
+
+        Regression guard: the closed form assumed the drawn generator squares to a multiple of the
+        identity, which only holds for a single qudit; a CZ at 0.9 came out at 0.9009. The bound
+        below is ~1000x tighter than that error; the residual is round-off from rebuilding the
+        channel through its Hamiltonian.
+        """
+        ch = Channel.from_random_coherent_error(gate, requested, rng=np.random.default_rng(3))
+        assert ch.process_fidelity == pytest.approx(requested, abs=1e-6)
+
+    def test_error_is_purely_coherent(self):
+        ch = Channel.from_random_coherent_error(CNOT(0, 1), 0.97, rng=np.random.default_rng(5))
+        assert ch.unitarity == pytest.approx(1.0, abs=1e-6)
+        assert ch.stochastic_infidelity == pytest.approx(0.0, abs=1e-6)
+
+    def test_perfect_fidelity_gives_the_ideal_gate(self):
+        ch = Channel.from_random_coherent_error(X(0), 1.0, rng=np.random.default_rng(1))
+        assert ch.process_infidelity == pytest.approx(0.0, abs=1e-9)
+
+    def test_is_reproducible_for_a_given_seed(self):
+        a = Channel.from_random_coherent_error(X(0), 0.97, rng=np.random.default_rng(11))
+        b = Channel.from_random_coherent_error(X(0), 0.97, rng=np.random.default_rng(11))
+        assert jnp.allclose(a.process.matrix, b.process.matrix)
+
+    @pytest.mark.parametrize("requested", [0.0, -0.1, 1.5])
+    def test_rejects_out_of_range_fidelity(self, requested):
+        with pytest.raises(ValueError, match=r"must lie in \(0, 1\]"):
+            Channel.from_random_coherent_error(X(0), requested, rng=np.random.default_rng(1))
+
+
+# ──────────────────────────────────────────────────────────
+# Pauli noise / twirl bookkeeping
+# ──────────────────────────────────────────────────────────
+
+
+class TestPauliNoiseIdentityHandling:
+    def test_rejects_explicit_identity_term(self):
+        """The identity probability is implicit; supplying it broke trace preservation.
+
+        Regression guard: an explicit ``"I"`` key won the assignment over the ``1 - sum(others)``
+        normalization, producing a channel whose Choi trace was 1.2 instead of 2.
+        """
+        with pytest.raises(ValueError, match="is the identity"):
+            SuperopChannel.from_pauli_noise(X(0), {"I": 0.5, "X": 0.1})
+        with pytest.raises(ValueError, match="is the identity"):
+            SuperopChannel.from_pauli_noise(CNOT(0, 1), {"II": 0.5})
+
+    @pytest.mark.parametrize(
+        "pauli_noise",
+        [{"X": 0.02}, {"X": 0.02, "Y": 0.03, "Z": 0.05}, {"Z": 0.0}],
+        ids=["one-term", "three-terms", "zero-rate"],
+    )
+    def test_is_trace_preserving(self, pauli_noise):
+        ch = SuperopChannel.from_pauli_noise(X(0), pauli_noise)
+        ptm = np.asarray(qx.to_pauli_liouville(ch.process).matrix).real
+        np.testing.assert_allclose(ptm[0], [1.0, 0.0, 0.0, 0.0], atol=1e-9)
+        choi_trace = np.trace(np.asarray(qx.to_choi(ch.process).matrix)).real
+        assert choi_trace == pytest.approx(2.0, abs=1e-9)
+
+    def test_pauli_vector_recovers_the_input_probabilities(self):
+        pauli_noise = {"X": 0.02, "Y": 0.03, "Z": 0.05}
+        ch = SuperopChannel.from_pauli_noise(X(0), pauli_noise)
+        vector = np.asarray(ch.to_pauli_vector())
+        np.testing.assert_allclose(vector, [0.90, 0.02, 0.03, 0.05], atol=1e-9)

--- a/test/unit/test_noise_model.py
+++ b/test/unit/test_noise_model.py
@@ -19,6 +19,7 @@ from dataclasses import replace
 import jax.numpy as jnp
 import numpy as np
 import pytest
+import pickle
 import quax as qx
 
 from pyquil.external.rpcq import CompilerISA
@@ -52,9 +53,8 @@ class TestChannel:
         inst = RX(np.pi / 4, 0)
         ch = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
         assert isinstance(ch.process, qx.SuperOp)
-        # Process fidelity should be close to the depolarizing constant
-        assert ch.fidelity < 1.0
-        assert ch.fidelity > 0.95
+        expected_fidelity = qx.depolarizing_constant_to_average_fidelity(0.98, num_qubits=1)
+        np.testing.assert_allclose(ch.fidelity, expected_fidelity, rtol=1e-4)
 
     def test_from_gate_fidelity(self):
         """Channel.from_gate_fidelity produces correct fidelity."""
@@ -329,7 +329,6 @@ class TestNoiseModel:
 
         This is what lets a model be shipped to multiprocessing workers.
         """
-        import pickle
 
         gate = RX(np.pi / 4, 0)
         prog = Program(MEASURE(0, None))

--- a/test/unit/test_noise_model.py
+++ b/test/unit/test_noise_model.py
@@ -1,0 +1,644 @@
+# Copyright 2024-2026 Rigetti Computing
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Unit tests for the quax-based noise model (Channel, MeasurementChannel, ResetChannel, NoiseModel)."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import quax as qx
+
+from pyquil.external.rpcq import CompilerISA
+from pyquil.gates import CNOT, MEASURE, RESET, RX, RY, RZ, X
+from pyquil.noise._channels import (
+    Channel,
+    CycleChannel,
+    MeasurementChannel,
+    ResetChannel,
+    _build_cycle_channel,
+    get_instruction_unitary,
+)
+from pyquil.noise._noise_model import NoiseModel
+from pyquil.quil import Program
+from pyquil.quilatom import FormalArgument, Qubit
+from pyquil.quilbase import DefCircuit, Gate, Measurement, ResetQubit
+
+# ──────────────────────────────────────────────────────────
+# Channel tests
+# ──────────────────────────────────────────────────────────
+
+
+class TestChannel:
+    def test_from_depolarizing_constant(self):
+        """Channel.from_depolarizing_constant produces valid superoperator."""
+        inst = RX(np.pi / 4, 0)
+        ch = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
+        assert isinstance(ch.process, qx.SuperOp)
+        # Process fidelity should be close to the depolarizing constant
+        assert ch.fidelity < 1.0
+        assert ch.fidelity > 0.95
+
+    def test_from_gate_fidelity(self):
+        """Channel.from_gate_fidelity produces correct fidelity."""
+        inst = RX(np.pi / 2, 0)
+        ch = Channel.from_gate_fidelity(inst=inst, fidelity=0.99)
+        assert abs(ch.fidelity - 0.99) < 0.001
+
+    def test_from_pauli_fidelity(self):
+        """Channel.from_pauli_fidelity produces a valid channel."""
+        inst = X(0)
+        ch = Channel.from_pauli_fidelity(inst=inst, pauli_fidelity=0.97)
+        assert isinstance(ch.process, qx.SuperOp)
+        assert ch.pauli_fidelity == pytest.approx(0.97, abs=0.001)
+
+    def test_from_pauli_noise(self):
+        """Channel.from_pauli_noise produces a valid Pauli noise channel."""
+        inst = RX(0.5, 0)
+        ch = Channel.from_pauli_noise(inst=inst, pauli_noise={"X": 0.01, "Z": 0.02})
+        assert isinstance(ch.process, qx.SuperOp)
+        assert ch.fidelity < 1.0
+
+    def test_from_coherence_times(self):
+        """Channel.from_coherence_times produces a valid decoherence channel."""
+        inst = RX(np.pi / 4, 0)
+        ch = Channel.from_coherence_times(inst=inst, gate_duration=40e-9, t1s=[30e-6], t2s=[20e-6])
+        assert isinstance(ch.process, qx.SuperOp)
+        assert ch.fidelity < 1.0
+        assert ch.fidelity > 0.99  # short gate relative to T1/T2
+
+    def test_qubits(self):
+        """Channel.qubits reflects the instruction's qubits."""
+        ch = Channel.from_depolarizing_constant(inst=RX(0.1, 3), depolarizing_constant=0.99)
+        assert ch.qubits == [3]
+
+    def test_num_qubits(self):
+        """Channel.num_qubits is correct for 2Q gates."""
+        ch = Channel.from_depolarizing_constant(inst=CNOT(0, 1), depolarizing_constant=0.95)
+        assert ch.num_qubits == 2
+
+    def test_fidelity_properties(self):
+        """Fidelity, infidelity, pauli_fidelity, pauli_infidelity are consistent."""
+        ch = Channel.from_gate_fidelity(inst=RX(0.3, 0), fidelity=0.98)
+        assert ch.fidelity + ch.infidelity == pytest.approx(1.0)
+        assert ch.pauli_fidelity + ch.pauli_infidelity == pytest.approx(1.0)
+        assert ch.stochastic_fidelity + ch.stochastic_infidelity == pytest.approx(1.0)
+        assert ch.coherent_fidelity + ch.coherent_infidelity == pytest.approx(1.0)
+
+    def test_noise_process(self):
+        """noise_process factors out the ideal gate unitary."""
+        ch = Channel.from_depolarizing_constant(inst=RX(np.pi / 4, 0), depolarizing_constant=0.99)
+        noise = ch.noise_process
+        assert isinstance(noise, qx.SuperOp)
+
+    def test_is_pauli(self):
+        """A depolarizing channel on a Clifford gate should be a Pauli channel."""
+        ch = Channel.from_depolarizing_constant(inst=X(0), depolarizing_constant=0.98)
+        assert ch.is_pauli()
+
+    def test_pauli_twirl(self):
+        """Pauli twirl of a channel on a Clifford gate should be a Pauli channel."""
+        ch = Channel.from_random_coherent_error(inst=X(0), process_fidelity=0.97, rng=np.random.default_rng(42))
+        twirled = ch.pauli_twirl()
+        assert twirled.is_pauli()
+
+    def test_unitarity(self):
+        """A depolarizing channel should have unitarity < 1."""
+        ch = Channel.from_depolarizing_constant(inst=RX(0.5, 0), depolarizing_constant=0.95)
+        assert 0 < ch.unitarity < 1.0
+
+    def test_pauli_vector_sums_to_one(self):
+        """Pauli error probability vector should sum to 1."""
+        ch = Channel.from_depolarizing_constant(inst=X(0), depolarizing_constant=0.97)
+        pv = ch.pauli_vector
+        assert float(jnp.sum(pv)) == pytest.approx(1.0, abs=1e-8)
+
+    def test_perfect_channel(self):
+        """A depolarizing constant of 1.0 should give fidelity 1.0."""
+        ch = Channel.from_depolarizing_constant(inst=RX(np.pi, 0), depolarizing_constant=1.0)
+        assert ch.fidelity == pytest.approx(1.0, abs=1e-10)
+
+    def test_from_pauli_noise_rejects_invalid_probabilities(self):
+        """Pauli error rates must be probabilities with total error no greater than 1."""
+        with pytest.raises(ValueError, match="negative"):
+            Channel.from_pauli_noise(inst=RX(0.5, 0), pauli_noise={"X": -0.1})
+
+        with pytest.raises(ValueError, match="at most 1.0"):
+            Channel.from_pauli_noise(inst=RX(0.5, 0), pauli_noise={"X": 0.6, "Z": 0.5})
+
+    def test_from_pauli_noise_two_qubit(self):
+        """from_pauli_noise builds the correct 16-term Pauli channel for a 2Q gate (regression)."""
+        pauli_noise = {"IX": 0.01, "XI": 0.005, "ZZ": 0.02}
+        ch = Channel.from_pauli_noise(inst=CNOT(0, 1), pauli_noise=pauli_noise)
+        pv = np.asarray(ch.pauli_vector)
+        assert pv.size == 16
+        assert float(jnp.sum(ch.pauli_vector)) == pytest.approx(1.0, abs=1e-3)
+        terms = [a + b for a in "IXYZ" for b in "IXYZ"]
+        rates = dict(zip(terms, pv, strict=True))
+        for term, rate in pauli_noise.items():
+            assert rates[term] == pytest.approx(rate, abs=1e-3)
+        assert rates["II"] == pytest.approx(1.0 - sum(pauli_noise.values()), abs=1e-3)
+
+    def test_pow_scales_noise(self):
+        """Channel ** power scales the noise while preserving the gate."""
+        ch = Channel.from_depolarizing_constant(inst=RX(np.pi / 2, 0), depolarizing_constant=0.99)
+        assert (ch**0.0).pauli_infidelity == pytest.approx(0.0, abs=1e-3)
+        assert (ch**1.0).pauli_infidelity == pytest.approx(ch.pauli_infidelity, abs=1e-3)
+        assert (ch**2.0).pauli_infidelity > ch.pauli_infidelity
+        # The ideal gate is preserved.
+        assert (ch**2.0).qubits == ch.qubits
+        assert jnp.allclose((ch**2.0).target_unitary.matrix, ch.target_unitary.matrix)
+
+    def test_json_roundtrip_preserves_qutrit_dims(self):
+        """Channel JSON includes explicit dims for non-qubit operators."""
+        qutrit_x = jnp.array(
+            [
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ],
+            dtype=complex,
+        )
+        target_unitary = qx.Unitary.from_matrix(qutrit_x, ((3,), (3,)))
+        channel = Channel(
+            inst=Gate("TX", [], [0]), process=qx.to_superop(target_unitary), target_unitary=target_unitary
+        )
+
+        restored = Channel.from_json(channel.to_json())
+
+        assert restored.inst == channel.inst
+        assert restored.process.dims == ((3,), (3,))
+        assert restored.target_unitary.dims == ((3,), (3,))
+        assert jnp.allclose(restored.process.matrix, channel.process.matrix)
+
+
+# ──────────────────────────────────────────────────────────
+# MeasurementChannel tests
+# ──────────────────────────────────────────────────────────
+
+
+class TestMeasurementChannel:
+    def test_from_readout_fidelity(self):
+        """MeasurementChannel.from_readout_fidelity produces a valid quantum instrument."""
+        # Use the pyquil MEASURE gate to get qubit
+        prog = Program(MEASURE(0, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        ch = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.95)
+        assert isinstance(ch.process, qx.QuantumInstrument)
+
+    def test_from_readout_fidelity_with_asymmetry(self):
+        """MeasurementChannel with asymmetry produces asymmetric confusion."""
+        prog = Program(MEASURE(0, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        ch = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.95, asymmetry=0.5)
+        assert isinstance(ch.process, qx.QuantumInstrument)
+
+    def test_qubits(self):
+        """MeasurementChannel.qubits returns the correct qubit."""
+        prog = Program(MEASURE(5, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        ch = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.99)
+        assert ch.qubits == [5]
+
+    @pytest.mark.parametrize("asymmetry", [0.0, 0.5])
+    def test_pow_scales_readout_noise(self, asymmetry):
+        """MeasurementChannel ** power scales readout noise via the stochastic generator."""
+        prog = Program(MEASURE(0, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        ch = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.95, asymmetry=asymmetry)
+
+        def bitflip(channel):
+            cm = np.asarray(channel.confusion_matrix)
+            return 1.0 - 0.5 * (float(cm[0, 0]) + float(cm[1, 1]))
+
+        assert bitflip(ch**0.0) == pytest.approx(0.0, abs=1e-3)
+        assert bitflip(ch**1.0) == pytest.approx(bitflip(ch), abs=1e-3)
+        assert bitflip(ch**2.0) > bitflip(ch)
+        # The generator construction keeps the result exactly column-stochastic and non-negative.
+        powered = np.asarray((ch**1.5).confusion_matrix)
+        assert np.all(powered >= -1e-9)
+        assert np.allclose(powered.sum(axis=0), 1.0, atol=1e-6)
+
+    def test_pow_rejects_non_embeddable_measurement(self):
+        """A confusion matrix with no real generator cannot be fractionally powered."""
+        prog = Program(MEASURE(0, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        # Near-complete bit flip: eigenvalue ~ -0.8, so the matrix is not embeddable.
+        confusion = jnp.array([[0.1, 0.9], [0.9, 0.1]])
+        ch = MeasurementChannel.from_confusion_and_transition(meas_inst, confusion, jnp.eye(2))
+        with pytest.raises(ValueError, match="not embeddable|not a valid"):
+            _ = ch**0.5
+
+    def test_from_binary_discriminator_qubit_is_faithful_readout(self):
+        """Regression: dim=2/threshold=1 is a real qubit readout, not an always-0 collapse.
+
+        The previous implementation mapped both |0> and |1> to outcome 0 for a qubit,
+        silently erasing all measurement information.
+        """
+        prog = Program(MEASURE(0, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        ch = MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=2, threshold=1)
+        cm = np.asarray(ch.confusion_matrix)
+        assert cm.shape == (2, 2)  # two reachable outcomes
+        assert np.allclose(cm, np.eye(2))  # |0> -> 0, |1> -> 1
+
+    def test_from_binary_discriminator_qutrit_split(self):
+        """dim=3 splits into exactly two outcomes at the threshold."""
+        prog = Program(MEASURE(0, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        # threshold=2: {0,1} -> 0, {2} -> 1 (flag leakage only)
+        cm2 = np.asarray(MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=3, threshold=2).confusion_matrix)
+        assert np.allclose(cm2, [[1, 1, 0], [0, 0, 1]])
+        # threshold=1: {0} -> 0, {1,2} -> 1 (ground vs excited-or-leaked)
+        cm1 = np.asarray(MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=3, threshold=1).confusion_matrix)
+        assert np.allclose(cm1, [[1, 0, 0], [0, 1, 1]])
+
+    def test_from_binary_discriminator_fidelity_degrades(self):
+        """Sub-unit fidelity stays column-stochastic and keeps both outcomes reachable."""
+        prog = Program(MEASURE(0, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        cm = np.asarray(
+            MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=2, threshold=1, fidelity=0.9).confusion_matrix
+        )
+        assert cm.shape == (2, 2)
+        assert np.allclose(cm.sum(axis=0), 1.0)
+        assert cm[1, 1] > cm[0, 1]  # |1> still most likely reads as outcome 1
+
+    def test_from_binary_discriminator_rejects_bad_threshold(self):
+        """threshold must satisfy 1 <= threshold < dim."""
+        prog = Program(MEASURE(0, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        with pytest.raises(ValueError, match="threshold"):
+            MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=2, threshold=2)
+
+    def test_json_roundtrip_preserves_qutrit_dims(self):
+        """MeasurementChannel JSON includes explicit dims for non-qubit instruments."""
+        prog = Program(MEASURE(0, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        channel = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.95, dim=3)
+
+        restored = MeasurementChannel.from_json(channel.to_json())
+
+        assert restored.inst == channel.inst
+        assert restored.process.dims == channel.process.dims
+        assert restored.process.measured_qudits == channel.process.measured_qudits
+        assert jnp.allclose(restored.process.matrix, channel.process.matrix)
+
+
+# ──────────────────────────────────────────────────────────
+# NoiseModel tests
+# ──────────────────────────────────────────────────────────
+
+
+class TestNoiseModel:
+    def test_empty_model(self):
+        """An empty NoiseModel has no channels."""
+        nm = NoiseModel()
+        assert nm.get_channel(RX(0.5, 0)) is None
+
+    def test_constructor_accepts_instruction_mapping(self):
+        """NoiseModel stores channels keyed by instruction."""
+        inst = RX(np.pi / 4, 0)
+        ch = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
+        nm = NoiseModel(channels={inst: ch})
+        assert nm.channels[inst] is ch
+        assert nm.get_channel(inst) is ch
+
+    def test_constructor_rejects_channel_iterable(self):
+        """Sequence construction should go through from_channels."""
+        inst = RX(np.pi / 4, 0)
+        ch = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
+        with pytest.raises(TypeError, match="from_channels"):
+            NoiseModel(channels=[ch])  # type: ignore[arg-type]
+
+    def test_pickle_roundtrip(self):
+        """NoiseModel survives pickling (its MappingProxyType channels would otherwise block it).
+
+        This is what lets a model be shipped to multiprocessing workers.
+        """
+        import pickle
+
+        gate = RX(np.pi / 4, 0)
+        prog = Program(MEASURE(0, None))
+        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
+        nm = NoiseModel.from_channels(
+            [
+                Channel.from_depolarizing_constant(inst=gate, depolarizing_constant=0.98),
+                MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.95),
+            ]
+        )
+        restored = pickle.loads(pickle.dumps(nm))
+        assert set(restored.channels) == set(nm.channels)
+        assert isinstance(restored.get_channel(gate), Channel)
+        # Channels survive the round-trip intact (exercises value-based __eq__).
+        assert restored == nm
+
+    def test_constructor_rejects_mismatched_mapping_key(self):
+        """Mapping keys must match the instruction stored on each channel."""
+        inst = RX(np.pi / 4, 0)
+        ch = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
+        with pytest.raises(ValueError, match="does not match"):
+            NoiseModel(channels={RY(np.pi / 2, 0): ch})
+
+    def test_from_channels_rejects_duplicates(self):
+        """Duplicate instruction channels are ambiguous and rejected."""
+        inst = RX(np.pi / 4, 0)
+        ch1 = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
+        ch2 = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.97)
+        with pytest.raises(ValueError, match="Duplicate noise channel"):
+            NoiseModel.from_channels([ch1, ch2])
+
+    def test_get_channel_gate(self):
+        """NoiseModel.get_channel returns the correct Channel for a gate."""
+        inst = RX(np.pi / 4, 0)
+        ch = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
+        nm = NoiseModel.from_channels([ch])
+        retrieved = nm.get_channel(inst)
+        assert retrieved is ch
+
+    def test_get_channel_returns_none_for_missing(self):
+        """get_channel returns None for instructions not in the model."""
+        inst = RX(np.pi / 4, 0)
+        ch = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
+        nm = NoiseModel.from_channels([ch])
+        other_inst = RY(np.pi / 2, 1)
+        assert nm.get_channel(other_inst) is None
+
+    def test_multiple_channels(self):
+        """NoiseModel with multiple channels retrieves each correctly."""
+        inst1 = RX(0.5, 0)
+        inst2 = RY(0.3, 1)
+        inst3 = CNOT(0, 1)
+        ch1 = Channel.from_depolarizing_constant(inst=inst1, depolarizing_constant=0.99)
+        ch2 = Channel.from_depolarizing_constant(inst=inst2, depolarizing_constant=0.97)
+        ch3 = Channel.from_depolarizing_constant(inst=inst3, depolarizing_constant=0.95)
+        nm = NoiseModel.from_channels([ch1, ch2, ch3])
+        assert nm.get_channel(inst1) is ch1
+        assert nm.get_channel(inst2) is ch2
+        assert nm.get_channel(inst3) is ch3
+
+    def test_json_roundtrip(self):
+        """NoiseModel JSON keeps the existing channel-list wire format."""
+        ch = Channel.from_depolarizing_constant(inst=RX(np.pi / 4, 0), depolarizing_constant=0.98)
+        meas_ch = MeasurementChannel.from_readout_fidelity(inst=MEASURE(1, None), fidelity=0.95)
+        nm = NoiseModel.from_channels([ch, meas_ch])
+
+        restored = NoiseModel.from_json(nm.to_json())
+
+        assert restored == nm
+        assert set(restored.channels) == {ch.inst, meas_ch.inst}
+
+    def test_add_combines_disjoint_channels(self):
+        """NoiseModel addition preserves disjoint channels from both operands."""
+        ch1 = Channel.from_depolarizing_constant(inst=RX(np.pi / 4, 0), depolarizing_constant=0.98)
+        ch2 = Channel.from_depolarizing_constant(inst=RY(np.pi / 4, 1), depolarizing_constant=0.97)
+
+        combined = NoiseModel.from_channels([ch1]) + NoiseModel.from_channels([ch2])
+
+        assert combined.get_channel(ch1.inst) == ch1
+        assert combined.get_channel(ch2.inst) == ch2
+
+    def test_add_rejects_overlapping_channels(self):
+        """Addition is a disjoint union; a shared instruction is a conflict, not a composition."""
+        inst = RX(np.pi / 4, 0)
+        ch1 = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
+        ch2 = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.97)
+
+        with pytest.raises(ValueError, match="same instruction"):
+            _ = NoiseModel.from_channels([ch1]) + NoiseModel.from_channels([ch2])
+
+    def test_with_channels_returns_extended_model(self):
+        """with_channels returns a new model and rejects duplicate instructions."""
+        ch1 = Channel.from_depolarizing_constant(inst=RX(np.pi / 4, 0), depolarizing_constant=0.98)
+        ch2 = Channel.from_depolarizing_constant(inst=RY(np.pi / 4, 1), depolarizing_constant=0.97)
+        nm = NoiseModel.from_channels([ch1])
+
+        extended = nm.with_channels([ch2])
+
+        assert nm.get_channel(ch2.inst) is None
+        assert extended.get_channel(ch1.inst) is ch1
+        assert extended.get_channel(ch2.inst) is ch2
+        with pytest.raises(ValueError, match="Duplicate noise channel"):
+            nm.with_channels([ch1])
+
+    def test_noise_model_is_unhashable(self):
+        """NoiseModel is unhashable (consistent with value-based equality)."""
+        nm = NoiseModel.from_channels([Channel.from_depolarizing_constant(RX(0.5, 0), 0.98)])
+        with pytest.raises(TypeError):
+            hash(nm)
+
+
+# ──────────────────────────────────────────────────────────
+# get_instruction_unitary tests
+# ──────────────────────────────────────────────────────────
+
+
+class TestGetInstructionUnitary:
+    def test_standard_gate(self):
+        """get_instruction_unitary resolves standard gates."""
+        u = get_instruction_unitary(RX(np.pi / 2, 0))
+        assert isinstance(u, qx.Unitary)
+        assert u.matrix.shape == (2, 2)
+
+    def test_two_qubit_gate(self):
+        """get_instruction_unitary resolves 2Q gates."""
+        u = get_instruction_unitary(CNOT(0, 1))
+        assert isinstance(u, qx.Unitary)
+        assert u.matrix.shape == (4, 4)
+
+    def test_custom_gate(self):
+        """get_instruction_unitary resolves custom gates from custom_gates dict."""
+        custom_matrix = np.array([[0, 1], [1, 0]], dtype=complex)
+        inst = Gate("MY_GATE", [], [0])
+        u = get_instruction_unitary(inst, custom_gates={"MY_GATE": qx.Unitary.from_matrix(custom_matrix, ((2,), (2,)))})
+        assert isinstance(u, qx.Unitary)
+        assert np.allclose(np.asarray(u.matrix), custom_matrix)
+
+
+# ──────────────────────────────────────────────────────────
+# ResetChannel tests
+# ──────────────────────────────────────────────────────────
+
+
+class TestResetChannel:
+    def test_from_reset_fidelity_perfect(self):
+        """A perfect reset (fidelity=1.0) should produce a valid superoperator."""
+        inst = RESET(0)
+        ch = ResetChannel.from_reset_fidelity(inst=inst, fidelity=1.0)
+        assert isinstance(ch.process, qx.SuperOp)
+
+    def test_from_reset_fidelity_noisy(self):
+        """A noisy reset should have lower fidelity than a perfect one."""
+        inst = RESET(0)
+        ch_perfect = ResetChannel.from_reset_fidelity(inst=inst, fidelity=1.0)
+        ch_noisy = ResetChannel.from_reset_fidelity(inst=inst, fidelity=0.95)
+        assert isinstance(ch_noisy.process, qx.SuperOp)
+        assert ch_noisy.fidelity < ch_perfect.fidelity
+
+    def test_qubits(self):
+        """ResetChannel.qubits returns the correct qubit."""
+        inst = RESET(3)
+        ch = ResetChannel.from_reset_fidelity(inst=inst, fidelity=0.99)
+        assert ch.qubits == [3]
+
+    def test_global_reset_channel_rejected(self):
+        """ResetChannel is intentionally scoped to targeted resets."""
+        with pytest.raises(TypeError, match="targeted"):
+            ResetChannel.from_reset_fidelity(inst=RESET(), fidelity=1.0)
+
+    def test_json_roundtrip_preserves_qutrit_dims(self):
+        """ResetChannel JSON includes explicit dims for non-qubit resets."""
+        channel = ResetChannel.from_reset_fidelity(inst=ResetQubit(0), fidelity=0.9, dim=3)
+
+        restored = ResetChannel.from_json(channel.to_json())
+
+        assert restored.inst == channel.inst
+        assert restored.process.dims == ((3,), (3,))
+        assert jnp.allclose(restored.process.matrix, channel.process.matrix)
+
+
+# ──────────────────────────────────────────────────────────
+# Channel equality / hashing semantics
+# ──────────────────────────────────────────────────────────
+
+
+class TestChannelEqualityAndHashing:
+    def test_channels_are_unhashable(self):
+        """Channels hold jax arrays and are intentionally unhashable."""
+        ch = Channel.from_depolarizing_constant(RX(0.5, 0), 0.98)
+        with pytest.raises(TypeError):
+            hash(ch)
+
+    def test_channel_equality_is_exact(self):
+        """Channel equality is exact: identical builds are equal, different ones are not."""
+        ch1 = Channel.from_depolarizing_constant(RX(0.5, 0), 0.98)
+        ch2 = Channel.from_depolarizing_constant(RX(0.5, 0), 0.98)
+        ch3 = Channel.from_depolarizing_constant(RX(0.5, 0), 0.97)
+        assert ch1 == ch2
+        assert ch1 != ch3
+        assert ch1 != "not a channel"
+
+    def test_channel_inequality_on_different_instruction(self):
+        """Channels on different instructions are never equal."""
+        ch_a = Channel.from_depolarizing_constant(RX(0.5, 0), 0.98)
+        ch_b = Channel.from_depolarizing_constant(RX(0.5, 1), 0.98)
+        assert ch_a != ch_b
+
+
+# ──────────────────────────────────────────────────────────
+# Channel construction / analysis coverage
+# ──────────────────────────────────────────────────────────
+
+
+class TestChannelAnalysis:
+    def test_from_mixture(self):
+        """from_mixture builds a noisy channel from unitary errors with probabilities."""
+        z = qx.Unitary.from_matrix(jnp.array([[1, 0], [0, -1]], dtype=complex), ((2,), (2,)))
+        ch = Channel.from_mixture(X(0), constituents=[z], probabilities=[0.1])
+        assert isinstance(ch.process, qx.SuperOp)
+        assert ch.pauli_infidelity > 0.0
+
+    def test_coherent_and_stochastic_decomposition(self):
+        """to_coherent_channel / to_stochastic_channel split the noise into components."""
+        ch = Channel.from_random_coherent_error(X(0), process_fidelity=0.95, rng=np.random.default_rng(0))
+        coherent = ch.to_coherent_channel()
+        stochastic = ch.to_stochastic_channel()
+        assert isinstance(coherent, Channel)
+        assert isinstance(stochastic, Channel)
+        # Coherent + stochastic infidelity decomposition is non-negative and finite.
+        assert np.isfinite(ch.coherent_infidelity)
+        assert np.isfinite(ch.stochastic_infidelity)
+
+    def test_pauli_twirl_is_pauli(self):
+        """Twirling a coherent-error channel yields a stochastic Pauli channel."""
+        ch = Channel.from_random_coherent_error(X(0), process_fidelity=0.95, rng=np.random.default_rng(1))
+        twirled = ch.pauli_twirl()
+        assert twirled.is_pauli()
+
+
+# ──────────────────────────────────────────────────────────
+# NoiseModel.from_isa
+# ──────────────────────────────────────────────────────────
+
+
+class TestFromIsa:
+    @staticmethod
+    def _isa() -> CompilerISA:
+        return CompilerISA.parse_obj(
+            {
+                "1Q": {
+                    "0": {
+                        "id": 0,
+                        "gates": [
+                            {
+                                "operator_type": "gate",
+                                "operator": "RX",
+                                "parameters": [1.5707963267948966],
+                                "arguments": ["_"],
+                                "fidelity": 0.99,
+                            },
+                            # A fidelity-less measurement entry must not mask the real one below.
+                            {"operator_type": "measure", "qubit": "0", "fidelity": None},
+                            {"operator_type": "measure", "qubit": "0", "fidelity": 0.95},
+                        ],
+                    },
+                    "1": {"id": 1, "gates": []},
+                },
+                "2Q": {
+                    "0-1": {
+                        "ids": [0, 1],
+                        "gates": [
+                            {
+                                "operator_type": "gate",
+                                "operator": "CZ",
+                                "parameters": [],
+                                "arguments": ["_", "_"],
+                                "fidelity": 0.9,
+                            }
+                        ],
+                    }
+                },
+            }
+        )
+
+    def test_builds_gate_and_edge_channels(self):
+        nm = NoiseModel.from_isa(self._isa())
+        assert isinstance(nm.get_channel(Gate("RX", [1.5707963267948966], [0])), Channel)
+        assert isinstance(nm.get_channel(Gate("CZ", [], [0, 1])), Channel)
+
+    def test_measurement_dedup_prefers_real_fidelity(self):
+        """A None-fidelity measure entry must not block a later usable one (dedup ordering)."""
+        nm = NoiseModel.from_isa(self._isa())
+        channel = nm.get_channel(Measurement(qubit=Qubit(0), classical_reg=None))
+        assert isinstance(channel, MeasurementChannel)
+
+
+class TestCycleChannel:
+    def test_complete_cycle_constructs(self):
+        """A CycleChannel whose channels cover every DefCircuit body instruction is valid."""
+        channels = tuple(
+            Channel.from_depolarizing_constant(inst, depolarizing_constant=0.99) for inst in (RX(0.1, 0), RZ(0.2, 1))
+        )
+        cycle = _build_cycle_channel(list(channels))
+        assert cycle.channels == channels
+
+    def test_incomplete_cycle_rejected(self):
+        """A body instruction with no corresponding channel is a footgun and must raise."""
+        q0, q1 = FormalArgument("q0"), FormalArgument("q1")
+        # DefCircuit body has two gates, but only one channel is supplied for q0.
+        defcircuit = DefCircuit("CYCLE", [], [q0, q1], [RX(0.1, q0), RZ(0.2, q1)])
+        cycle_inst = Gate("CYCLE", [], [Qubit(0), Qubit(1)])
+        channels = (Channel.from_depolarizing_constant(RX(0.1, 0), depolarizing_constant=0.99),)
+
+        with pytest.raises(ValueError, match="incomplete"):
+            _ = CycleChannel(inst=cycle_inst, defcircuit=defcircuit, channels=channels)

--- a/test/unit/test_noise_model.py
+++ b/test/unit/test_noise_model.py
@@ -14,6 +14,8 @@
 
 """Unit tests for the quax-based noise model (Channel, MeasurementChannel, ResetChannel, NoiseModel)."""
 
+from dataclasses import replace
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -23,13 +25,13 @@ from pyquil.external.rpcq import CompilerISA
 from pyquil.gates import CNOT, MEASURE, RESET, RX, RY, RZ, X
 from pyquil.noise._channels import (
     Channel,
-    ChannelProtocol,
     CycleChannel,
     MeasurementChannel,
     ResetChannel,
     SuperopChannel,
     SuperopResetChannel,
     _build_cycle_channel,
+    _ChannelBase,
     _resolve_params,
     get_custom_gates_from_program,
     get_instruction_unitary,
@@ -252,10 +254,14 @@ class TestMeasurementChannel:
         prog = Program(MEASURE(0, None))
         meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
         # threshold=2: {0,1} -> 0, {2} -> 1 (flag leakage only)
-        cm2 = np.asarray(MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=3, threshold=2).confusion_matrix)
+        cm2 = np.asarray(
+            MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=3, threshold=2).confusion_matrix
+        )
         assert np.allclose(cm2, [[1, 1, 0], [0, 0, 1]])
         # threshold=1: {0} -> 0, {1,2} -> 1 (ground vs excited-or-leaked)
-        cm1 = np.asarray(MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=3, threshold=1).confusion_matrix)
+        cm1 = np.asarray(
+            MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=3, threshold=1).confusion_matrix
+        )
         assert np.allclose(cm1, [[1, 0, 0], [0, 1, 1]])
 
     def test_from_binary_discriminator_fidelity_degrades(self):
@@ -263,7 +269,9 @@ class TestMeasurementChannel:
         prog = Program(MEASURE(0, None))
         meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
         cm = np.asarray(
-            MeasurementChannel.from_binary_discriminator(inst=meas_inst, dim=2, threshold=1, fidelity=0.9).confusion_matrix
+            MeasurementChannel.from_binary_discriminator(
+                inst=meas_inst, dim=2, threshold=1, fidelity=0.9
+            ).confusion_matrix
         )
         assert cm.shape == (2, 2)
         assert np.allclose(cm.sum(axis=0), 1.0)
@@ -538,14 +546,18 @@ class TestChannelEqualityAndHashing:
         with pytest.raises(TypeError):
             hash(ch)
 
-    def test_channel_equality_is_exact(self):
-        """SuperopChannel equality is exact: identical builds are equal, different ones are not."""
+    def test_channel_equality_is_elementwise_close(self):
+        """Channel equality is element-wise ``jnp.allclose`` on the process/unitary matrices.
+
+        Identical builds are equal, distinct noise is not, and a JSON round-trip stays equal.
+        """
         ch1 = Channel.from_depolarizing_constant(RX(0.5, 0), 0.98)
         ch2 = Channel.from_depolarizing_constant(RX(0.5, 0), 0.98)
         ch3 = Channel.from_depolarizing_constant(RX(0.5, 0), 0.97)
         assert ch1 == ch2
         assert ch1 != ch3
         assert ch1 != "not a channel"
+        assert ch1 == Channel.from_json(ch1.to_json())
 
     def test_channel_inequality_on_different_instruction(self):
         """Channels on different instructions are never equal."""
@@ -662,6 +674,30 @@ class TestCycleChannel:
         with pytest.raises(ValueError, match="incomplete"):
             _ = CycleChannel(inst=cycle_inst, defcircuit=defcircuit, channels=channels)
 
+    def test_cycle_can_contain_reset_channel(self):
+        """A cycle may mix a gate channel with a reset channel on disjoint qubits."""
+        gate = Channel.from_depolarizing_constant(RX(0.1, 0), depolarizing_constant=0.99)
+        reset = ResetChannel.from_amplitude_damping(ResetQubit(1), gamma=0.5)
+        cycle = gate | reset
+        assert isinstance(cycle, CycleChannel)
+        assert cycle.channels == (gate, reset)
+        assert set(cycle.qubits) == {0, 1}
+
+    def test_reset_channel_or_from_reset_side(self):
+        """`reset | other` builds a cycle from the reset channel's side too."""
+        reset = SuperopResetChannel.from_reset_fidelity(ResetQubit(0), fidelity=0.95)
+        measure = MeasurementChannel.from_readout_fidelity(MEASURE(1, None), fidelity=0.98)
+        cycle = reset | measure
+        assert isinstance(cycle, CycleChannel)
+        assert cycle.channels == (reset, measure)
+
+    def test_cycle_with_reset_json_roundtrip(self):
+        """A cycle containing a reset channel survives a JSON round-trip."""
+        gate = Channel.from_depolarizing_constant(RX(0.1, 0), depolarizing_constant=0.99)
+        reset = ResetChannel.from_amplitude_damping(ResetQubit(1), gamma=0.5)
+        cycle = gate | reset
+        assert CycleChannel.from_json(cycle.to_json()) == cycle
+
 
 # ──────────────────────────────────────────────────────────
 # Channel tests
@@ -670,9 +706,9 @@ class TestCycleChannel:
 
 class TestChannelGeneratorOps:
     def test_process_is_superop_and_is_gate_channel(self):
-        """process is derived by evolving the generator; the channel is a ChannelProtocol."""
+        """process is derived by evolving the generator; the channel is a _ChannelBase."""
         ch = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
-        assert isinstance(ch, ChannelProtocol)
+        assert isinstance(ch, _ChannelBase)
         assert isinstance(ch.process, qx.SuperOp)
 
     def test_matches_superop_channel_fidelity(self):
@@ -708,10 +744,38 @@ class TestChannelGeneratorOps:
     def test_superop_ops_downgrade_to_channel(self):
         """Operations that leave the Lindbladian manifold return a plain SuperopChannel."""
         ch = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
-        assert isinstance(ch @ ch, SuperopChannel) and not isinstance(ch @ ch, Channel)
         assert isinstance(ch.pauli_twirl(), SuperopChannel)
         assert isinstance(ch.to_coherent_channel(), SuperopChannel)
         assert isinstance(ch.to_stochastic_channel(), SuperopChannel)
+        # Composing with a non-Lindbladian channel falls back to a superoperator SuperopChannel.
+        superop = ch.pauli_twirl()
+        assert isinstance(ch @ superop, SuperopChannel) and not isinstance(ch @ superop, Channel)
+
+    def test_matmul_of_lindbladian_channels_stays_a_channel(self):
+        """Composing two Lindbladian channels combines the jump operators, staying a Channel."""
+        a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        b = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.98)
+        composed = a @ b
+        assert isinstance(composed, Channel)
+        # Composition combines the noise (same as adding on a shared gate) and keeps the gate.
+        assert composed == a + b
+        assert composed.pauli_infidelity > a.pauli_infidelity
+        assert jnp.allclose(composed.unitary.matrix, a.unitary.matrix)
+
+    def test_matmul_rejects_different_gates(self):
+        a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        b = Channel.from_depolarizing_constant(RY(np.pi / 2, 1), 0.99)
+        with pytest.raises(ValueError, match="different gates"):
+            _ = a @ b
+
+    def test_noise_and_target_lindbladians_decompose_the_generator(self):
+        """`lindbladian` splits into `noise_lindbladian + target_lindbladian`."""
+        ch = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        recombined = ch.noise_lindbladian + ch.target_lindbladian
+        assert jnp.allclose(recombined.matrix, ch.lindbladian.matrix)
+        # The target alone (zero dissipation) reproduces the ideal gate.
+        target_only = replace(ch, lindbladian=ch.target_lindbladian)
+        assert target_only.pauli_infidelity == pytest.approx(0.0, abs=1e-6)
 
     def test_coherence_times(self):
         """A short gate relative to T1/T2 gives high fidelity."""

--- a/test/unit/test_noise_model.py
+++ b/test/unit/test_noise_model.py
@@ -23,9 +23,12 @@ from pyquil.external.rpcq import CompilerISA
 from pyquil.gates import CNOT, MEASURE, RESET, RX, RY, RZ, X
 from pyquil.noise._channels import (
     Channel,
+    ChannelProtocol,
     CycleChannel,
     MeasurementChannel,
     ResetChannel,
+    SuperopChannel,
+    SuperopResetChannel,
     _build_cycle_channel,
     _resolve_params,
     get_custom_gates_from_program,
@@ -64,10 +67,10 @@ class TestChannel:
         assert isinstance(ch.process, qx.SuperOp)
         assert ch.pauli_fidelity == pytest.approx(0.97, abs=0.001)
 
-    def test_from_pauli_noise(self):
-        """Channel.from_pauli_noise produces a valid Pauli noise channel."""
+    def test_from_pauli_generators(self):
+        """Channel.from_pauli_generators produces a valid Pauli-dissipation channel."""
         inst = RX(0.5, 0)
-        ch = Channel.from_pauli_noise(inst=inst, pauli_noise={"X": 0.01, "Z": 0.02})
+        ch = Channel.from_pauli_generators(inst=inst, pauli_generators={"X": 0.01, "Z": 0.02})
         assert isinstance(ch.process, qx.SuperOp)
         assert ch.fidelity < 1.0
 
@@ -80,12 +83,12 @@ class TestChannel:
         assert ch.fidelity > 0.99  # short gate relative to T1/T2
 
     def test_qubits(self):
-        """Channel.qubits reflects the instruction's qubits."""
+        """SuperopChannel.qubits reflects the instruction's qubits."""
         ch = Channel.from_depolarizing_constant(inst=RX(0.1, 3), depolarizing_constant=0.99)
         assert ch.qubits == [3]
 
     def test_num_qubits(self):
-        """Channel.num_qubits is correct for 2Q gates."""
+        """SuperopChannel.num_qubits is correct for 2Q gates."""
         ch = Channel.from_depolarizing_constant(inst=CNOT(0, 1), depolarizing_constant=0.95)
         assert ch.num_qubits == 2
 
@@ -128,31 +131,60 @@ class TestChannel:
     def test_perfect_channel(self):
         """A depolarizing constant of 1.0 should give fidelity 1.0."""
         ch = Channel.from_depolarizing_constant(inst=RX(np.pi, 0), depolarizing_constant=1.0)
-        assert ch.fidelity == pytest.approx(1.0, abs=1e-10)
+        assert ch.fidelity == pytest.approx(1.0, abs=1e-6)
 
-    def test_from_pauli_noise_rejects_invalid_probabilities(self):
-        """Pauli error rates must be probabilities with total error no greater than 1."""
+    def test_from_pauli_generators_rejects_negative_rate(self):
+        """Pauli generator rates must be non-negative (they are Lindbladian rates, not probs)."""
         with pytest.raises(ValueError, match="negative"):
-            Channel.from_pauli_noise(inst=RX(0.5, 0), pauli_noise={"X": -0.1})
+            Channel.from_pauli_generators(inst=RX(0.5, 0), pauli_generators={"X": -0.1})
 
-        with pytest.raises(ValueError, match="at most 1.0"):
-            Channel.from_pauli_noise(inst=RX(0.5, 0), pauli_noise={"X": 0.6, "Z": 0.5})
+    def test_from_pauli_generators_rejects_wrong_length(self):
+        """A Pauli term must have one character per qubit."""
+        with pytest.raises(ValueError, match="length"):
+            Channel.from_pauli_generators(inst=RX(0.5, 0), pauli_generators={"XX": 0.1})
 
-    def test_from_pauli_noise_two_qubit(self):
-        """from_pauli_noise builds the correct 16-term Pauli channel for a 2Q gate (regression)."""
-        pauli_noise = {"IX": 0.01, "XI": 0.005, "ZZ": 0.02}
-        ch = Channel.from_pauli_noise(inst=CNOT(0, 1), pauli_noise=pauli_noise)
+    def test_from_pauli_generators_two_qubit(self):
+        """from_pauli_generators builds a valid 16-term Pauli-error vector for a 2Q gate.
+
+        The rates are Lindbladian generator rates, so the exponentiated channel does not reproduce
+        the input rates exactly; we check the vector is a normalized distribution whose weight sits
+        on the identity and the specified error terms.
+        """
+        pauli_generators = {"IX": 0.01, "XI": 0.005, "ZZ": 0.02}
+        ch = Channel.from_pauli_generators(inst=CNOT(0, 1), pauli_generators=pauli_generators)
         pv = np.asarray(ch.pauli_vector)
         assert pv.size == 16
         assert float(jnp.sum(ch.pauli_vector)) == pytest.approx(1.0, abs=1e-3)
+        terms = [a + b for a in "IXYZ" for b in "IXYZ"]
+        rates = dict(zip(terms, pv, strict=True))
+        # Identity keeps the dominant weight; each specified error term is populated.
+        assert rates["II"] > 0.9
+        for term in pauli_generators:
+            assert rates[term] > 0.0
+        # An unspecified error term carries negligible weight (only tiny higher-order cross terms).
+        assert rates["YY"] < 1e-3
+
+    def test_superop_from_pauli_noise_reproduces_exact_probabilities(self):
+        """SuperopChannel.from_pauli_noise is the one-shot post-gate model: exact error probabilities."""
+        pauli_noise = {"IX": 0.01, "XI": 0.005, "ZZ": 0.02}
+        ch = SuperopChannel.from_pauli_noise(inst=CNOT(0, 1), pauli_noise=pauli_noise)
+        assert isinstance(ch, SuperopChannel)
+        pv = np.asarray(ch.pauli_vector)
+        assert pv.size == 16
+        assert float(jnp.sum(pv)) == pytest.approx(1.0, abs=1e-6)
         terms = [a + b for a in "IXYZ" for b in "IXYZ"]
         rates = dict(zip(terms, pv, strict=True))
         for term, rate in pauli_noise.items():
             assert rates[term] == pytest.approx(rate, abs=1e-3)
         assert rates["II"] == pytest.approx(1.0 - sum(pauli_noise.values()), abs=1e-3)
 
+    def test_superop_from_pauli_noise_rejects_excessive_probability(self):
+        """The one-shot model requires probabilities summing to at most 1."""
+        with pytest.raises(ValueError, match="at most 1.0"):
+            SuperopChannel.from_pauli_noise(inst=RX(0.5, 0), pauli_noise={"X": 0.6, "Z": 0.5})
+
     def test_json_roundtrip_preserves_qutrit_dims(self):
-        """Channel JSON includes explicit dims for non-qubit operators."""
+        """SuperopChannel JSON includes explicit dims for non-qubit operators."""
         qutrit_x = jnp.array(
             [
                 [0.0, 0.0, 1.0],
@@ -162,11 +194,11 @@ class TestChannel:
             dtype=complex,
         )
         target_unitary = qx.Unitary.from_matrix(qutrit_x, ((3,), (3,)))
-        channel = Channel(
+        channel = SuperopChannel(
             inst=Gate("TX", [], [0]), process=qx.to_superop(target_unitary), target_unitary=target_unitary
         )
 
-        restored = Channel.from_json(channel.to_json())
+        restored = SuperopChannel.from_json(channel.to_json())
 
         assert restored.inst == channel.inst
         assert restored.process.dims == ((3,), (3,))
@@ -201,35 +233,6 @@ class TestMeasurementChannel:
         meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
         ch = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.99)
         assert ch.qubits == [5]
-
-    @pytest.mark.parametrize("asymmetry", [0.0, 0.5])
-    def test_pow_scales_readout_noise(self, asymmetry):
-        """MeasurementChannel ** power scales readout noise via the stochastic generator."""
-        prog = Program(MEASURE(0, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
-        ch = MeasurementChannel.from_readout_fidelity(inst=meas_inst, fidelity=0.95, asymmetry=asymmetry)
-
-        def bitflip(channel):
-            cm = np.asarray(channel.confusion_matrix)
-            return 1.0 - 0.5 * (float(cm[0, 0]) + float(cm[1, 1]))
-
-        assert bitflip(ch**0.0) == pytest.approx(0.0, abs=1e-3)
-        assert bitflip(ch**1.0) == pytest.approx(bitflip(ch), abs=1e-3)
-        assert bitflip(ch**2.0) > bitflip(ch)
-        # The generator construction keeps the result exactly column-stochastic and non-negative.
-        powered = np.asarray((ch**1.5).confusion_matrix)
-        assert np.all(powered >= -1e-9)
-        assert np.allclose(powered.sum(axis=0), 1.0, atol=1e-6)
-
-    def test_pow_rejects_non_embeddable_measurement(self):
-        """A confusion matrix with no real generator cannot be fractionally powered."""
-        prog = Program(MEASURE(0, None))
-        meas_inst = [i for i in prog if isinstance(i, Measurement)][0]
-        # Near-complete bit flip: eigenvalue ~ -0.8, so the matrix is not embeddable.
-        confusion = jnp.array([[0.1, 0.9], [0.9, 0.1]])
-        ch = MeasurementChannel.from_confusion_and_transition(meas_inst, confusion, jnp.eye(2))
-        with pytest.raises(ValueError, match="not embeddable|not a valid"):
-            _ = ch**0.5
 
     def test_from_binary_discriminator_qubit_is_faithful_readout(self):
         """Regression: dim=2/threshold=1 is a real qubit readout, not an always-0 collapse.
@@ -351,7 +354,7 @@ class TestNoiseModel:
             NoiseModel.from_channels([ch1, ch2])
 
     def test_get_channel_gate(self):
-        """NoiseModel.get_channel returns the correct Channel for a gate."""
+        """NoiseModel.get_channel returns the correct SuperopChannel for a gate."""
         inst = RX(np.pi / 4, 0)
         ch = Channel.from_depolarizing_constant(inst=inst, depolarizing_constant=0.98)
         nm = NoiseModel.from_channels([ch])
@@ -482,41 +485,41 @@ class TestGetInstructionUnitary:
 
 
 # ──────────────────────────────────────────────────────────
-# ResetChannel tests
+# SuperopResetChannel tests
 # ──────────────────────────────────────────────────────────
 
 
-class TestResetChannel:
+class TestSuperopResetChannel:
     def test_from_reset_fidelity_perfect(self):
         """A perfect reset (fidelity=1.0) should produce a valid superoperator."""
         inst = RESET(0)
-        ch = ResetChannel.from_reset_fidelity(inst=inst, fidelity=1.0)
+        ch = SuperopResetChannel.from_reset_fidelity(inst=inst, fidelity=1.0)
         assert isinstance(ch.process, qx.SuperOp)
 
     def test_from_reset_fidelity_noisy(self):
         """A noisy reset should have lower fidelity than a perfect one."""
         inst = RESET(0)
-        ch_perfect = ResetChannel.from_reset_fidelity(inst=inst, fidelity=1.0)
-        ch_noisy = ResetChannel.from_reset_fidelity(inst=inst, fidelity=0.95)
+        ch_perfect = SuperopResetChannel.from_reset_fidelity(inst=inst, fidelity=1.0)
+        ch_noisy = SuperopResetChannel.from_reset_fidelity(inst=inst, fidelity=0.95)
         assert isinstance(ch_noisy.process, qx.SuperOp)
         assert ch_noisy.fidelity < ch_perfect.fidelity
 
     def test_qubits(self):
-        """ResetChannel.qubits returns the correct qubit."""
+        """SuperopResetChannel.qubits returns the correct qubit."""
         inst = RESET(3)
-        ch = ResetChannel.from_reset_fidelity(inst=inst, fidelity=0.99)
+        ch = SuperopResetChannel.from_reset_fidelity(inst=inst, fidelity=0.99)
         assert ch.qubits == [3]
 
     def test_global_reset_channel_rejected(self):
-        """ResetChannel is intentionally scoped to targeted resets."""
+        """SuperopResetChannel is intentionally scoped to targeted resets."""
         with pytest.raises(TypeError, match="targeted"):
-            ResetChannel.from_reset_fidelity(inst=RESET(), fidelity=1.0)
+            SuperopResetChannel.from_reset_fidelity(inst=RESET(), fidelity=1.0)
 
     def test_json_roundtrip_preserves_qutrit_dims(self):
-        """ResetChannel JSON includes explicit dims for non-qubit resets."""
-        channel = ResetChannel.from_reset_fidelity(inst=ResetQubit(0), fidelity=0.9, dim=3)
+        """SuperopResetChannel JSON includes explicit dims for non-qubit resets."""
+        channel = SuperopResetChannel.from_reset_fidelity(inst=ResetQubit(0), fidelity=0.9, dim=3)
 
-        restored = ResetChannel.from_json(channel.to_json())
+        restored = SuperopResetChannel.from_json(channel.to_json())
 
         assert restored.inst == channel.inst
         assert restored.process.dims == ((3,), (3,))
@@ -524,7 +527,7 @@ class TestResetChannel:
 
 
 # ──────────────────────────────────────────────────────────
-# Channel equality / hashing semantics
+# SuperopChannel equality / hashing semantics
 # ──────────────────────────────────────────────────────────
 
 
@@ -536,7 +539,7 @@ class TestChannelEqualityAndHashing:
             hash(ch)
 
     def test_channel_equality_is_exact(self):
-        """Channel equality is exact: identical builds are equal, different ones are not."""
+        """SuperopChannel equality is exact: identical builds are equal, different ones are not."""
         ch1 = Channel.from_depolarizing_constant(RX(0.5, 0), 0.98)
         ch2 = Channel.from_depolarizing_constant(RX(0.5, 0), 0.98)
         ch3 = Channel.from_depolarizing_constant(RX(0.5, 0), 0.97)
@@ -552,7 +555,7 @@ class TestChannelEqualityAndHashing:
 
 
 # ──────────────────────────────────────────────────────────
-# Channel construction / analysis coverage
+# SuperopChannel construction / analysis coverage
 # ──────────────────────────────────────────────────────────
 
 
@@ -569,8 +572,8 @@ class TestChannelAnalysis:
         ch = Channel.from_random_coherent_error(X(0), process_fidelity=0.95, rng=np.random.default_rng(0))
         coherent = ch.to_coherent_channel()
         stochastic = ch.to_stochastic_channel()
-        assert isinstance(coherent, Channel)
-        assert isinstance(stochastic, Channel)
+        assert isinstance(coherent, SuperopChannel)
+        assert isinstance(stochastic, SuperopChannel)
         # Coherent + stochastic infidelity decomposition is non-negative and finite.
         assert np.isfinite(ch.coherent_infidelity)
         assert np.isfinite(ch.stochastic_infidelity)
@@ -658,3 +661,92 @@ class TestCycleChannel:
 
         with pytest.raises(ValueError, match="incomplete"):
             _ = CycleChannel(inst=cycle_inst, defcircuit=defcircuit, channels=channels)
+
+
+# ──────────────────────────────────────────────────────────
+# Channel tests
+# ──────────────────────────────────────────────────────────
+
+
+class TestChannelGeneratorOps:
+    def test_process_is_superop_and_is_gate_channel(self):
+        """process is derived by evolving the generator; the channel is a ChannelProtocol."""
+        ch = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        assert isinstance(ch, ChannelProtocol)
+        assert isinstance(ch.process, qx.SuperOp)
+
+    def test_matches_superop_channel_fidelity(self):
+        """A depolarizing Channel matches the equivalent superoperator SuperopChannel."""
+        lind = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        superop = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        assert lind.pauli_fidelity == pytest.approx(superop.pauli_fidelity, abs=1e-6)
+
+    def test_pow_scales_noise_and_keeps_gate(self):
+        """** scales the noise while preserving the ideal gate; result stays a Channel."""
+        ch = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        assert (ch**0.0).pauli_infidelity == pytest.approx(0.0, abs=1e-6)
+        assert (ch**1.0).pauli_infidelity == pytest.approx(ch.pauli_infidelity, abs=1e-6)
+        assert (ch**2.0).pauli_infidelity == pytest.approx(2 * ch.pauli_infidelity, rel=1e-2)
+        assert isinstance(ch**2.0, Channel)
+        assert jnp.allclose((ch**2.0).target_unitary.matrix, ch.target_unitary.matrix)
+
+    def test_add_combines_noise_on_same_gate(self):
+        """Adding two channels on the same gate keeps the gate and combines the noise."""
+        a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        b = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.98)
+        combined = a + b
+        assert isinstance(combined, Channel)
+        assert combined.pauli_infidelity > a.pauli_infidelity
+        assert jnp.allclose(combined.target_unitary.matrix, a.target_unitary.matrix)
+
+    def test_add_rejects_different_gates(self):
+        a = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        b = Channel.from_depolarizing_constant(RY(np.pi / 2, 1), 0.99)
+        with pytest.raises(ValueError, match="different gates"):
+            _ = a + b
+
+    def test_superop_ops_downgrade_to_channel(self):
+        """Operations that leave the Lindbladian manifold return a plain SuperopChannel."""
+        ch = Channel.from_depolarizing_constant(RX(np.pi / 2, 0), 0.99)
+        assert isinstance(ch @ ch, SuperopChannel) and not isinstance(ch @ ch, Channel)
+        assert isinstance(ch.pauli_twirl(), SuperopChannel)
+        assert isinstance(ch.to_coherent_channel(), SuperopChannel)
+        assert isinstance(ch.to_stochastic_channel(), SuperopChannel)
+
+    def test_coherence_times(self):
+        """A short gate relative to T1/T2 gives high fidelity."""
+        ch = Channel.from_coherence_times(RX(np.pi / 2, 0), gate_duration=40e-9, t1s=[30e-6], t2s=[20e-6])
+        assert isinstance(ch.process, qx.SuperOp)
+        assert ch.fidelity > 0.99
+
+    def test_json_roundtrip(self):
+        ch = Channel.from_depolarizing_constant(RX(0.3, 0), 0.97)
+        assert Channel.from_json(ch.to_json()) == ch
+
+
+# ──────────────────────────────────────────────────────────
+# ResetChannel tests
+# ──────────────────────────────────────────────────────────
+
+
+class TestResetChannel:
+    def test_stronger_damping_gives_better_reset(self):
+        weak = ResetChannel.from_amplitude_damping(ResetQubit(0), gamma=0.5)
+        strong = ResetChannel.from_amplitude_damping(ResetQubit(0), gamma=5.0)
+        assert isinstance(weak.process, qx.SuperOp)
+        assert strong.fidelity > weak.fidelity
+
+    def test_pow_scales_relaxation(self):
+        ch = ResetChannel.from_amplitude_damping(ResetQubit(0), gamma=0.5)
+        assert isinstance(ch**2.0, ResetChannel)
+        assert (ch**2.0).fidelity > ch.fidelity
+
+    def test_rejects_global_reset(self):
+        from pyquil.quilbase import Reset
+
+        with pytest.raises(TypeError, match="targeted"):
+            ResetChannel.from_lindbladian(Reset(), qx.lindbladians.amplitude_damping(1.0, (2,)))
+
+    def test_json_roundtrip(self):
+        ch = ResetChannel.from_coherence_times(ResetQubit(0), duration=1.0, t1=2.0, t2=1.5)
+        assert ResetChannel.from_json(ch.to_json()) == ch

--- a/test/unit/test_quilbase.py
+++ b/test/unit/test_quilbase.py
@@ -59,6 +59,7 @@ from pyquil.quilbase import (
     DefGateByPaulis,
     DefMeasureCalibration,
     DefPermutationGate,
+    _integer_base_and_exponent,
     DefWaveform,
     DelayFrames,
     DelayQubits,
@@ -319,6 +320,84 @@ class TestDefPermutationGate:
 
     def test_parameters(self, def_permutation_gate: DefPermutationGate):
         assert not def_permutation_gate.parameters
+
+
+class TestQuditGateDefinitions:
+    """Qudit dimensions for ``DefGate``: matrix sizes may be any prime power, not just ``2**k``.
+
+    A prime-power dimension is always read with the *prime* as the qudit dimension, so 4 means two
+    qubits (never one ququart) and 16 means four qubits. Non-prime qudit dimensions cannot be
+    inferred from a matrix size and are rejected outright.
+    """
+
+    @staticmethod
+    def _identity(dimension: int) -> np.ndarray:
+        return np.eye(dimension, dtype=complex)
+
+    @pytest.mark.parametrize(
+        ("dimension", "expected_num_args"),
+        [
+            (2, 1),  # one qubit
+            (4, 2),  # two qubits, not one ququart
+            (8, 3),
+            (16, 4),  # four qubits, not two ququarts
+            (3, 1),  # one qutrit
+            (9, 2),  # two qutrits
+            (27, 3),
+            (5, 1),
+            (25, 2),
+        ],
+    )
+    def test_num_args_for_prime_power_dimensions(self, dimension: int, expected_num_args: int):
+        def_gate = DefGate(f"QUDIT{dimension}", self._identity(dimension))
+        assert def_gate.num_args() == expected_num_args
+
+    @pytest.mark.parametrize("dimension", [1, 6, 10, 12, 15, 18, 20, 24])
+    def test_rejects_non_prime_power_dimensions(self, dimension: int):
+        """6 = 2*3 is ambiguous: a qubit-qutrit pair, or a single six-level system?"""
+        with pytest.raises(ValueError, match="prime"):
+            DefGate(f"BAD{dimension}", self._identity(dimension))
+
+    @pytest.mark.parametrize(
+        ("levels", "expected_num_args"),
+        [(2, 1), (4, 2), (8, 3), (3, 1), (9, 2), (27, 3)],
+    )
+    def test_permutation_gate_num_args_matches_def_gate(self, levels: int, expected_num_args: int):
+        """DefPermutationGate must read its length the way DefGate reads its matrix size."""
+        def_gate = DefPermutationGate(f"PERM{levels}", list(reversed(range(levels))))
+        assert def_gate.num_args() == expected_num_args
+
+    @pytest.mark.parametrize("levels", [6, 10, 12])
+    def test_permutation_gate_rejects_non_prime_power_length(self, levels: int):
+        def_gate = DefPermutationGate(f"PERM{levels}", list(reversed(range(levels))))
+        with pytest.raises(ValueError, match="prime"):
+            def_gate.num_args()
+
+    def test_qutrit_gate_constructor_takes_one_argument(self):
+        """A 3x3 definition builds a single-qudit gate."""
+        def_gate = DefGate("QUTRIT_X", np.array([[0, 0, 1], [1, 0, 0], [0, 1, 0]], dtype=complex))
+        gate = def_gate.get_constructor()(Qubit(7))
+        assert gate.out() == "QUTRIT_X 7"  # type: ignore[union-attr]
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (1, None),
+            (2, (2, 1)),
+            (3, (3, 1)),
+            (4, (2, 2)),
+            (6, None),
+            (8, (2, 3)),
+            (9, (3, 2)),
+            (12, None),
+            (64, (2, 6)),  # composite exponent: 64 = 8**2 = 4**3 = 2**6; the maximal exponent wins
+            (729, (3, 6)),  # composite exponent for an odd prime
+            (1024, (2, 10)),
+            (2**61, (2, 61)),  # large enough to be slow if the search were linear in n
+        ],
+    )
+    def test_integer_base_and_exponent(self, value: int, expected: Optional[Tuple[int, int]]):
+        assert _integer_base_and_exponent(value) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Part of the effort to land the experimental noise model and simulation module (originally PR #1848, branch `nonbreaking-noise-model`) as a reviewable stack. This is **PR 2 of 5**, stacked on #1858 — review/merge in order. Closes #1854.

This PR introduces the new quax-backed **qudit noise model** under `pyquil/noise/`:
- `Channel`, `MeasurementChannel`, `ResetChannel`, and `CycleChannel` (`_channels.py`), and the new `NoiseModel` container plus `DepolarizingNoiseModel` / `CompositeNoiseModel` and fidelity estimators (`_noise_model.py`).
- The historical `pyquil.noise` public API is preserved: `pyquil/noise.py` is moved to `pyquil/noise/_legacy_noise.py` and re-exported from `pyquil/noise/__init__.py`, with the legacy `NoiseModel`/`KrausModel` now marked deprecated in favor of the quax-based model.

It also adds qudit `DefGate` support in `quilbase.py` (matrix dimensions may now be any perfect power, e.g. 3, 9, …, not just powers of two), which the qutrit noise channels and later simulators rely on, and enables float64 (`jax_enable_x64`) for the test suite.

A handful of `ResetChannel` tests verify behavior end-to-end through the density-matrix simulator; since that simulator lands in the next PR, those specific assertions are deferred to #1855 (they are restored there). Everything else in the noise module is fully tested here (`test_noise_model.py`).

### Stack
1. #1852 — Drop Python 3.9
2. **#1854 — Qudit noise model (this PR)**
3. #1855 — Experimental exact simulators
4. #1856 — Trajectory simulator
5. #1857 — Dynamic-shape trajectory simulator


Tracked in #1863.
